### PR TITLE
Fix regeneration selected persona

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -184,7 +184,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			},
@@ -233,7 +232,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			}
@@ -1832,7 +1830,6 @@
 			"integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.58.1",
 				"@typescript-eslint/types": "8.58.1",
@@ -2150,7 +2147,6 @@
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2669,7 +2665,6 @@
 			"integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
@@ -3280,7 +3275,6 @@
 			"integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@asamuzakjp/css-color": "^5.0.1",
 				"@asamuzakjp/dom-selector": "^7.0.3",
@@ -4722,7 +4716,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -4797,7 +4790,6 @@
 			"version": "6.4.2",
 			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
 			"integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -1325,7 +1325,7 @@ export async function regenerate(modelMessageIndex: number): Promise<void> {
 	}
 
 	const modelMessage = chat.content[modelMessageIndex];
-	const targetPersonalityId = modelMessage?.personalityid || getSelectedPersonalityId();
+	const targetPersonalityId = getSelectedPersonalityId();
 	const message = chat.content[modelMessageIndex - 1];
 	if (!message) {
 		console.error("No message found");

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -1324,7 +1324,6 @@ export async function regenerate(modelMessageIndex: number): Promise<void> {
 		return;
 	}
 
-	const modelMessage = chat.content[modelMessageIndex];
 	const targetPersonalityId = getSelectedPersonalityId();
 	const message = chat.content[modelMessageIndex - 1];
 	if (!message) {

--- a/tests/integration/messages/message-send.test.ts
+++ b/tests/integration/messages/message-send.test.ts
@@ -326,6 +326,19 @@ function seedMockPersonas(personas: Array<{ id: string; persona: Partial<Persona
 	}
 }
 
+function selectPersonality(personalityId: string): void {
+	const card = document.createElement("label");
+	card.id = `personality-${personalityId}`;
+
+	const input = document.createElement("input");
+	input.type = "radio";
+	input.name = "personality";
+	input.checked = true;
+
+	card.append(input);
+	document.body.append(card);
+}
+
 async function loadServices() {
 	const dbService = await import("../../../src/services/Db.service");
 	const chatsService = await import("../../../src/services/Chats.service");
@@ -812,6 +825,7 @@ describe("Message send lifecycle", () => {
 				}
 			}
 		]);
+		selectPersonality("persona-regen");
 
 		queueOpenRouterResponse("Regenerated second reply", "Regenerated thinking");
 
@@ -898,6 +912,77 @@ describe("Message send lifecycle", () => {
 		]);
 		expect(document.querySelector(".message-container")?.textContent).not.toContain("Third prompt");
 		expect(document.querySelector(".message-container")?.textContent).not.toContain("Third reply");
+	});
+
+	it("regenerate uses the currently selected persona instead of the original response persona", async () => {
+		seedMockPersonas([
+			{
+				id: "persona-original",
+				persona: {
+					name: "Original Persona",
+					description: "Responded to the original message."
+				}
+			},
+			{
+				id: "persona-selected",
+				persona: {
+					name: "Selected Persona",
+					description: "Currently selected before regeneration."
+				}
+			}
+		]);
+		selectPersonality("persona-selected");
+
+		queueOpenRouterResponse("Regenerated with selected persona");
+
+		const { db: testDb, chatsService, messageService } = await loadServices();
+		db = testDb;
+
+		const chatId = await createAndLoadChat({
+			chatsService,
+			chat: makeChat({
+				id: "chat-regenerate-selected-persona",
+				title: "Regenerate Selected Persona Chat",
+				content: [
+					makeUserMessage("Original prompt"),
+					makeModelMessage("Original reply", {
+						personalityid: "persona-original",
+						originModel: "openai/gpt-5.4"
+					})
+				]
+			})
+		});
+
+		await messageService.regenerate(1);
+		await chatsService.waitForPendingWrites(chatId);
+
+		const persistedChat = await testDb.chats.get(chatId);
+		const visiblePersistedMessages = (persistedChat?.content ?? []).filter((message) => !message.hidden);
+		expect(visiblePersistedMessages.map((message) => message.parts[0]?.text)).toEqual([
+			"Original prompt",
+			"Regenerated with selected persona"
+		]);
+		expect(visiblePersistedMessages.at(-1)).toMatchObject({
+			role: "model",
+			personalityid: "persona-selected",
+			parts: [expect.objectContaining({ text: "Regenerated with selected persona" })]
+		});
+
+		const currentChat = await chatsService.getCurrentChat();
+		expect((currentChat?.content ?? []).filter((message) => !message.hidden).at(-1)).toMatchObject({
+			role: "model",
+			personalityid: "persona-selected"
+		});
+		expect(messageService.getIsGenerating(chatId)).toBe(false);
+
+		await waitForCondition(
+			async () => getVisibleMessageTexts().length === 2,
+			"Timed out waiting for selected persona regeneration DOM to settle"
+		);
+		expect(getVisibleMessageTexts()).toEqual(["Original prompt", "Regenerated with selected persona"]);
+		expect(document.querySelector<HTMLElement>(".message:last-of-type .message-role")?.textContent).toBe(
+			"Selected Persona"
+		);
 	});
 
 	it("regeneration in an RPG group chat round prunes later round DOM and state consistently", async () => {


### PR DESCRIPTION
## Summary
- Regenerate normal chat responses with the currently selected persona instead of the original response persona.
- Add a regression test covering persona switching before regeneration.
- Keep the existing regeneration pruning test focused by explicitly selecting its expected persona.

## Tests
- npm run test:vitest -- tests/integration/messages/message-send.test.ts
- npm run type-check
- npm run lint
- npm run test

Closes #171