### PR TITLE
Prepare v1.8.0 release

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1586,7 +1586,7 @@
 				</form>
 
 				<div id="whats-new" class="hidden">
-					<h1 id="header-version">What's New in</h1>
+					<h1 id="header-version">What's New in </h1>
 					<ul id="changelog">
 						<li>
 							<b>Roleplay composer:</b> Quick action suggestions can now help shape replies, with custom

--- a/src/index.html
+++ b/src/index.html
@@ -1589,16 +1589,24 @@
 					<h1 id="header-version">What's New in</h1>
 					<ul id="changelog">
 						<li>
-							<b>Login and registration refresh:</b> Auth screens now use native forms with better
-							validation and a smoother password recovery flow
+							<b>Roleplay composer:</b> Quick action suggestions can now help shape replies, with custom
+							actions, labels, categories, favorites, and synced preferences
 						</li>
 						<li>
-							<b>Gemini model naming updates:</b> Model labels now use clearer intrinsic version names,
-							including the newer Flash Lite 3.1 naming
+							<b>Chat switching stability:</b> Ongoing generations stay tied to the right chat, including
+							background streaming and RPG regeneration flows
 						</li>
 						<li>
-							<b>Worktree tooling polish:</b> Branch worktree setup removes unused MCP config and fixes
-							path resolution issues in the creation script
+							<b>Group chat improvements:</b> Dynamic group chats work more reliably in BYOK mode, and
+							persona pings now follow the global ping setting more consistently
+						</li>
+						<li>
+							<b>Composer and sidebar fixes:</b> Resizing the message box keeps recent chat history clear,
+							and sidebar actions no longer switch chats unexpectedly
+						</li>
+						<li>
+							<b>Cloud sync quota clarity:</b> Quota-related sync failures now explain what happened more
+							clearly and remain easier to recover from
 						</li>
 					</ul>
 				</div>

--- a/src/services/Supabase.service.ts
+++ b/src/services/Supabase.service.ts
@@ -26,7 +26,7 @@ export type {
 let userCache: SupabaseUser | null = null;
 
 export const SUPABASE_URL = "https://hglcltvwunzynnzduauy.supabase.co";
-export const PRO_REQUEST_FUNCTION_NAME = "handle-pro-request";
+export const PRO_REQUEST_FUNCTION_NAME = "handle-pro-request-x";
 export const PRO_REQUEST_ENDPOINT = `${SUPABASE_URL}/functions/v1/${PRO_REQUEST_FUNCTION_NAME}`;
 const SUPABASE_ANON_KEY =
 	"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhnbGNsdHZ3dW56eW5uemR1YXV5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM3MTIzOTIsImV4cCI6MjA2OTI4ODM5Mn0.q4VZu-0vEZVdjSXAhlSogB9ihfPVwero0S4UFVCvMDQ";

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -57,7 +57,7 @@ export function lightenCard(element: HTMLElement) {
 }
 
 export function getVersion() {
-	return "1.7.3";
+	return "1.8.0";
 }
 
 export function getSanitized(string: string) {


### PR DESCRIPTION
## Summary
- bump the in-app version to 1.8.0
- refresh the What's New copy for the release
- point premium requests at the handle-pro-request-x slot

## Verification
- npm run build
- pre-push: npm run lint
- pre-push: npm run type-check
- pre-push: npm run test:vitest