### PR TITLE
Prepare v1.8.1 release

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1588,24 +1588,16 @@
 					<h1 id="header-version">What's New in</h1>
 					<ul id="changelog">
 						<li>
-							<b>Roleplay composer:</b> Quick action suggestions can now help shape replies, with custom
-							actions, labels, categories, favorites, and synced preferences
+							<b>More Gemini choices:</b> Gemini 3.5 Flash is now available for chat, giving you a newer
+							fast model option
 						</li>
 						<li>
-							<b>Chat switching stability:</b> Ongoing generations stay tied to the right chat, including
-							background streaming and RPG regeneration flows
+							<b>Restored 2.5 models:</b> Gemini 2.5 Flash and Gemini 2.5 Pro are back in the model list
+							for users who prefer them
 						</li>
 						<li>
-							<b>Group chat improvements:</b> Dynamic group chats work more reliably in BYOK mode, and
-							persona pings now follow the global ping setting more consistently
-						</li>
-						<li>
-							<b>Composer and sidebar fixes:</b> Resizing the message box keeps recent chat history clear,
-							and sidebar actions no longer switch chats unexpectedly
-						</li>
-						<li>
-							<b>Cloud sync quota clarity:</b> Quota-related sync failures now explain what happened more
-							clearly and remain easier to recover from
+							<b>Model list refresh:</b> Gemini Flash Lite now points at the current supported model name,
+							keeping roleplay suggestions and chat selection up to date
 						</li>
 					</ul>
 				</div>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -57,7 +57,7 @@ export function lightenCard(element: HTMLElement) {
 }
 
 export function getVersion() {
-	return "1.8.0";
+	return "1.8.1";
 }
 
 export function getSanitized(string: string) {


### PR DESCRIPTION
## Summary
- bump app version to 1.8.1
- update the in-app changelog for Gemini model updates

## Verification
- npm run build