### PR TITLE
fix: keep chat history clear above resizing composer

### DIFF
--- a/src/components/static/ChatInput.component.ts
+++ b/src/components/static/ChatInput.component.ts
@@ -19,6 +19,7 @@ interface AttachmentRemovedDetail {
 
 const messageInput = document.querySelector<HTMLDivElement>("#messageInput");
 const messageBox = document.querySelector<HTMLDivElement>("#message-box");
+const bottomUiContainer = document.querySelector<HTMLDivElement>("#bottom-ui-container");
 const attachmentsInput = document.querySelector<HTMLInputElement>("#attachments");
 const attachmentPreview = document.querySelector<HTMLDivElement>("#attachment-preview");
 const sendMessageButton = document.querySelector<HTMLButtonElement>("#btn-send");
@@ -33,7 +34,7 @@ const startRoundText = document.querySelector<HTMLSpanElement>("#start-round-tex
 const skipTurnBtn = document.querySelector<HTMLButtonElement>("#btn-skip-turn");
 const rpgSettingsButton = document.querySelector<HTMLButtonElement>("#btn-rpg-settings");
 
-if (!messageInput || !messageBox || !attachmentsInput || !attachmentPreview || !sendMessageButton || !internetSearchToggle || !roleplayActionsMenu) {
+if (!messageInput || !messageBox || !bottomUiContainer || !attachmentsInput || !attachmentPreview || !sendMessageButton || !internetSearchToggle || !roleplayActionsMenu) {
     console.error("Chat input component is missing some elements. Please check the HTML structure.");
     throw new Error("Chat input component is not properly initialized.");
 }
@@ -66,6 +67,19 @@ let isGroupChatContext = false;
 let isRpgGroupChatContext = false;
 let isDynamicGroupChatContext = false;
 let allowDynamicPings = false;
+
+function syncBottomUiHeight(): void {
+    const height = Math.ceil(bottomUiContainer!.getBoundingClientRect().height);
+    document.documentElement.style.setProperty('--bottom-ui-height', `${height}px`);
+}
+
+syncBottomUiHeight();
+
+const bottomUiResizeObserver = new ResizeObserver(() => {
+    syncBottomUiHeight();
+});
+
+bottomUiResizeObserver.observe(bottomUiContainer);
 
 function syncComposerInteractivity(): void {
     const canEdit = !isRpgGroupChatContext || (!isCurrentlyGenerating && isUserTurnInRpg);
@@ -509,6 +523,7 @@ document.addEventListener("click", (event) => {
 });
 
 window.addEventListener("resize", () => {
+    syncBottomUiHeight();
     if (mentionMenuOpen && mentionState) {
         positionMentionMenu(mentionState.range);
     }

--- a/src/components/static/ChatInput.component.ts
+++ b/src/components/static/ChatInput.component.ts
@@ -70,7 +70,20 @@ let allowDynamicPings = false;
 
 function syncBottomUiHeight(): void {
     const height = Math.ceil(bottomUiContainer!.getBoundingClientRect().height);
+    const prevHeightStr = document.documentElement.style.getPropertyValue('--bottom-ui-height');
+    
+    if (prevHeightStr === `${height}px`) return;
+
+    const scrollContainer = document.querySelector<HTMLDivElement>("#scrollable-chat-container");
+    const isAtBottom = scrollContainer 
+        ? scrollContainer.scrollHeight - scrollContainer.scrollTop - scrollContainer.clientHeight < 50 
+        : false;
+
     document.documentElement.style.setProperty('--bottom-ui-height', `${height}px`);
+
+    if (isAtBottom && scrollContainer) {
+        helpers.messageContainerScrollToBottom(true);
+    }
 }
 
 syncBottomUiHeight();
@@ -523,7 +536,6 @@ document.addEventListener("click", (event) => {
 });
 
 window.addEventListener("resize", () => {
-    syncBottomUiHeight();
     if (mentionMenuOpen && mentionState) {
         positionMentionMenu(mentionState.range);
     }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3085,7 +3085,7 @@ body.full-width-chat .message-container {
     scroll-behavior: auto;
     width: 100%;
     flex-grow: 1;
-    padding-bottom: 7rem;
+    padding-bottom: calc(var(--bottom-ui-height, 6rem) + 1rem);
     padding-top: 1rem;
 }
 
@@ -3114,13 +3114,6 @@ body.full-width-chat .message-container {
 
 .chat-loading-indicator.hidden {
     display: none;
-}
-
-/* when an image is attached we should increase the padding of scrollable-chat-container by an extra 4 rem */
-/* we check if #attachment-preview has more than 2 elements */
-
-body:has(#attachment-preview > :nth-child(2)) #scrollable-chat-container {
-    padding-bottom: 11rem;
 }
 
 .message-text {


### PR DESCRIPTION
## Summary
- measure the live height of the bottom composer stack and use it to reserve space for chat history
- keep the latest messages visible when the input grows, attachments are added, or RPG/group chat controls appear
- remove the old attachment-specific padding hack in favor of a single dynamic spacing rule

Fixes #136