### PR TITLE
Fix dropdown blur over sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,13 @@ Services export an `initialize()` function called from `main.ts` in dependency o
 - Prefer `surfaceService.show("element-id")` / `surfaceService.close("element-id")` for adaptive sheets instead of `overlayService.show()` / `overlayService.closeOverlay()`.
 - Keep feature-specific state resets in the feature component. `Surface.service.ts` dispatches `surface-closed` on the surface element after the close animation completes.
 
+### Dropdown Menus
+
+- Prefer [src/utils/dropdownPortal.ts](src/utils/dropdownPortal.ts) for `.dropdown-menu` elements that open inside the sidebar or other blurred surfaces.
+- The sidebar uses `backdrop-filter`; nested dropdowns with their own `backdrop-filter` can blur the sidebar's already-flattened backdrop instead of the real content behind the menu, which makes the menu look foggy rather than properly blurred.
+- `openDropdownPortal(menu, anchor)` temporarily moves the menu to `document.body`, positions it from the anchor's `getBoundingClientRect()`, closes it on scroll/resize, and restores it to its original parent on close.
+- Keep dropdown-specific open state in the owning component, and use the portal `onClose` callback to reset ARIA/state when the helper closes the menu externally.
+
 ### Database Migrations
 
 Dexie schema versions in `Db.service.ts` are additive. Use `.upgrade()` for data migrations:

--- a/src/components/static/ChatSort.component.ts
+++ b/src/components/static/ChatSort.component.ts
@@ -21,14 +21,23 @@ function updateSortLabel(mode: ChatSortMode) {
 	}
 }
 
