### PR TITLE
Fix premium endpoint preference rehydration after sync

### DIFF
--- a/src/components/static/ApiKeyInput.component.ts
+++ b/src/components/static/ApiKeyInput.component.ts
@@ -38,6 +38,11 @@ function applyPremiumPreferenceFromStorage(): void {
 	}
 }
 
+function rehydratePremiumPreferenceFromStorage(): void {
+	applyPremiumPreferenceFromStorage();
+	dispatchAppEvent("premium-endpoint-preference-changed", { preferred: ensuredPreferPremiumCheckbox.checked });
+}
+
 function clearValidationState(input: HTMLInputElement, errorElement: HTMLElement): void {
 	input.classList.remove("api-key-valid", "api-key-invalid");
 	errorElement.classList.add("hidden");
@@ -109,13 +114,11 @@ onAppEvent("auth-state-changed", (event) => {
 });
 
 onAppEvent("sync-data-pulled", () => {
-	applyPremiumPreferenceFromStorage();
-	dispatchAppEvent("premium-endpoint-preference-changed", { preferred: ensuredPreferPremiumCheckbox.checked });
+	rehydratePremiumPreferenceFromStorage();
 });
 
 onAppEvent("settings-loaded-from-storage", () => {
-	applyPremiumPreferenceFromStorage();
-	dispatchAppEvent("premium-endpoint-preference-changed", { preferred: ensuredPreferPremiumCheckbox.checked });
+	rehydratePremiumPreferenceFromStorage();
 });
 
 attachValidation({

--- a/src/components/static/ApiKeyInput.component.ts
+++ b/src/components/static/ApiKeyInput.component.ts
@@ -113,6 +113,11 @@ onAppEvent("sync-data-pulled", () => {
 	dispatchAppEvent("premium-endpoint-preference-changed", { preferred: ensuredPreferPremiumCheckbox.checked });
 });
 
+onAppEvent("settings-loaded-from-storage", () => {
+	applyPremiumPreferenceFromStorage();
+	dispatchAppEvent("premium-endpoint-preference-changed", { preferred: ensuredPreferPremiumCheckbox.checked });
+});
+
 attachValidation({
 	input: ensuredGeminiApiKeyInput,
 	errorElement: ensuredGeminiError,

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -129,9 +129,7 @@ export interface PremiumEndpointPreferenceChangedDetail {
 	preferred: boolean;
 }
 
-export interface SettingsLoadedFromStorageDetail {
-	// No detail payload - listeners should re-read their owned settings from storage.
-}
+export type SettingsLoadedFromStorageDetail = Record<string, never>;
 
 // --- Image Mode Events ---
 

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -129,6 +129,10 @@ export interface PremiumEndpointPreferenceChangedDetail {
 	preferred: boolean;
 }
 
+export interface SettingsLoadedFromStorageDetail {
+	// No detail payload - listeners should re-read their owned settings from storage.
+}
+
 // --- Image Mode Events ---
 
 export interface ImageGenerationToggledDetail {
@@ -255,6 +259,7 @@ export const EventNames = {
 	THINKING_TOGGLED: "thinking-toggled",
 	EDIT_MODEL_CHANGED: "edit-model-changed",
 	PREMIUM_ENDPOINT_PREFERENCE_CHANGED: "premium-endpoint-preference-changed",
+	SETTINGS_LOADED_FROM_STORAGE: "settings-loaded-from-storage",
 	API_KEYS_CHANGED: "api-keys-changed",
 
 	// Image Mode
@@ -329,6 +334,7 @@ export interface AppEventMap {
 	[EventNames.THINKING_TOGGLED]: ThinkingToggledDetail;
 	[EventNames.EDIT_MODEL_CHANGED]: EditModelChangedDetail;
 	[EventNames.PREMIUM_ENDPOINT_PREFERENCE_CHANGED]: PremiumEndpointPreferenceChangedDetail;
+	[EventNames.SETTINGS_LOADED_FROM_STORAGE]: SettingsLoadedFromStorageDetail;
 	[EventNames.API_KEYS_CHANGED]: ApiKeysChangedDetail;
 
 	// Image Mode

--- a/src/services/Settings.service.ts
+++ b/src/services/Settings.service.ts
@@ -5,7 +5,7 @@ import type { User } from "../types/User";
 import { getDefaultChatModel, getValidChatModel } from "../types/Models";
 import * as syncService from "./Sync.service";
 import { SETTINGS_STORAGE_KEYS } from "../constants/SettingsStorageKeys";
-import { dispatchAppEvent } from "../events";
+import { dispatchAppEvent, dispatchEmptyAppEvent } from "../events";
 
 const geminiApiKeyInput = document.querySelector("#apiKeyInput") as HTMLInputElement;
 const openRouterApiKeyInput = document.querySelector("#openRouterApiKeyInput") as HTMLInputElement;
@@ -399,6 +399,7 @@ export function loadSettings() {
 	} finally {
 		isLoadingSettings = false;
 	}
+	dispatchEmptyAppEvent("settings-loaded-from-storage");
 }
 
 export function saveSettings() {

--- a/tests/integration/settings/premium-endpoint-sync.test.ts
+++ b/tests/integration/settings/premium-endpoint-sync.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SETTINGS_STORAGE_KEYS } from "../../../src/constants/SettingsStorageKeys";
+import { bootstrapDom } from "../../helpers/dom";
+
+vi.mock("../../../src/services/Supabase.service", () => ({
+	getSubscriptionTier: vi.fn(() => "pro")
+}));
+
+vi.mock("../../../src/services/ApiKeyValidation.service", () => ({
+	validateGeminiApiKey: vi.fn(),
+	validateOpenRouterApiKey: vi.fn()
+}));
+
+vi.mock("../../../src/services/Sync.service", () => ({
+	applySyncedSettingsToLocalStorage: vi.fn(async () => {
+		localStorage.setItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT, "false");
+		return true;
+	}),
+	pushCurrentSettings: vi.fn(async () => true)
+}));
+
+function bootstrapSettingsDom(): void {
+	bootstrapDom(`
+		<input id="apiKeyInput" value="">
+		<input id="openRouterApiKeyInput" value="">
+		<div id="gemini-api-key-error" class="hidden"></div>
+		<div id="openrouter-api-key-error" class="hidden"></div>
+		<div id="prefer-premium-endpoint-toggle"></div>
+		<input id="preferPremiumEndpoint" type="checkbox">
+
+		<input id="maxTokens" value="1000">
+		<input id="temperature" value="60">
+		<select id="selectedModel"><option value="gemini-2.5-flash" selected>Gemini Flash</option></select>
+		<select id="selectedImageModel"><option value="imagen-4.0-ultra-generate-001" selected>Imagen</option></select>
+		<select id="selectedImageEditingModel"><option value="qwen" selected>Qwen</option></select>
+		<select id="roleplaySuggestionModel"><option value="gemini-2.5-flash" selected>Gemini Flash</option></select>
+		<input id="autoscroll" type="checkbox">
+		<input id="streamResponses" type="checkbox">
+		<select id="enableThinkingSelect"><option value="enabled">Enabled</option><option value="disabled">Disabled</option></select>
+		<input id="thinkingBudget" value="500">
+		<input id="rpgGroupChatsProgressAutomatically" type="checkbox">
+		<input id="allowPersonaPinging" type="checkbox">
+		<input id="dynamicGroupChatPingOnly" type="checkbox">
+		<input id="fullWidthChat" type="checkbox">
+		<input id="uiScale" value="2">
+		<select id="delimiterPreset"><option value="zodiac" selected>Zodiac</option><option value="novel">Novel</option><option value="custom">Custom</option></select>
+		<div id="customDelimiterInstructions"></div>
+		<div id="delimiterPreview"></div>
+		<input id="customDialogueInstruction" value="">
+		<input id="customActionInstruction" value="">
+		<input id="customThoughtInstruction" value="">
+		<p id="delimiterPreviewDialogue"></p>
+		<p id="delimiterPreviewAction"></p>
+		<p id="delimiterPreviewThought"></p>
+	`);
+}
+
+describe("premium endpoint synced settings", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		bootstrapSettingsDom();
+	});
+
+	it("rehydrates the premium endpoint toggle after synced settings replace stale local state", async () => {
+		localStorage.setItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT, "true");
+
+		const apiKeyInputComponent = await import("../../../src/components/static/ApiKeyInput.component");
+		const settingsService = await import("../../../src/services/Settings.service");
+		const syncService = await import("../../../src/services/Sync.service");
+		const toggle = document.querySelector<HTMLInputElement>("#preferPremiumEndpoint");
+
+		expect(toggle?.checked).toBe(true);
+		expect(apiKeyInputComponent.shouldPreferPremiumEndpoint()).toBe(true);
+
+		await syncService.applySyncedSettingsToLocalStorage();
+		settingsService.loadSettings();
+
+		expect(apiKeyInputComponent.shouldPreferPremiumEndpoint()).toBe(false);
+		expect(toggle?.checked).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- rehydrate the premium endpoint toggle when settings are loaded from storage
- add a typed settings-loaded event for settings-owned UI refreshes
- add a regression test for stale local premium endpoint state being replaced by synced settings

## Tests
- npx vitest run --config vitest.config.mts tests/integration/settings/premium-endpoint-sync.test.ts
- npm run type-check
- push hook: npm run lint
- push hook: npm run test

Closes #174