### PR TITLE
chore: backmerge release v1.7.2

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1125,12 +1125,9 @@
             <div id="whats-new" class="hidden">
                 <h1 id="header-version">What's New in </h1>
                 <ul id="changelog">
-                    <li><b>Model origin labels:</b> Generated replies now show which model/provider they came from, including the pending response state while a message is still streaming</li>
-
-                    <li>Visit my Discord if you'd like to connect regarding the project, need support, or have any
-                        questions: <a href="https://discord.gg/ZbdPu4Dm3e">Discord Server</a></li>
-                    <li>You may also contact the project via email: <a
-                            href="mailto:zodiac@faetalize.dev">zodiac@faetalize.dev</a></li>
+                    <li><b>Login and registration refresh:</b> Auth screens now use native forms with better validation and a smoother password recovery flow</li>
+                    <li><b>Gemini model naming updates:</b> Model labels now use clearer intrinsic version names, including the newer Flash Lite 3.1 naming</li>
+                    <li><b>Worktree tooling polish:</b> Branch worktree setup removes unused MCP config and fixes path resolution issues in the creation script</li>
                 </ul>
             </div>
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -57,7 +57,7 @@ export function lightenCard(element: HTMLElement) {
 }
 
 export function getVersion() {
-    return "1.7.1";
+    return "1.7.2";
 }
 
 export function getSanitized(string: string) {


### PR DESCRIPTION
## Summary
- sync the `1.7.2` app version bump into `main`
- carry over the in-app changelog updates for the login/register refresh, Gemini model naming updates, and worktree tooling polish
- keep `main` aligned with the latest shipped release metadata
Branch state
- release/v1.7.2 is clean and tracking origin/release/v1.7.2
- diff to main is only:
  - src/utils/helpers.ts:59
  - src/index.html:1125