-function closeMenu() {
+function resetMenuState() {
 	if (!menu || !sortButton) return;
-	menuPortal?.close();
 	menuPortal = null;
 	menu.classList.remove("open");
 	sortButton.setAttribute("aria-expanded", "false");
 	sortButton.classList.remove("chat-sort-toggle-open");
 	isOpen = false;
+}
+
+function closeMenu() {
+	if (!menu || !sortButton) return;
+	const portal = menuPortal;
+	if (portal) {
+		portal.close();
+	} else {
+		resetMenuState();
+	}
 }
 
 function handleOutsideClick(event: MouseEvent) {
@@ -99,15 +108,7 @@ function openMenu() {
 	menu.classList.add("open");
 	sortButton.setAttribute("aria-expanded", "true");
 	sortButton.classList.add("chat-sort-toggle-open");
-	menuPortal = openDropdownPortal(menu, sortButton, {
-		onClose: () => {
-			menuPortal = null;
-			menu?.classList.remove("open");
-			sortButton.setAttribute("aria-expanded", "false");
-			sortButton.classList.remove("chat-sort-toggle-open");
-			isOpen = false;
-		}
-	});
+	menuPortal = openDropdownPortal(menu, sortButton, { onClose: resetMenuState });
 	isOpen = true;
 }
 

--- a/src/components/static/ChatSort.component.ts
+++ b/src/components/static/ChatSort.component.ts
@@ -1,11 +1,13 @@
 import { getChatSortMode, setChatSortMode } from "../../services/Chats.service";
 import type { ChatSortMode } from "../../types/Chat";
+import { openDropdownPortal, type DropdownPortal } from "../../utils/dropdownPortal";
 
 const sortButton = document.querySelector<HTMLButtonElement>("#btn-chat-sort");
 const sortLabel = document.querySelector<HTMLSpanElement>("#chat-sort-label");
 
 let menu: HTMLDivElement | null = null;
 let isOpen = false;
+let menuPortal: DropdownPortal | null = null;
 
 const MODE_LABELS: Record<ChatSortMode, string> = {
 	created_at: "Created",
@@ -21,6 +23,8 @@ function updateSortLabel(mode: ChatSortMode) {
 
 function closeMenu() {
 	if (!menu || !sortButton) return;
+	menuPortal?.close();
+	menuPortal = null;
 	menu.classList.remove("open");
 	sortButton.setAttribute("aria-expanded", "false");
 	sortButton.classList.remove("chat-sort-toggle-open");
@@ -95,6 +99,15 @@ function openMenu() {
 	menu.classList.add("open");
 	sortButton.setAttribute("aria-expanded", "true");
 	sortButton.classList.add("chat-sort-toggle-open");
+	menuPortal = openDropdownPortal(menu, sortButton, {
+		onClose: () => {
+			menuPortal = null;
+			menu?.classList.remove("open");
+			sortButton.setAttribute("aria-expanded", "false");
+			sortButton.classList.remove("chat-sort-toggle-open");
+			isOpen = false;
+		}
+	});
 	isOpen = true;
 }
 

--- a/src/components/static/PersonaSort.component.ts
+++ b/src/components/static/PersonaSort.component.ts
@@ -21,14 +21,23 @@ function updateSortLabel(mode: PersonaSortMode) {
 	}
 }
 
-function closeMenu() {
+function resetMenuState() {
 	if (!menu || !sortButton) return;
-	menuPortal?.close();
 	menuPortal = null;
 	menu.classList.remove("open");
 	sortButton.setAttribute("aria-expanded", "false");
 	sortButton.classList.remove("chat-sort-toggle-open");
 	isOpen = false;
+}
+
+function closeMenu() {
+	if (!menu || !sortButton) return;
+	const portal = menuPortal;
+	if (portal) {
+		portal.close();
+	} else {
+		resetMenuState();
+	}
 }
 
 function handleOutsideClick(event: MouseEvent) {
@@ -102,15 +111,7 @@ function openMenu() {
 	menu.classList.add("open");
 	sortButton.setAttribute("aria-expanded", "true");
 	sortButton.classList.add("chat-sort-toggle-open");
-	menuPortal = openDropdownPortal(menu, sortButton, {
-		onClose: () => {
-			menuPortal = null;
-			menu?.classList.remove("open");
-			sortButton.setAttribute("aria-expanded", "false");
-			sortButton.classList.remove("chat-sort-toggle-open");
-			isOpen = false;
-		}
-	});
+	menuPortal = openDropdownPortal(menu, sortButton, { onClose: resetMenuState });
 	isOpen = true;
 }
 

--- a/src/components/static/PersonaSort.component.ts
+++ b/src/components/static/PersonaSort.component.ts
@@ -1,11 +1,13 @@
 import { getPersonaSortMode, setPersonaSortMode } from "../../services/Personality.service";
 import type { PersonaSortMode } from "../../types/Personality";
+import { openDropdownPortal, type DropdownPortal } from "../../utils/dropdownPortal";
 
 const sortButton = document.querySelector<HTMLButtonElement>("#btn-persona-sort");
 const sortLabel = document.querySelector<HTMLSpanElement>("#persona-sort-label");
 
 let menu: HTMLDivElement | null = null;
 let isOpen = false;
+let menuPortal: DropdownPortal | null = null;
 
 const MODE_LABELS: Record<PersonaSortMode, string> = {
 	date_added: "Added",
@@ -21,6 +23,8 @@ function updateSortLabel(mode: PersonaSortMode) {
 
 function closeMenu() {
 	if (!menu || !sortButton) return;
+	menuPortal?.close();
+	menuPortal = null;
 	menu.classList.remove("open");
 	sortButton.setAttribute("aria-expanded", "false");
 	sortButton.classList.remove("chat-sort-toggle-open");
@@ -98,6 +102,15 @@ function openMenu() {
 	menu.classList.add("open");
 	sortButton.setAttribute("aria-expanded", "true");
 	sortButton.classList.add("chat-sort-toggle-open");
+	menuPortal = openDropdownPortal(menu, sortButton, {
+		onClose: () => {
+			menuPortal = null;
+			menu?.classList.remove("open");
+			sortButton.setAttribute("aria-expanded", "false");
+			sortButton.classList.remove("chat-sort-toggle-open");
+			isOpen = false;
+		}
+	});
 	isOpen = true;
 }
 

--- a/src/components/static/SplitButton.component.ts
+++ b/src/components/static/SplitButton.component.ts
@@ -26,7 +26,10 @@
  * - Add your own event handlers to main button and menu items
  */
 
+import { openDropdownPortal, type DropdownPortal } from "../../utils/dropdownPortal";
+
 const splitButtons = document.querySelectorAll<HTMLElement>(".split-button");
+let closeOpenSplitButtonMenu: (() => void) | null = null;
 
 splitButtons.forEach((splitButton) => {
 	const toggleButton = splitButton.querySelector<HTMLButtonElement>(".split-button__toggle");
@@ -37,37 +40,45 @@ splitButtons.forEach((splitButton) => {
 		console.error("Split button missing required elements (.split-button__toggle or .split-button__menu)");
 		throw new Error("Split button component is not properly initialized.");
 	}
+	const toggleElement = toggleButton;
+	const menuElement = menu;
 
 	let currentFocusIndex = -1;
+	let menuPortal: DropdownPortal | null = null;
+
+	function resetMenuState() {
+		splitButton.classList.remove("open");
+		toggleElement.setAttribute("aria-expanded", "false");
+		currentFocusIndex = -1;
+		menuPortal = null;
+		if (closeOpenSplitButtonMenu === closeMenu) closeOpenSplitButtonMenu = null;
+	}
 
 	function closeMenu() {
-		if (splitButton.classList.contains("open")) {
-			splitButton.classList.remove("open");
-			toggleButton!.setAttribute("aria-expanded", "false");
-			currentFocusIndex = -1;
+		if (splitButton.classList.contains("open") || menuPortal) {
+			menuPortal?.close();
+			if (!menuPortal) resetMenuState();
 		}
 	}
 
 	function openMenu() {
 		if (!splitButton.classList.contains("open")) {
-			// Close other open split button menus
-			document.querySelectorAll(".split-button.open").forEach((el) => {
-				if (el !== splitButton) {
-					el.classList.remove("open");
-					const otherToggle = el.querySelector<HTMLButtonElement>(".split-button__toggle");
-					if (otherToggle) {
-						otherToggle.setAttribute("aria-expanded", "false");
-					}
-				}
-			});
+			closeOpenSplitButtonMenu?.();
 			splitButton.classList.add("open");
-			toggleButton!.setAttribute("aria-expanded", "true");
+			toggleElement.setAttribute("aria-expanded", "true");
+			menuPortal = openDropdownPortal(menuElement, splitButton, {
+				align: "left",
+				matchAnchorWidth: true,
+				offsetY: 4,
+				onClose: resetMenuState
+			});
+			closeOpenSplitButtonMenu = closeMenu;
 			currentFocusIndex = -1;
 		}
 	}
 
 	// Toggle menu on toggle button click
-	toggleButton.addEventListener("click", (e) => {
+	toggleElement.addEventListener("click", (e) => {
 		e.stopPropagation();
 		if (!splitButton.classList.contains("open")) {
 			openMenu();
@@ -111,7 +122,7 @@ splitButtons.forEach((splitButton) => {
 			case "Escape":
 				e.preventDefault();
 				closeMenu();
-				toggleButton.focus();
+				toggleElement.focus();
 				break;
 		}
 	});
@@ -123,18 +134,9 @@ splitButtons.forEach((splitButton) => {
 			// Let the menu handler above deal with it
 		});
 	});
-});
 
-// Close all split button menus when clicking outside
-document.addEventListener("click", (e) => {
-	const target = e.target as HTMLElement;
-	if (!target.closest(".split-button")) {
-		document.querySelectorAll(".split-button.open").forEach((el) => {
-			el.classList.remove("open");
-			const toggle = el.querySelector<HTMLButtonElement>(".split-button__toggle");
-			if (toggle) {
-				toggle.setAttribute("aria-expanded", "false");
-			}
-		});
-	}
+	document.addEventListener("click", (e) => {
+		const target = e.target as Node;
+		if (!splitButton.contains(target) && !menuElement.contains(target)) closeMenu();
+	});
 });

--- a/src/components/static/SplitButton.component.ts
+++ b/src/components/static/SplitButton.component.ts
@@ -30,6 +30,8 @@ import { openDropdownPortal, type DropdownPortal } from "../../utils/dropdownPor
 
 const splitButtons = document.querySelectorAll<HTMLElement>(".split-button");
 let closeOpenSplitButtonMenu: (() => void) | null = null;
+let openSplitButton: HTMLElement | null = null;
+let openSplitButtonMenu: HTMLElement | null = null;
 
 splitButtons.forEach((splitButton) => {
 	const toggleButton = splitButton.querySelector<HTMLButtonElement>(".split-button__toggle");
@@ -51,13 +53,21 @@ splitButtons.forEach((splitButton) => {
 		toggleElement.setAttribute("aria-expanded", "false");
 		currentFocusIndex = -1;
 		menuPortal = null;
-		if (closeOpenSplitButtonMenu === closeMenu) closeOpenSplitButtonMenu = null;
+		if (closeOpenSplitButtonMenu === closeMenu) {
+			closeOpenSplitButtonMenu = null;
+			openSplitButton = null;
+			openSplitButtonMenu = null;
+		}
 	}
 
 	function closeMenu() {
 		if (splitButton.classList.contains("open") || menuPortal) {
-			menuPortal?.close();
-			if (!menuPortal) resetMenuState();
+			const portal = menuPortal;
+			if (portal) {
+				portal.close();
+			} else {
+				resetMenuState();
+			}
 		}
 	}
 
@@ -73,6 +83,8 @@ splitButtons.forEach((splitButton) => {
 				onClose: resetMenuState
 			});
 			closeOpenSplitButtonMenu = closeMenu;
+			openSplitButton = splitButton;
+			openSplitButtonMenu = menuElement;
 			currentFocusIndex = -1;
 		}
 	}
@@ -134,9 +146,10 @@ splitButtons.forEach((splitButton) => {
 			// Let the menu handler above deal with it
 		});
 	});
+});
 
-	document.addEventListener("click", (e) => {
-		const target = e.target as Node;
-		if (!splitButton.contains(target) && !menuElement.contains(target)) closeMenu();
-	});
+document.addEventListener("click", (e) => {
+	const target = e.target as Node;
+	if (openSplitButton?.contains(target) || openSplitButtonMenu?.contains(target)) return;
+	closeOpenSplitButtonMenu?.();
 });

--- a/src/services/Chats.service.ts
+++ b/src/services/Chats.service.ts
@@ -11,6 +11,7 @@ import { v4 as uuidv4 } from "uuid";
 import * as syncService from "./Sync.service";
 import * as toastService from "./Toast.service";
 import * as pinningService from "./Pinning.service";
+import { openDropdownPortal, type DropdownPortal } from "../utils/dropdownPortal";
 const messageContainer = document.querySelector<HTMLDivElement>(".message-container");
 const scrollableChatContainerSelector = "#scrollable-chat-container";
 const chatHistorySection = document.querySelector<HTMLDivElement>("#chatHistorySection");
@@ -38,6 +39,7 @@ let chatLoadDelayTimer: number | null = null;
 let activeChatLoadToken = 0;
 let activeChatLoadAbortController: AbortController | null = null;
 const generatingChatIds = new Set<string>();
+let closeOpenChatActionsMenu: (() => void) | null = null;
 
 const CHAT_SORT_MODE_STORAGE_KEY = "chat-sort-mode";
 // Lazily initialized from localStorage on first access so that the initial
@@ -598,42 +600,30 @@ function insertChatEntry(chat: DbChat, position: "append" | "prepend" = "prepend
 	menu.classList.add("chat-actions-menu");
 	menu.classList.add("dropdown-menu");
 	menu.setAttribute("role", "menu");
+	let menuPortal: DropdownPortal | null = null;
+
+	function resetMenuState() {
+		actionsWrapper.classList.remove("open");
+		actionsButton.setAttribute("aria-expanded", "false");
+		menuPortal = null;
+		if (closeOpenChatActionsMenu === closeMenu) closeOpenChatActionsMenu = null;
+	}
 
 	function closeMenu() {
-		if (actionsWrapper.classList.contains("open")) {
-			actionsWrapper.classList.remove("open");
-			actionsButton.setAttribute("aria-expanded", "false");
+		if (actionsWrapper.classList.contains("open") || menuPortal) {
+			menuPortal?.close();
+			if (!menuPortal) resetMenuState();
 		}
 	}
 
 	function openMenu() {
 		if (!actionsWrapper.classList.contains("open")) {
-			// close other open menus
-			document.querySelectorAll(".chat-actions-wrapper.open").forEach((el) => {
-				if (el !== actionsWrapper) el.classList.remove("open");
-			});
-
-			// Check if menu would overflow at the bottom
-			const scrollContainer = chatHistorySection;
-			if (scrollContainer) {
-				const buttonRect = actionsButton.getBoundingClientRect();
-				const containerRect = scrollContainer.getBoundingClientRect();
-
-				const menuItemsCount = menu.querySelectorAll("button.chat-actions-item").length;
-				const estimatedMenuHeight = Math.max(120, menuItemsCount * 40 + 16);
-				const spaceBelow = containerRect.bottom - buttonRect.bottom;
-				const spaceAbove = buttonRect.top - containerRect.top;
-
-				// If not enough space below but enough space above, open upward
-				if (spaceBelow < estimatedMenuHeight && spaceAbove > estimatedMenuHeight) {
-					actionsWrapper.classList.add("menu-above");
-				} else {
-					actionsWrapper.classList.remove("menu-above");
-				}
-			}
+			closeOpenChatActionsMenu?.();
 
 			actionsWrapper.classList.add("open");
 			actionsButton.setAttribute("aria-expanded", "true");
+			menuPortal = openDropdownPortal(menu, actionsButton, { onClose: resetMenuState });
+			closeOpenChatActionsMenu = closeMenu;
 		}
 	}
 
@@ -786,7 +776,8 @@ function insertChatEntry(chat: DbChat, position: "append" | "prepend" = "prepend
 
 	// close on outside click
 	document.addEventListener("click", (e) => {
-		if (!actionsWrapper.contains(e.target as Node)) {
+		const target = e.target as Node;
+		if (!actionsWrapper.contains(target) && !menu.contains(target)) {
 			closeMenu();
 		}
 	});

--- a/src/services/Chats.service.ts
+++ b/src/services/Chats.service.ts
@@ -611,8 +611,12 @@ function insertChatEntry(chat: DbChat, position: "append" | "prepend" = "prepend
 
 	function closeMenu() {
 		if (actionsWrapper.classList.contains("open") || menuPortal) {
-			menuPortal?.close();
-			if (!menuPortal) resetMenuState();
+			const portal = menuPortal;
+			if (portal) {
+				portal.close();
+			} else {
+				resetMenuState();
+			}
 		}
 	}
 

--- a/src/styles/dark.css
+++ b/src/styles/dark.css
@@ -11,7 +11,7 @@
 	--sidebar-chrome-border: rgba(255, 255, 255, 0.11);
 
 	/* dropdown */
-	--dropdown-menu-bg: #131313a6;
+	--dropdown-menu-bg: #1313134a;
 	--dropdown-menu-fg: #f5f5f5;
 	--dropdown-menu-border: 1px solid rgba(255, 255, 255, 0.192);
 	--dropdown-menu-shadow: 0 4px 18px -4px rgba(0, 0, 0, 0.25);

--- a/src/styles/light.css
+++ b/src/styles/light.css
@@ -24,7 +24,7 @@
 	--modal-shadow: var(--dropdown-menu-shadow);
 
 	/* dropdown */
-	--dropdown-menu-bg: #ffffffa6;
+	--dropdown-menu-bg: #ffffff73;
 	--dropdown-menu-fg: #000000;
 	--dropdown-menu-border: 1px solid rgba(0, 0, 0, 0.1);
 	--dropdown-menu-shadow: 0 4px 18px -4px rgba(0, 0, 0, 0.25), 0 2px 6px -1px rgba(0, 0, 0, 0.15);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4075,12 +4075,28 @@ body.full-width-chat #message-box {
 	opacity: 0;
 }
 
+.dropdown-menu.dropdown-menu--portal {
+	position: fixed;
+	top: var(--dropdown-menu-top, 0);
+	left: var(--dropdown-menu-left, 0);
+	right: auto;
+	width: var(--dropdown-menu-width, auto);
+	display: flex;
+	visibility: visible;
+	opacity: 1;
+	z-index: 10030;
+	animation: menuFadeIn 0.12s ease forwards;
+}
+
+.dropdown-menu.dropdown-menu--portal.dropdown-menu--above {
+	animation: menuFadeInAbove 0.12s ease forwards;
+}
+
 .dropdown-menu {
 	flex-direction: column;
 	color: var(--dropdown-menu-fg);
 	background: var(--dropdown-menu-bg);
 	backdrop-filter: blur(20px);
-	-webkit-backdrop-filter: blur(20px);
 	border: var(--dropdown-menu-border);
 	padding: 0.25rem;
 	border-radius: 0.5rem;
@@ -5034,7 +5050,7 @@ body.full-width-chat #message-box {
 		0 0 0 1px rgba(0, 0, 0, 0.06);
 	outline: none;
 	background-color: var(--sidebar-bg);
-	backdrop-filter: blur(80px);
+	backdrop-filter: blur(32px);
 }
 
 .sidebar-top-bar {

--- a/src/utils/dropdownPortal.ts
+++ b/src/utils/dropdownPortal.ts
@@ -53,7 +53,13 @@ export function openDropdownPortal(
 		menu.style.removeProperty("--dropdown-menu-left");
 		menu.style.removeProperty("--dropdown-menu-top");
 		menu.style.removeProperty("--dropdown-menu-width");
-		if (originalParent) originalParent.insertBefore(menu, originalNextSibling);
+		if (originalParent) {
+			if (originalNextSibling?.parentNode === originalParent) {
+				originalParent.insertBefore(menu, originalNextSibling);
+			} else {
+				originalParent.appendChild(menu);
+			}
+		}
 		options.onClose?.();
 	}
 

--- a/src/utils/dropdownPortal.ts
+++ b/src/utils/dropdownPortal.ts
@@ -1,0 +1,69 @@
+type DropdownPortalOptions = {
+	align?: "left" | "right";
+	matchAnchorWidth?: boolean;
+	offsetY?: number;
+	onClose?: () => void;
+};
+
+export type DropdownPortal = {
+	close: () => void;
+	position: () => void;
+};
+
+let closeActivePortal: (() => void) | null = null;
+
+export function openDropdownPortal(
+	menu: HTMLElement,
+	anchor: HTMLElement,
+	options: DropdownPortalOptions = {}
+): DropdownPortal {
+	const originalParent = menu.parentNode;
+	const originalNextSibling = menu.nextSibling;
+	const viewportMargin = 8;
+	const align = options.align ?? "right";
+	const offsetY = options.offsetY ?? 0;
+	let isClosed = false;
+
+	function position() {
+		const anchorRect = anchor.getBoundingClientRect();
+		const menuRect = menu.getBoundingClientRect();
+		const menuWidth = options.matchAnchorWidth ? anchorRect.width : menuRect.width || 128;
+		const menuHeight = menuRect.height || 120;
+		const canOpenAbove = anchorRect.top > menuHeight + viewportMargin + offsetY;
+		const openAbove =
+			window.innerHeight - anchorRect.bottom < menuHeight + viewportMargin + offsetY && canOpenAbove;
+		const rawLeft = align === "left" ? anchorRect.left : anchorRect.right - menuWidth;
+		const left = Math.min(Math.max(rawLeft, viewportMargin), window.innerWidth - menuWidth - viewportMargin);
+		const rawTop = openAbove ? anchorRect.top - menuHeight - offsetY : anchorRect.bottom + offsetY;
+		const top = Math.min(Math.max(rawTop, viewportMargin), window.innerHeight - menuHeight - viewportMargin);
+
+		menu.style.setProperty("--dropdown-menu-left", `${left}px`);
+		menu.style.setProperty("--dropdown-menu-top", `${top}px`);
+		if (options.matchAnchorWidth) menu.style.setProperty("--dropdown-menu-width", `${menuWidth}px`);
+		menu.classList.toggle("dropdown-menu--above", openAbove);
+	}
+
+	function close() {
+		if (isClosed) return;
+		isClosed = true;
+		if (closeActivePortal === close) closeActivePortal = null;
+		window.removeEventListener("resize", position);
+		window.removeEventListener("scroll", close, true);
+		menu.classList.remove("dropdown-menu--portal", "dropdown-menu--above");
+		menu.style.removeProperty("--dropdown-menu-left");
+		menu.style.removeProperty("--dropdown-menu-top");
+		menu.style.removeProperty("--dropdown-menu-width");
+		if (originalParent) originalParent.insertBefore(menu, originalNextSibling);
+		options.onClose?.();
+	}
+
+	closeActivePortal?.();
+	menu.classList.add("dropdown-menu--portal");
+	document.body.append(menu);
+	position();
+	window.addEventListener("resize", position);
+	window.addEventListener("scroll", close, true);
+	closeActivePortal = close;
+
+	return { close, position };
+}

--- a/tests/e2e/chats/chat-delete.spec.ts
+++ b/tests/e2e/chats/chat-delete.spec.ts
@@ -67,9 +67,11 @@ async function openChatActions(page: Page, chatId: string): Promise<void> {
 }
 
 async function deleteChatFromSidebar(page: Page, chatId: string): Promise<void> {
-	const row = page.locator(`label[for='chat${chatId}']`);
 	await openChatActions(page, chatId);
-	await row.locator(".chat-actions-item").filter({ hasText: "Delete" }).click();
+	await page
+		.locator(".chat-actions-menu.dropdown-menu--portal .chat-actions-item")
+		.filter({ hasText: "Delete" })
+		.click();
 }
 
 test("deleting the selected chat from the sidebar returns the app to cleared new-chat state", async ({ page }) => {


### PR DESCRIPTION
## Summary
- add a shared dropdown portal helper for menus inside blurred surfaces
- apply the portal to chat actions, chat/persona sort, and split-button dropdowns
- tune dropdown transparency and sidebar blur, and document the portal convention

## Verification
- npm run build
- push hook: eslint, type-check, vitest