### PR TITLE
chore: update deprecated gemini-3.1-flash-lite-preview model

### DIFF
--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -1,7 +1,7 @@
 export enum ChatModel {
 	PRO = "gemini-3.1-pro-preview",
 	FLASH = "gemini-3-flash-preview",
-	FLASH_LITE = "gemini-3.1-flash-lite-preview",
+	FLASH_LITE = "gemini-3.1-flash-lite",
 	NANO_BANANA = "gemini-2.5-flash-image",
 	NANO_BANANA_PRO = "gemini-3-pro-image-preview",
 	NANO_BANANA_2 = "gemini-3.1-flash-image-preview"
@@ -65,7 +65,7 @@ export function requiresThoughtSignaturesInHistory(model: string): boolean {
 export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 	{
 		id: ChatModel.FLASH_LITE,
-		label: "Gemini 3.1 Flash Lite Preview",
+		label: "Gemini 3.1 Flash Lite",
 		provider: "gemini",
 		mega: false,
 		roleplayModeSuggester: true,

--- a/tests/integration/messages/roleplay-composer-model-dropdown.test.ts
+++ b/tests/integration/messages/roleplay-composer-model-dropdown.test.ts
@@ -134,7 +134,7 @@ describe("roleplay suggestion model dropdown", () => {
 		const options = Array.from(document.querySelectorAll<HTMLOptionElement>("#roleplaySuggestionModel option"));
 
 		const expectedModels = [
-			"Gemini 3.1 Flash Lite Preview",
+			"Gemini 3.1 Flash Lite",
 			"Gemini 3 Flash Preview",
 			"Gemini 3.5 Flash",
 			"Gemini 3.1 Pro Preview",

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -7,7 +7,7 @@ describe("roleplay suggestion models", () => {
 		const fullAccess: ChatModelAccess = { hasGeminiAccess: true, hasOpenRouterAccess: true };
 
 		const expectedModels = [
-			"Gemini 3.1 Flash Lite Preview",
+			"Gemini 3.1 Flash Lite",
 			"Gemini 3 Flash Preview",
 			"Gemini 3.5 Flash",
 			"Gemini 3.1 Pro Preview",


### PR DESCRIPTION
Updates the deprecated gemini-3.1-flash-lite-preview model ID and label to gemini-3.1-flash-lite. All 45 tests are green.