### PR TITLE
chore: prepare v1.8.2 release

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1588,16 +1588,20 @@
 					<h1 id="header-version">What's New in</h1>
 					<ul id="changelog">
 						<li>
-							<b>More Gemini choices:</b> Gemini 3.5 Flash is now available for chat, giving you a newer
-							fast model option
+							<b>Profile save feedback:</b> Profile updates now show a clear saving state, success
+							message, and failure message so you know whether changes landed
 						</li>
 						<li>
-							<b>Restored 2.5 models:</b> Gemini 2.5 Flash and Gemini 2.5 Pro are back in the model list
-							for users who prefer them
+							<b>More reliable account sessions:</b> Zodiac now restores the signed-in UI when Supabase
+							refreshes an existing session
 						</li>
 						<li>
-							<b>Model list refresh:</b> Gemini Flash Lite now points at the current supported model name,
-							keeping roleplay suggestions and chat selection up to date
+							<b>Image credits work without local keys:</b> Eligible image generations can use account
+							credits without requiring a Gemini API key
+						</li>
+						<li>
+							<b>Regeneration persona fixes:</b> Regenerating a reply now uses the currently selected
+							persona instead of sticking to the persona from the old response
 						</li>
 					</ul>
 				</div>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -57,7 +57,7 @@ export function lightenCard(element: HTMLElement) {
 }
 
 export function getVersion() {
-	return "1.8.1";
+	return "1.8.2";
 }
 
 export function getSanitized(string: string) {


### PR DESCRIPTION
## Summary
- bump the in-app version to 1.8.2
- refresh the user-facing changelog for the 1.8.2 release

## Verification
- npm run build
- push hook: eslint, type-check, Vitest