### PR TITLE
Add OpenRouter Gemini text variants

### DIFF
--- a/src/components/dynamic/message.ts
+++ b/src/components/dynamic/message.ts
@@ -316,7 +316,6 @@ export const messageElement = async (message: Message, index: number): Promise<H
 		if (isNarrator) {
 			messageDiv.classList.add("message-narrator");
 		}
-		const visiblePart = getVisibleMessagePart(message);
 		const rawInitial = getVisibleMessageText(message);
 		const initialHtmlRaw = (await helpers.getDecoded(rawInitial)) || "";
 		const initialHtml = await decorateMentions(initialHtmlRaw);

--- a/src/components/dynamic/message.ts
+++ b/src/components/dynamic/message.ts
@@ -227,11 +227,10 @@ function getVisibleMessagePart(message: Message): Message["parts"][number] | und
 }
 
 function getVisibleMessageText(message: Message): string {
-	const visibleText = message.parts
+	return message.parts
 		.filter((part) => !part.thought)
 		.map((part) => part.text || "")
 		.join("");
-	return visibleText || message.parts[0]?.text || "";
 }
 
 export const messageElement = async (message: Message, index: number): Promise<HTMLElement> => {

--- a/src/components/dynamic/message.ts
+++ b/src/components/dynamic/message.ts
@@ -233,6 +233,33 @@ function getVisibleMessageText(message: Message): string {
 		.join("");
 }
 
+function getThoughtInlineImages(message: Message): Array<{ data: string; mimeType: string }> {
+	const partImages = (message.parts || [])
+		.filter((part) => part.thought && part.inlineData?.data)
+		.map((part) => ({
+			data: part.inlineData!.data,
+			mimeType: part.inlineData!.mimeType || "image/png"
+		}));
+	const legacyGeneratedImages = (message.generatedImages || [])
+		.filter((img) => img.thought && img.base64)
+		.map((img) => ({ data: img.base64, mimeType: img.mimeType || "image/png" }));
+
+	return [...partImages, ...legacyGeneratedImages];
+}
+
+async function buildThinkingContentHtml(message: Message): Promise<string> {
+	const thinkingText = message.thinking?.trim() ? await helpers.getDecoded(message.thinking || "") : "";
+	const thoughtImages = getThoughtInlineImages(message);
+	const imageHtml = thoughtImages
+		.map(
+			(img) =>
+				`<div class="thought-image-wrapper"><img class="thought-image" src="data:${escapeHtml(img.mimeType)};base64,${img.data}" loading="lazy" /></div>`
+		)
+		.join("");
+
+	return `${thinkingText}${imageHtml ? `<div class="thought-images">${imageHtml}</div>` : ""}`;
+}
+
 export const messageElement = async (message: Message, index: number): Promise<HTMLElement> => {
 	const messageDiv = document.createElement("div");
 	//keep the chat index on the DOM node so that downstream logic (e.g.
@@ -319,9 +346,11 @@ export const messageElement = async (message: Message, index: number): Promise<H
 		const initialHtmlRaw = (await helpers.getDecoded(rawInitial)) || "";
 		const initialHtml = await decorateMentions(initialHtmlRaw);
 		// If we already have generated images, don't show loading spinner even if text is empty
-		const hasImages = Array.isArray(message.generatedImages) && message.generatedImages.length > 0;
+		const visibleImages = (message.generatedImages || []).filter((img) => !img.thought);
+		const hasImages = visibleImages.length > 0;
 		const isLoading = rawInitial.trim().length === 0 && !hasImages;
-		const hasThinking = !!message.thinking && message.thinking.trim().length > 0;
+		const thinkingContentHtml = await buildThinkingContentHtml(message);
+		const hasThinking = thinkingContentHtml.trim().length > 0;
 
 		if (isNarrator) {
 			const originModelLabel = formatOriginModelLabel(message.originModel);
@@ -342,7 +371,7 @@ export const messageElement = async (message: Message, index: number): Promise<H
 				hasThinking
 					? `<div class="message-thinking">` +
 						`<button class="thinking-toggle btn-textual" aria-expanded="false">Show reasoning</button>` +
-						`<div class="thinking-content" hidden>${await helpers.getDecoded(message.thinking || "")}</div>` +
+						`<div class="thinking-content" hidden>${thinkingContentHtml}</div>` +
 						`</div>`
 					: ""
 			}
@@ -388,7 +417,7 @@ export const messageElement = async (message: Message, index: number): Promise<H
 				hasThinking
 					? `<div class="message-thinking">` +
 						`<button class="thinking-toggle btn-textual" aria-expanded="false">Show reasoning</button>` +
-						`<div class="thinking-content" hidden>${await helpers.getDecoded(message.thinking || "")}</div>` +
+						`<div class="thinking-content" hidden>${thinkingContentHtml}</div>` +
 						`</div>`
 					: ""
 			}
@@ -399,8 +428,8 @@ export const messageElement = async (message: Message, index: number): Promise<H
             <div class="message-images">
                 ${
 					hasImages
-						? message
-								.generatedImages!.map((img, idx) => {
+						? visibleImages
+								.map((img, idx) => {
 									const needsBlob = (!img.base64 || img.base64.length === 0) && !!img._blobRef;
 									const src = needsBlob ? "" : `data:${img.mimeType};base64,${img.base64}`;
 									return `

--- a/src/components/dynamic/message.ts
+++ b/src/components/dynamic/message.ts
@@ -769,6 +769,24 @@ function setupMessageEditing(messageElement: HTMLElement) {
 	});
 }
 
+function copyRuntimeFileMetadata(source: File, target: File): void {
+	for (const key of Object.keys(source as any)) {
+		(target as any)[key] = (source as any)[key];
+	}
+}
+
+function filesToFileList(files: File[]): FileList {
+	const transfer = new DataTransfer();
+	for (const file of files) {
+		transfer.items.add(file);
+	}
+	files.forEach((file, index) => {
+		const clonedFile = transfer.files[index] as File | undefined;
+		if (clonedFile) copyRuntimeFileMetadata(file, clonedFile);
+	});
+	return transfer.files;
+}
+
 function setupMessageRegeneration(messageElement: HTMLElement, index: number) {
 	const refreshButton = messageElement.querySelector<HTMLButtonElement>(".btn-refresh");
 	if (!refreshButton) {
@@ -853,21 +871,7 @@ async function updateMessageInDatabase(markdownContent: string, messageIndex: nu
 		const currentChat = await chatsService.getCurrentChat();
 		if (!currentChat || !markdownContent) return;
 
-		const nextAttachments =
-			attachments === undefined
-				? undefined
-				: (() => {
-						const dataTransfer = new DataTransfer();
-						attachments.forEach((file) => dataTransfer.items.add(file));
-						attachments.forEach((file, index) => {
-							const clonedFile = dataTransfer.files[index] as File | undefined;
-							if (!clonedFile) return;
-							for (const key of Object.keys(file as any)) {
-								(clonedFile as any)[key] = (file as any)[key];
-							}
-						});
-						return dataTransfer.files;
-					})();
+		const nextAttachments = attachments === undefined ? undefined : filesToFileList(attachments);
 
 		const didUpdate = await chatsService.mutateChat(currentChat.id, (chat) => {
 			const targetMessage = chat.content[messageIndex];
@@ -1284,9 +1288,7 @@ function resolveBlobAttachmentPreviews(messageDiv: HTMLElement, message: Message
 				// Replace placeholder in message object so downstream logic
 				// (e.g. edit/save/regenerate paths) sees a real File.
 				attachments[idx] = resolved;
-				const transfer = new DataTransfer();
-				attachments.forEach((file) => transfer.items.add(file));
-				firstPart.attachments = transfer.files;
+				firstPart.attachments = filesToFileList(attachments);
 
 				void settle.finally(markDone);
 			})

--- a/src/components/dynamic/message.ts
+++ b/src/components/dynamic/message.ts
@@ -859,6 +859,13 @@ async function updateMessageInDatabase(markdownContent: string, messageIndex: nu
 				: (() => {
 						const dataTransfer = new DataTransfer();
 						attachments.forEach((file) => dataTransfer.items.add(file));
+						attachments.forEach((file, index) => {
+							const clonedFile = dataTransfer.files[index] as File | undefined;
+							if (!clonedFile) return;
+							for (const key of Object.keys(file as any)) {
+								(clonedFile as any)[key] = (file as any)[key];
+							}
+						});
 						return dataTransfer.files;
 					})();
 

--- a/src/components/dynamic/message.ts
+++ b/src/components/dynamic/message.ts
@@ -222,6 +222,18 @@ function unwrapMentionsToRaw(html: string): string {
 	return root.innerHTML;
 }
 
+function getVisibleMessagePart(message: Message): Message["parts"][number] | undefined {
+	return message.parts.find((part) => !part.thought) ?? message.parts[0];
+}
+
+function getVisibleMessageText(message: Message): string {
+	const visibleText = message.parts
+		.filter((part) => !part.thought)
+		.map((part) => part.text || "")
+		.join("");
+	return visibleText || message.parts[0]?.text || "";
+}
+
 export const messageElement = async (message: Message, index: number): Promise<HTMLElement> => {
 	const messageDiv = document.createElement("div");
 	//keep the chat index on the DOM node so that downstream logic (e.g.
@@ -256,7 +268,8 @@ export const messageElement = async (message: Message, index: number): Promise<H
 
 	//user message
 	if (!message.personalityid) {
-		const rawInitial = message.parts[0]?.text || "";
+		const visiblePart = getVisibleMessagePart(message);
+		const rawInitial = getVisibleMessageText(message);
 		const initialHtmlRaw = (await helpers.getDecoded(rawInitial)) || "";
 		const initialHtml = await decorateMentions(initialHtmlRaw);
 		messageDiv.innerHTML = `<div class="message-header">
@@ -271,7 +284,7 @@ export const messageElement = async (message: Message, index: number): Promise<H
         <div class="message-role-api" style="display: none;">${message.role}</div>
         <div class="message-text">${initialHtml}</div>
         <div class="attachment-preview-container">
-            ${Array.from(message.parts[0]?.attachments || [])
+            ${Array.from(visiblePart?.attachments || [])
 				.map((attachment: File, attachmentIndex: number) => {
 					if (attachment.type.startsWith("image/")) {
 						const hasBlobRef = !!(attachment as any)._blobRef;
@@ -303,7 +316,8 @@ export const messageElement = async (message: Message, index: number): Promise<H
 		if (isNarrator) {
 			messageDiv.classList.add("message-narrator");
 		}
-		const rawInitial = message.parts[0]?.text || "";
+		const visiblePart = getVisibleMessagePart(message);
+		const rawInitial = getVisibleMessageText(message);
 		const initialHtmlRaw = (await helpers.getDecoded(rawInitial)) || "";
 		const initialHtml = await decorateMentions(initialHtmlRaw);
 		// If we already have generated images, don't show loading spinner even if text is empty
@@ -504,7 +518,7 @@ function setupMessageEditing(messageElement: HTMLElement) {
 				if (messageIndex >= 0) {
 					const currentChat = await chatsService.getCurrentChat();
 					if (currentChat && currentChat.content[messageIndex]) {
-						originalAttachments = currentChat.content[messageIndex].parts[0]?.attachments;
+						originalAttachments = getVisibleMessagePart(currentChat.content[messageIndex])?.attachments;
 						editingAttachments = originalAttachments ? Array.from(originalAttachments) : [];
 					}
 				}
@@ -825,17 +839,24 @@ async function updateMessageInDatabase(markdownContent: string, messageIndex: nu
 			const targetMessage = chat.content[messageIndex];
 			if (!targetMessage) return undefined;
 
-			if (targetMessage.parts.length === 0) {
+			const visiblePartIndex = targetMessage.parts.findIndex((part) => !part.thought);
+			const visiblePart = visiblePartIndex >= 0 ? targetMessage.parts[visiblePartIndex] : undefined;
+
+			if (!visiblePart) {
 				targetMessage.parts.push({ text: markdownContent });
 			} else {
-				targetMessage.parts[0].text = markdownContent;
+				visiblePart.text = markdownContent;
+				targetMessage.parts = targetMessage.parts.filter(
+					(part, index) => part.thought || index === visiblePartIndex
+				);
 			}
 
 			if (nextAttachments !== undefined) {
-				if (targetMessage.parts.length === 0) {
+				const nextVisiblePart = targetMessage.parts.find((part) => !part.thought);
+				if (!nextVisiblePart) {
 					targetMessage.parts.push({ text: "", attachments: nextAttachments });
 				} else {
-					targetMessage.parts[0].attachments = nextAttachments;
+					nextVisiblePart.attachments = nextAttachments;
 				}
 			}
 
@@ -1181,7 +1202,7 @@ function resolveBlobImages(messageDiv: HTMLElement, message: Message): void {
 function resolveBlobAttachmentPreviews(messageDiv: HTMLElement, message: Message): void {
 	if (message.personalityid) return; // user messages only
 
-	const firstPart = message.parts[0];
+	const firstPart = getVisibleMessagePart(message);
 	if (!firstPart?.attachments || firstPart.attachments.length === 0) return;
 
 	const attachments = Array.from(firstPart.attachments);

--- a/src/components/static/AttachmentPreview.component.ts
+++ b/src/components/static/AttachmentPreview.component.ts
@@ -102,12 +102,21 @@ export function clearAttachmentPreviews() {
 function removeFileFromInput(file: File): void {
 	const signatureToRemove = getFileSignature(file);
 	const dataTransfer = new DataTransfer();
+	const keptFiles: File[] = [];
 	for (const existing of Array.from(input!.files || [])) {
 		if (getFileSignature(existing) === signatureToRemove) {
 			continue;
 		}
+		keptFiles.push(existing);
 		dataTransfer.items.add(existing);
 	}
+	keptFiles.forEach((existing, index) => {
+		const clonedFile = dataTransfer.files[index] as File | undefined;
+		if (!clonedFile) return;
+		for (const key of Object.keys(existing as any)) {
+			(clonedFile as any)[key] = (existing as any)[key];
+		}
+	});
 	input!.files = dataTransfer.files;
 }
 

--- a/src/components/static/ChatInput.component.ts
+++ b/src/components/static/ChatInput.component.ts
@@ -81,6 +81,25 @@ let isRpgGroupChatContext = false;
 let isDynamicGroupChatContext = false;
 let allowDynamicPings = false;
 
+function copyRuntimeFileMetadata(source: File, target: File): void {
+	const sourceMetadata = source as any;
+	for (const key of Object.keys(sourceMetadata)) {
+		(target as any)[key] = sourceMetadata[key];
+	}
+}
+
+function filesToFileList(files: File[]): FileList {
+	const dataTransfer = new DataTransfer();
+	for (const file of files) {
+		dataTransfer.items.add(file);
+	}
+	for (let index = 0; index < files.length; index++) {
+		const clonedFile = dataTransfer.files[index] as File | undefined;
+		if (clonedFile) copyRuntimeFileMetadata(files[index], clonedFile);
+	}
+	return dataTransfer.files;
+}
+
 function syncBottomUiHeight(): void {
 	const height = Math.ceil(bottomUiContainer!.getBoundingClientRect().height);
 	const prevHeightStr = document.documentElement.style.getPropertyValue("--bottom-ui-height");
@@ -1168,11 +1187,7 @@ function addAttachments(rawFiles: File[]): void {
 }
 
 function syncAttachmentInput(): void {
-	const dataTransfer = new DataTransfer();
-	for (const file of attachmentState) {
-		dataTransfer.items.add(file);
-	}
-	attachmentsInput!.files = dataTransfer.files;
+	attachmentsInput!.files = filesToFileList(attachmentState);
 }
 
 function collectFilesFromClipboard(event: ClipboardEvent): File[] {

--- a/src/components/static/ImageCreditsLabel.component.ts
+++ b/src/components/static/ImageCreditsLabel.component.ts
@@ -10,7 +10,7 @@ import {
 	isImageGenerationAvailable
 } from "../../services/Supabase.service";
 import type { ImageGenerationPermitted } from "../../types/ImageGenerationTypes";
-import { ChatModel, getChatModelDefinition, ImageModel } from "../../types/Models";
+import { ChatModel, getChatModelDefinition, getPremiumEndpointChatModel, ImageModel } from "../../types/Models";
 import * as overlayService from "../../services/Overlay.service";
 import * as helpers from "../../utils/helpers";
 import { dispatchAppEvent } from "../../events";
@@ -21,7 +21,16 @@ const imageModelSelector = document.querySelector<HTMLSelectElement>("#selectedI
 const modelSelector = document.querySelector<HTMLSelectElement>("#selectedModel");
 
 const PRO_NANO_BANANA_DAILY_LIMIT = 20;
-const NANO_BANANA_MODELS = new Set<string>([ChatModel.NANO_BANANA, ChatModel.NANO_BANANA_PRO, ChatModel.NANO_BANANA_2]);
+const NANO_BANANA_MODELS = new Set<string>(
+	[
+		ChatModel.NANO_BANANA,
+		ChatModel.NANO_BANANA_PRO,
+		ChatModel.NANO_BANANA_2,
+		getPremiumEndpointChatModel(ChatModel.NANO_BANANA),
+		getPremiumEndpointChatModel(ChatModel.NANO_BANANA_PRO),
+		getPremiumEndpointChatModel(ChatModel.NANO_BANANA_2)
+	].filter((model): model is string => !!model)
+);
 
 if (!imageCreditsLabel || !imageCreditsPopover) {
 	console.error("Image credits label component initialization failed");

--- a/src/components/static/ModelSelector.component.ts
+++ b/src/components/static/ModelSelector.component.ts
@@ -7,6 +7,7 @@ import {
 	getAccessibleChatModels,
 	getDefaultChatModel,
 	getValidChatModel,
+	type ChatModelDefinition,
 	type ChatModelAccess
 } from "../../types/Models";
 import { SETTINGS_STORAGE_KEYS } from "../../constants/SettingsStorageKeys";
@@ -26,7 +27,13 @@ const ensuredOpenRouterApiKeyInput = openRouterApiKeyInput;
 
 let hasPremiumModelAccess = false;
 
+function isPremiumEndpointPreferred(): boolean {
+	const saved = localStorage.getItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT);
+	return hasPremiumModelAccess && (saved === null || saved === "true");
+}
+
 function buildAccess(): ChatModelAccess {
+	const usePremiumEndpoint = isPremiumEndpointPreferred();
 	return {
 		hasGeminiAccess:
 			hasPremiumModelAccess ||
@@ -35,19 +42,24 @@ function buildAccess(): ChatModelAccess {
 		hasOpenRouterAccess:
 			hasPremiumModelAccess ||
 			ensuredOpenRouterApiKeyInput.value.trim().length > 0 ||
-			(localStorage.getItem(SETTINGS_STORAGE_KEYS.OPENROUTER_API_KEY) || "").trim().length > 0
+			(localStorage.getItem(SETTINGS_STORAGE_KEYS.OPENROUTER_API_KEY) || "").trim().length > 0,
+		isPremiumEndpointPreferred: usePremiumEndpoint
 	};
 }
 
-function setOptGroup(label: string, options: { id: string; label: string }[]): HTMLOptGroupElement {
+function createModelOption(model: ChatModelDefinition, usePremiumLabel: boolean): HTMLOptionElement {
+	const element = document.createElement("option");
+	element.value = model.id;
+	element.textContent = formatChatModelLabel(model, { usePremiumLabel });
+	return element;
+}
+
+function setOptGroup(label: string, options: ChatModelDefinition[]): HTMLOptGroupElement {
 	const optGroup = document.createElement("optgroup");
 	optGroup.label = label;
 
 	for (const option of options) {
-		const element = document.createElement("option");
-		element.value = option.id;
-		element.textContent = formatChatModelLabel(option);
-		optGroup.append(element);
+		optGroup.append(createModelOption(option, false));
 	}
 
 	return optGroup;
@@ -60,17 +72,25 @@ export function refreshModelSelectorOptions(): void {
 
 	ensuredModelSelect.replaceChildren();
 
-	const geminiModels = available.filter((model) => GEMINI_CHAT_MODELS.some((candidate) => candidate.id === model.id));
-	const openRouterModels = available.filter((model) =>
-		OPENROUTER_CHAT_MODELS.some((candidate) => candidate.id === model.id)
-	);
+	if (access.isPremiumEndpointPreferred) {
+		for (const model of available) {
+			ensuredModelSelect.append(createModelOption(model, true));
+		}
+	} else {
+		const geminiModels = available.filter((model) =>
+			GEMINI_CHAT_MODELS.some((candidate) => candidate.id === model.id)
+		);
+		const openRouterModels = available.filter((model) =>
+			OPENROUTER_CHAT_MODELS.some((candidate) => candidate.id === model.id)
+		);
 
-	if (geminiModels.length > 0) {
-		ensuredModelSelect.append(setOptGroup("Gemini", geminiModels));
-	}
+		if (geminiModels.length > 0) {
+			ensuredModelSelect.append(setOptGroup("Gemini", geminiModels));
+		}
 
-	if (openRouterModels.length > 0) {
-		ensuredModelSelect.append(setOptGroup("OpenRouter", openRouterModels));
+		if (openRouterModels.length > 0) {
+			ensuredModelSelect.append(setOptGroup("OpenRouter", openRouterModels));
+		}
 	}
 
 	if (available.length === 0) {
@@ -111,6 +131,10 @@ ensuredOpenRouterApiKeyInput.addEventListener("input", refreshModelSelectorOptio
 onAppEvent("auth-state-changed", (event) => {
 	const tier = getSubscriptionTier(event.detail.subscription ?? null);
 	hasPremiumModelAccess = tier === "pro" || tier === "pro_plus" || tier === "max";
+	refreshModelSelectorOptions();
+});
+
+onAppEvent("premium-endpoint-preference-changed", () => {
 	refreshModelSelectorOptions();
 });
 

--- a/src/components/static/Onboarding.component.ts
+++ b/src/components/static/Onboarding.component.ts
@@ -20,6 +20,7 @@ import {
 	getValidChatModel,
 	modelRequiresThinking,
 	modelSupportsThinking,
+	type ChatModelDefinition,
 	type ChatModelAccess
 } from "../../types/Models";
 import { SETTINGS_STORAGE_KEYS } from "../../constants/SettingsStorageKeys";
@@ -265,6 +266,11 @@ function hasAnyValidatedApiKey(): boolean {
 	return onboardingService.getState().apiKeyValidated;
 }
 
+function shouldUsePremiumEndpointForOnboarding(hasPremiumAccess: boolean): boolean {
+	const saved = localStorage.getItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT);
+	return hasPremiumAccess && (saved === null || saved === "true");
+}
+
 async function getOnboardingModelAccess(): Promise<ChatModelAccess> {
 	const currentUser = await supabaseService.getCurrentUser();
 	const subscription = currentUser ? await supabaseService.getUserSubscription() : null;
@@ -279,19 +285,25 @@ async function getOnboardingModelAccess(): Promise<ChatModelAccess> {
 		hasGeminiAccess:
 			hasPremiumAccess || (localStorage.getItem(SETTINGS_STORAGE_KEYS.API_KEY) || "").trim().length > 0,
 		hasOpenRouterAccess:
-			hasPremiumAccess || (localStorage.getItem(SETTINGS_STORAGE_KEYS.OPENROUTER_API_KEY) || "").trim().length > 0
+			hasPremiumAccess ||
+			(localStorage.getItem(SETTINGS_STORAGE_KEYS.OPENROUTER_API_KEY) || "").trim().length > 0,
+		isPremiumEndpointPreferred: shouldUsePremiumEndpointForOnboarding(hasPremiumAccess)
 	};
 }
 
-function buildOptionGroup(label: string, options: { id: string; label: string }[]): HTMLOptGroupElement {
+function createModelOption(model: ChatModelDefinition, usePremiumLabel: boolean): HTMLOptionElement {
+	const element = document.createElement("option");
+	element.value = model.id;
+	element.textContent = formatChatModelLabel(model, { usePremiumLabel });
+	return element;
+}
+
+function buildOptionGroup(label: string, options: ChatModelDefinition[]): HTMLOptGroupElement {
 	const optGroup = document.createElement("optgroup");
 	optGroup.label = label;
 
 	for (const option of options) {
-		const element = document.createElement("option");
-		element.value = option.id;
-		element.textContent = formatChatModelLabel(option);
-		optGroup.append(element);
+		optGroup.append(createModelOption(option, false));
 	}
 
 	return optGroup;
@@ -305,17 +317,25 @@ async function refreshOnboardingModelOptions(preferredModel?: string): Promise<v
 
 	advancedModelSelect!.replaceChildren();
 
-	const geminiModels = available.filter((model) => GEMINI_CHAT_MODELS.some((candidate) => candidate.id === model.id));
-	const openRouterModels = available.filter((model) =>
-		OPENROUTER_CHAT_MODELS.some((candidate) => candidate.id === model.id)
-	);
+	if (access.isPremiumEndpointPreferred) {
+		for (const model of available) {
+			advancedModelSelect!.append(createModelOption(model, true));
+		}
+	} else {
+		const geminiModels = available.filter((model) =>
+			GEMINI_CHAT_MODELS.some((candidate) => candidate.id === model.id)
+		);
+		const openRouterModels = available.filter((model) =>
+			OPENROUTER_CHAT_MODELS.some((candidate) => candidate.id === model.id)
+		);
 
-	if (geminiModels.length > 0) {
-		advancedModelSelect!.append(buildOptionGroup("Gemini", geminiModels));
-	}
+		if (geminiModels.length > 0) {
+			advancedModelSelect!.append(buildOptionGroup("Gemini", geminiModels));
+		}
 
-	if (openRouterModels.length > 0) {
-		advancedModelSelect!.append(buildOptionGroup("OpenRouter", openRouterModels));
+		if (openRouterModels.length > 0) {
+			advancedModelSelect!.append(buildOptionGroup("OpenRouter", openRouterModels));
+		}
 	}
 
 	if (available.length === 0) {

--- a/src/components/static/RoleplayComposer.component.ts
+++ b/src/components/static/RoleplayComposer.component.ts
@@ -19,7 +19,8 @@ import {
 	isOpenRouterModel,
 	modelRequiresThinking,
 	getRoleplaySuggestionThinkingCap,
-	modelSupportsTemperature
+	modelSupportsTemperature,
+	type ChatModelAccess
 } from "../../types/Models";
 import { PRO_REQUEST_ENDPOINT } from "../../services/Supabase.service";
 import type { PremiumEndpoint } from "../../types/PremiumEndpoint";
@@ -1165,13 +1166,15 @@ function buildSuggestionPrompts(args: {
 	return { systemInstruction, userPrompt };
 }
 
-function buildAccess() {
+function buildAccess(): ChatModelAccess {
+	const usePremiumEndpoint = hasPremiumModelAccess && shouldPreferPremiumEndpoint();
 	return {
 		hasGeminiAccess:
 			hasPremiumModelAccess || (localStorage.getItem(SETTINGS_STORAGE_KEYS.API_KEY) || "").trim().length > 0,
 		hasOpenRouterAccess:
 			hasPremiumModelAccess ||
-			(localStorage.getItem(SETTINGS_STORAGE_KEYS.OPENROUTER_API_KEY) || "").trim().length > 0
+			(localStorage.getItem(SETTINGS_STORAGE_KEYS.OPENROUTER_API_KEY) || "").trim().length > 0,
+		isPremiumEndpointPreferred: usePremiumEndpoint
 	};
 }
 
@@ -1208,6 +1211,7 @@ function buildRoleplaySuggestionBaseConfig(model: string) {
 function populateRoleplayModelOptions(): void {
 	const access = buildAccess();
 	const available = getAccessibleRoleplaySuggestionModels(access);
+	const usePremiumLabel = access.isPremiumEndpointPreferred === true;
 	const currentValue =
 		ensuredRoleplaySuggestionModelSelect.value ||
 		localStorage.getItem(SETTINGS_STORAGE_KEYS.ROLEPLAY_SUGGESTION_MODEL) ||
@@ -1230,7 +1234,7 @@ function populateRoleplayModelOptions(): void {
 	for (const model of available) {
 		const option = document.createElement("option");
 		option.value = model.id;
-		option.textContent = formatChatModelLabel(model);
+		option.textContent = formatChatModelLabel(model, { usePremiumLabel });
 		ensuredRoleplaySuggestionModelSelect.append(option);
 	}
 
@@ -1500,6 +1504,10 @@ onAppEvent("subscription-updated", (event) => {
 });
 
 onAppEvent("api-keys-changed", () => {
+	populateRoleplayModelOptions();
+});
+
+onAppEvent("premium-endpoint-preference-changed", () => {
 	populateRoleplayModelOptions();
 });
 

--- a/src/components/static/RoleplayComposer.component.ts
+++ b/src/components/static/RoleplayComposer.component.ts
@@ -1056,6 +1056,7 @@ function buildTranscript(
 		.map((message) => {
 			const speaker = message.role === "user" ? "User" : personaName;
 			const text = message.parts
+				.filter((part) => !part.thought)
 				.map((part) => part.text || "")
 				.join("\n")
 				.replace(/<[^>]+>/g, " ")

--- a/src/services/Chats.service.ts
+++ b/src/services/Chats.service.ts
@@ -12,6 +12,55 @@ import * as syncService from "./Sync.service";
 import * as toastService from "./Toast.service";
 import * as pinningService from "./Pinning.service";
 import { openDropdownPortal, type DropdownPortal } from "../utils/dropdownPortal";
+import type { BlobReference } from "../types/BlobReference";
+
+/**
+ * `structuredClone` clones `File` objects but silently drops expando properties
+ * such as the `_blobRef` we attach to blob-backed attachment placeholders during
+ * cloud-sync deserialization. Without that ref, the chat snapshot/cache can no
+ * longer resolve the original attachment bytes, so it gets omitted from request
+ * history even though the rendered message still shows the image (the renderer
+ * reads the un-cloned in-memory messages). Re-attach the ref by index after
+ * cloning so write/history paths keep working for cloud-loaded attachments.
+ */
+function reattachAttachmentBlobRefs(source: Message[] | undefined, cloned: Message[] | undefined): void {
+	if (!Array.isArray(source) || !Array.isArray(cloned)) return;
+	for (let i = 0; i < cloned.length; i++) {
+		const sourceParts = source[i]?.parts;
+		const clonedParts = cloned[i]?.parts;
+		if (!Array.isArray(sourceParts) || !Array.isArray(clonedParts)) continue;
+		for (let p = 0; p < clonedParts.length; p++) {
+			const sourceAttachments = Array.from(sourceParts[p]?.attachments ?? []);
+			const clonedAttachments = Array.from(clonedParts[p]?.attachments ?? []);
+			for (let a = 0; a < clonedAttachments.length; a++) {
+				const ref = (sourceAttachments[a] as { _blobRef?: BlobReference } | undefined)?._blobRef;
+				if (ref && clonedAttachments[a]) {
+					(clonedAttachments[a] as { _blobRef?: BlobReference })._blobRef = ref;
+				}
+			}
+		}
+	}
+}
+
+/**
+ * Clone a message array while preserving blob-backed attachment references.
+ */
+export function cloneChatContent(content: Message[] | undefined): Message[] {
+	const cloned = structuredClone(content ?? []);
+	reattachAttachmentBlobRefs(content, cloned);
+	return cloned;
+}
+
+/**
+ * Clone a chat (or chat-shaped object) while preserving blob-backed attachment
+ * references on its message content.
+ */
+function cloneChat<T extends { content?: Message[] }>(chat: T): T {
+	const cloned = structuredClone(chat);
+	reattachAttachmentBlobRefs(chat.content, (cloned as { content?: Message[] }).content);
+	return cloned;
+}
+
 const messageContainer = document.querySelector<HTMLDivElement>(".message-container");
 const scrollableChatContainerSelector = "#scrollable-chat-container";
 const chatHistorySection = document.querySelector<HTMLDivElement>("#chatHistorySection");
@@ -360,7 +409,7 @@ async function persistChatWithinQueue(chat: DbChat): Promise<void> {
 		}
 		upsertRemoteChat(chatToSave);
 		if (currentChatSnapshot?.id === chat.id) {
-			currentChatSnapshot = structuredClone(chatToSave);
+			currentChatSnapshot = cloneChat(chatToSave);
 		}
 		await refreshChatListAfterActivity(db);
 		return;
@@ -408,8 +457,8 @@ function cacheRemoteChats(chats: DbChat[]) {
 
 		const preservedContent =
 			existing && existing.content.length > chat.content.length
-				? structuredClone(existing.content)
-				: structuredClone(chat.content || []);
+				? cloneChatContent(existing.content)
+				: cloneChatContent(chat.content || []);
 
 		nextRemoteChatsById.set(chat.id, {
 			...structuredClone(chat),
@@ -424,7 +473,7 @@ function cacheRemoteChats(chats: DbChat[]) {
 }
 
 function upsertRemoteChat(chat: DbChat) {
-	remoteChatsById.set(chat.id, structuredClone(chat));
+	remoteChatsById.set(chat.id, cloneChat(chat));
 }
 
 function pickRicherChatSnapshot(
@@ -908,14 +957,14 @@ export async function addChatRecord(chat: Chat): Promise<string> {
 export async function getCurrentChat(dbArg: Db = db) {
 	if (syncService.isOnlineSyncEnabled()) {
 		if (!syncService.isSyncActive()) return null;
-		if (currentChatSnapshot) return structuredClone(currentChatSnapshot);
+		if (currentChatSnapshot) return cloneChat(currentChatSnapshot);
 		const id = getCurrentChatId();
 		if (!id) return null;
 		const remote = remoteChatsById.get(id) ?? (await syncService.fetchSyncedChatMetadata(id));
 		if (!remote) return null;
-		currentChatSnapshot = structuredClone(remote);
+		currentChatSnapshot = cloneChat(remote);
 		upsertRemoteChat(remote);
-		return structuredClone(remote);
+		return cloneChat(remote);
 	}
 
 	const id = getCurrentChatId();
@@ -1034,16 +1083,16 @@ export async function getChatById(id: string): Promise<DbChat | undefined> {
 		if (currentChatSnapshot?.id === id) {
 			const richestCurrent = pickRicherChatSnapshot(currentChatSnapshot, remoteChatsById.get(id));
 			if (richestCurrent) {
-				return structuredClone(richestCurrent);
+				return cloneChat(richestCurrent);
 			}
 		}
 		const cached = remoteChatsById.get(id);
-		if (cached) return structuredClone(cached);
+		if (cached) return cloneChat(cached);
 
 		const remote = await syncService.fetchSyncedChatMetadata(id);
 		if (!remote) return undefined;
 		upsertRemoteChat(remote);
-		return structuredClone(remote);
+		return cloneChat(remote);
 	}
 
 	return db.chats.get(id);
@@ -1051,7 +1100,7 @@ export async function getChatById(id: string): Promise<DbChat | undefined> {
 
 export async function replaceCurrentChatMessages(messages: Message[]): Promise<void> {
 	if (!currentChatSnapshot) return;
-	currentChatMessages = structuredClone(messages);
+	currentChatMessages = cloneChatContent(messages);
 	loadedStartIndex = 0;
 	loadedEndIndex = currentChatMessages.length;
 	hasMoreOlder = false;
@@ -1061,7 +1110,7 @@ export async function replaceCurrentChatMessages(messages: Message[]): Promise<v
 
 	currentChatSnapshot = {
 		...currentChatSnapshot,
-		content: structuredClone(currentChatMessages)
+		content: cloneChatContent(currentChatMessages)
 	};
 	upsertRemoteChat(currentChatSnapshot);
 	syncAllChatGenerationIndicators();
@@ -1073,7 +1122,7 @@ export function replaceCachedChatMessages(chatId: string, messages: Message[]): 
 
 	remoteChatsById.set(chatId, {
 		...cached,
-		content: structuredClone(messages)
+		content: cloneChatContent(messages)
 	});
 }
 
@@ -1264,7 +1313,7 @@ async function loadOlderMessages() {
 				if (currentChatSnapshot) {
 					currentChatSnapshot = {
 						...currentChatSnapshot,
-						content: structuredClone(currentChatMessages)
+						content: cloneChatContent(currentChatMessages)
 					};
 					upsertRemoteChat(currentChatSnapshot);
 				}
@@ -1353,7 +1402,7 @@ export async function loadChat(chatID: string, dbArg: Db = db) {
 
 		document.querySelector("#chat-title")!.textContent = chat.title || "";
 		const richestKnownChat = pickRicherChatSnapshot(chat, remoteChatsById.get(chatID));
-		currentChatSnapshot = structuredClone(richestKnownChat ?? chat);
+		currentChatSnapshot = cloneChat(richestKnownChat ?? chat);
 
 		if (syncService.isOnlineSyncEnabled()) {
 			if (!syncService.isSyncActive()) {
@@ -1373,7 +1422,7 @@ export async function loadChat(chatID: string, dbArg: Db = db) {
 				currentChatMessages = latestWindow.messages;
 				currentChatSnapshot = {
 					...chat,
-					content: structuredClone(currentChatMessages)
+					content: cloneChatContent(currentChatMessages)
 				};
 				upsertRemoteChat(currentChatSnapshot);
 				loadedStartIndex = 0;
@@ -1422,7 +1471,7 @@ export async function loadChat(chatID: string, dbArg: Db = db) {
 
 							currentChatSnapshot = {
 								...chat,
-								content: structuredClone(currentChatMessages)
+								content: cloneChatContent(currentChatMessages)
 							};
 							upsertRemoteChat(currentChatSnapshot);
 
@@ -1455,7 +1504,7 @@ export async function loadChat(chatID: string, dbArg: Db = db) {
 		currentChatMessages = chat.content || [];
 		currentChatSnapshot = {
 			...chat,
-			content: structuredClone(currentChatMessages)
+			content: cloneChatContent(currentChatMessages)
 		};
 
 		const total = currentChatMessages.length;

--- a/src/services/DynamicGroupChat.ts
+++ b/src/services/DynamicGroupChat.ts
@@ -352,6 +352,7 @@ async function respondAsPersona(args: {
 			userName: args.userName,
 			enforceThoughtSignatures: args.shouldEnforceThoughtSignaturesInHistory,
 			includeOpenRouterReasoningDetails: !args.isPremiumEndpointPreferred && isOpenRouterModel(settings.model),
+			includeThoughtParts: !args.isPremiumEndpointPreferred && !isOpenRouterModel(settings.model),
 			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE
 		});
 

--- a/src/services/DynamicGroupChat.ts
+++ b/src/services/DynamicGroupChat.ts
@@ -352,7 +352,7 @@ async function respondAsPersona(args: {
 			userName: args.userName,
 			enforceThoughtSignatures: args.shouldEnforceThoughtSignaturesInHistory,
 			includeOpenRouterReasoningDetails: !args.isPremiumEndpointPreferred && isOpenRouterModel(settings.model),
-			includeThoughtParts: !args.isPremiumEndpointPreferred && !isOpenRouterModel(settings.model),
+			includeThoughtParts: !args.isPremiumEndpointPreferred,
 			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE
 		});
 

--- a/src/services/DynamicGroupChat.ts
+++ b/src/services/DynamicGroupChat.ts
@@ -351,8 +351,6 @@ async function respondAsPersona(args: {
 			speakerNameById: args.speakerNameById,
 			userName: args.userName,
 			enforceThoughtSignatures: args.shouldEnforceThoughtSignaturesInHistory,
-			includeOpenRouterReasoningDetails: !args.isPremiumEndpointPreferred && isOpenRouterModel(settings.model),
-			includeThoughtParts: !args.isPremiumEndpointPreferred,
 			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE
 		});
 

--- a/src/services/DynamicGroupChat.ts
+++ b/src/services/DynamicGroupChat.ts
@@ -351,6 +351,7 @@ async function respondAsPersona(args: {
 			speakerNameById: args.speakerNameById,
 			userName: args.userName,
 			enforceThoughtSignatures: args.shouldEnforceThoughtSignaturesInHistory,
+			includeOpenRouterReasoningDetails: !args.isPremiumEndpointPreferred && isOpenRouterModel(settings.model),
 			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE
 		});
 

--- a/src/services/GeminiResponseProcessor.service.ts
+++ b/src/services/GeminiResponseProcessor.service.ts
@@ -1,6 +1,6 @@
 import type { GenerateContentResponse } from "@google/genai";
 import { BlockedReason, FinishReason } from "@google/genai";
-import type { GeneratedImage } from "../types/Message";
+import type { GeneratedImage, Message } from "../types/Message";
 import type { GeminiLocalSdkProcessArgs, GeminiLocalSdkProcessResult } from "../types/GeminiResponseProcessor";
 
 export function isGeminiBlockedFinishReason(finishReason: unknown): boolean {
@@ -67,6 +67,7 @@ export async function processGeminiLocalSdkResponse(args: {
 	const finishReason = getFinishReason(response);
 	let groundingContent = "";
 	const images: GeneratedImage[] = [];
+	const responseParts: Message["parts"] = [];
 
 	if (process.throwOnBlocked && isGeminiBlockedFinishReason(finishReason)) {
 		throwGeminiBlocked({ finishReason, finishMessage: getFinishMessage(response) });
@@ -74,6 +75,7 @@ export async function processGeminiLocalSdkResponse(args: {
 
 	for (const part of response?.candidates?.[0]?.content?.parts || []) {
 		if (part?.thought && part?.text) {
+			responseParts.push({ text: String(part.text), thought: true });
 			// Never mix thought parts into the main answer.
 			if (process.includeThoughts) {
 				const delta = String(part.text);
@@ -81,12 +83,14 @@ export async function processGeminiLocalSdkResponse(args: {
 				await process.callbacks?.onThinking?.({ delta, thinking });
 			}
 		} else if (part?.text) {
+			const partSignature =
+				part.thoughtSignature ??
+				(process.useSkipThoughtSignature ? process.skipThoughtSignatureValidator : undefined);
 			if (!textSignature) {
-				textSignature =
-					part.thoughtSignature ??
-					(process.useSkipThoughtSignature ? process.skipThoughtSignatureValidator : undefined);
+				textSignature = partSignature;
 			}
 			const delta = String(part.text);
+			responseParts.push({ text: delta, thoughtSignature: partSignature });
 			text += delta;
 			await process.callbacks?.onText?.({ delta, text });
 		} else if (part?.inlineData) {
@@ -109,6 +113,7 @@ export async function processGeminiLocalSdkResponse(args: {
 		text,
 		thinking,
 		textSignature,
+		responseParts,
 		finishReason,
 		groundingContent,
 		images,
@@ -128,6 +133,7 @@ export async function processGeminiLocalSdkStream(args: {
 	let finishReason: unknown;
 	let groundingContent = "";
 	const images: GeneratedImage[] = [];
+	const responseParts: Message["parts"] = [];
 	let wasAborted = false;
 
 	for await (const chunk of stream) {
@@ -146,6 +152,7 @@ export async function processGeminiLocalSdkStream(args: {
 
 		for (const part of chunk?.candidates?.[0]?.content?.parts || []) {
 			if (part?.thought && part?.text) {
+				responseParts.push({ text: String(part.text), thought: true });
 				// Never mix thought parts into the main answer.
 				if (process.includeThoughts) {
 					const delta = String(part.text);
@@ -153,12 +160,14 @@ export async function processGeminiLocalSdkStream(args: {
 					await process.callbacks?.onThinking?.({ delta, thinking });
 				}
 			} else if (part?.text) {
+				const partSignature =
+					part.thoughtSignature ??
+					(process.useSkipThoughtSignature ? process.skipThoughtSignatureValidator : undefined);
 				if (!textSignature) {
-					textSignature =
-						part.thoughtSignature ??
-						(process.useSkipThoughtSignature ? process.skipThoughtSignatureValidator : undefined);
+					textSignature = partSignature;
 				}
 				const delta = String(part.text);
+				responseParts.push({ text: delta, thoughtSignature: partSignature });
 				text += delta;
 				await process.callbacks?.onText?.({ delta, text });
 			} else if (part?.inlineData) {
@@ -183,6 +192,7 @@ export async function processGeminiLocalSdkStream(args: {
 		text,
 		thinking,
 		textSignature,
+		responseParts,
 		finishReason,
 		groundingContent,
 		images,

--- a/src/services/GeminiResponseProcessor.service.ts
+++ b/src/services/GeminiResponseProcessor.service.ts
@@ -40,18 +40,32 @@ function getGroundingRenderedContent(payload: any): string {
 
 function pushInlineImage(args: {
 	images: GeneratedImage[];
+	responseParts: Message["parts"];
 	part: any;
 	useSkipThoughtSignature: boolean;
 	skipThoughtSignatureValidator: string;
 }): void {
-	const { images, part, useSkipThoughtSignature, skipThoughtSignatureValidator } = args;
+	const { images, responseParts, part, useSkipThoughtSignature, skipThoughtSignatureValidator } = args;
+	const thoughtSignature =
+		part.thoughtSignature ?? (useSkipThoughtSignature ? skipThoughtSignatureValidator : undefined);
+
+	if (part.thought) {
+		responseParts.push({
+			inlineData: {
+				data: part.inlineData?.data || "",
+				mimeType: part.inlineData?.mimeType || "image/png"
+			},
+			thoughtSignature,
+			thought: true
+		});
+		return;
+	}
 
 	images.push({
 		mimeType: part.inlineData?.mimeType || "image/png",
 		base64: part.inlineData?.data || "",
-		thoughtSignature:
-			part.thoughtSignature ?? (useSkipThoughtSignature ? skipThoughtSignatureValidator : undefined),
-		thought: part.thought
+		thoughtSignature,
+		thought: undefined
 	});
 }
 
@@ -96,6 +110,7 @@ export async function processGeminiLocalSdkResponse(args: {
 		} else if (part?.inlineData) {
 			pushInlineImage({
 				images,
+				responseParts,
 				part,
 				useSkipThoughtSignature: process.useSkipThoughtSignature,
 				skipThoughtSignatureValidator: process.skipThoughtSignatureValidator
@@ -173,6 +188,7 @@ export async function processGeminiLocalSdkStream(args: {
 			} else if (part?.inlineData) {
 				pushInlineImage({
 					images,
+					responseParts,
 					part,
 					useSkipThoughtSignature: process.useSkipThoughtSignature,
 					skipThoughtSignatureValidator: process.skipThoughtSignatureValidator

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -90,6 +90,56 @@ import { sendGroupChatDynamic, type DynamicInputArgs } from "./DynamicGroupChat"
 // ================================================================================
 
 export const USER_SKIP_TURN_MARKER_TEXT = "__user_skip_turn__";
+
+/**
+ * THOUGHT SIGNATURE QUIRKS (read before touching history-building signature logic)
+ *
+ * Background:
+ * - The Gemini API can require a `thoughtSignature` on model-authored text/image
+ *   parts in request history. When a model message that originally came back with
+ *   thinking is replayed without its signature, Gemini rejects the request with
+ *   "Text/Image part is missing a thought_signature in content position X...".
+ * - `SKIP_THOUGHT_SIGNATURE_VALIDATOR` is a sentinel value Gemini accepts in place
+ *   of a real signature to bypass that validation. We use it whenever we must send
+ *   a signed-looking part but do not have a valid Gemini signature to provide.
+ *
+ * Quirk 1 — Only model parts ever get signatures.
+ * - User messages and persona scaffold messages must NEVER receive a synthetic
+ *   signature (real or skip-validator). Signatures are model-authored metadata.
+ *
+ * Quirk 2 — OpenRouter signatures are NOT Gemini signatures.
+ * - OpenRouter returns `reasoning.encrypted` data that we historically stored in
+ *   `thoughtSignature` fields. That value is incompatible with the Gemini SDK
+ *   (wrong format / invalid TYPE_BYTES base64) and must never be replayed to
+ *   Gemini. For any message whose `originModel` is an OpenRouter model, we ignore
+ *   the stored signature and fall back to `SKIP_THOUGHT_SIGNATURE_VALIDATOR` when
+ *   Gemini history requires one. See `isOpenRouterModel(originModel)` guards and
+ *   the `allowStoredThoughtSignatures` flag in `processGeneratedImagesToParts`.
+ * - OpenRouter requests themselves strip signatures during conversion, so storing
+ *   them was never useful in the first place.
+ *
+ * Quirk 3 — Signatures are per-part, but the skip-validator is applied sparingly.
+ * - Gemini attaches a `thoughtSignature` to each part it wants signed: a model
+ *   message can legitimately have multiple signed parts (text and/or images), and
+ *   we preserve every real per-part signature when replaying history.
+ * - The `hasThoughtSignature` / `suppressThoughtSignature` tracking does NOT strip
+ *   real signatures. It only avoids stamping the synthetic
+ *   `SKIP_THOUGHT_SIGNATURE_VALIDATOR` fallback onto additional parts once some
+ *   part in the message is already signed — real stored signatures (e.g. on an
+ *   image part) are still emitted regardless.
+ * - Exception: when stored signatures are disallowed (OpenRouter origin), image
+ *   parts still get the skip-validator because Gemini validates each image part's
+ *   signature independently.
+ *
+ * Quirk 4 — Thought (reasoning) parts are never signed and are excluded from
+ * rebuilt history entirely.
+ * - In practice Gemini only attaches a `thoughtSignature` to *contentful* parts:
+ *   non-thought text parts and generated-image (inlineData) parts. Parts flagged
+ *   `thought: true` are not signed.
+ * - Either way, thought parts are reasoning content and are dropped when
+ *   rebuilding request history, so they are never replayed to the provider and
+ *   never need a signature.
+ */
 export const SKIP_THOUGHT_SIGNATURE_VALIDATOR = "skip_thought_signature_validator";
 
 export { NARRATOR_PERSONALITY_ID, createPersonalityMarkerMessage };
@@ -1010,11 +1060,18 @@ export async function constructGeminiChatHistoryFromLocalChat(
 			if (text.trim().length > 0) {
 				const partObj: any = { text };
 				const isModelMessage = dbMessage.role === "model";
+				// Thought-signature quirk: only model messages may carry a signature, and
+				// OpenRouter-origin signatures are incompatible with Gemini (see the
+				// SKIP_THOUGHT_SIGNATURE_VALIDATOR doc block). For OpenRouter origin we
+				// ignore the stored signature and fall back to the skip-validator below.
 				const canUseStoredSignature = isModelMessage && !isOpenRouterModel(dbMessage.originModel || "");
 				const resolvedSignature = canUseStoredSignature ? await resolveThoughtSignature(part) : undefined;
 				const ts =
 					resolvedSignature ||
 					(isModelMessage && shouldEnforceThoughtSignatures ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined);
+				// Quirk: only stamp the skip-validator fallback once per message. Real
+				// per-part signatures are preserved elsewhere; this guard just avoids
+				// redundant synthetic sentinels when no real signature exists.
 				if (ts && !hasThoughtSignature) {
 					partObj.thoughtSignature = ts;
 					hasThoughtSignature = true;
@@ -1039,7 +1096,11 @@ export async function constructGeminiChatHistoryFromLocalChat(
 			shouldProcess: !!dbMessage.generatedImages,
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
 			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+			// A text part already carries the skip-validator fallback? Don't stamp it
+			// again on images. (Real per-part image signatures are still emitted.)
 			suppressThoughtSignature: hasThoughtSignature,
+			// OpenRouter image signatures are incompatible with Gemini; disallow reusing
+			// them so the builder substitutes the skip-validator when required.
 			allowStoredThoughtSignatures: !isOpenRouterModel(dbMessage.originModel || "")
 		});
 		if (imageParts.length > 0) {

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -2094,12 +2094,34 @@ async function handleTextChatOpenRouter(ctx: SendContext, state: TextChatRespons
 		onThinking: async ({ thinking }) => {
 			state.thinking = thinking;
 			await renderStreamingTextState(ctx, state);
+		},
+		onImage: (img) => {
+			state.generatedImages.push({
+				mimeType: img.mimeType,
+				base64: img.base64,
+				thoughtSignature:
+					img.thoughtSignature ??
+					(ctx.shouldUseSkipThoughtSignature ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined),
+				thought: undefined
+			});
 		}
 	});
 
 	state.rawText = result.text;
 	state.thinking = result.thinking;
 	state.finishReason = result.finishReason;
+	if (result.images && result.images.length > 0 && state.generatedImages.length === 0) {
+		for (const img of result.images) {
+			state.generatedImages.push({
+				mimeType: img.mimeType,
+				base64: img.base64,
+				thoughtSignature:
+					img.thoughtSignature ??
+					(ctx.shouldUseSkipThoughtSignature ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined),
+				thought: undefined
+			});
+		}
+	}
 }
 
 async function handleTextChatLocalSdk(ctx: SendContext, state: TextChatResponseState): Promise<void> {

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -912,7 +912,7 @@ async function insertHiddenMessageIntoDom(message: Message, index: number): Prom
 export async function constructGeminiChatHistoryFromLocalChat(
 	currentChat: Chat,
 	selectedPersonality: DbPersonality,
-	options?: { enforceThoughtSignatures?: boolean }
+	options?: { enforceThoughtSignatures?: boolean; includeOpenRouterReasoningDetails?: boolean }
 ): Promise<GeminiHistoryBuildResult> {
 	const history: Content[] = [];
 	const pinnedHistoryIndices: number[] = [];
@@ -994,7 +994,8 @@ export async function constructGeminiChatHistoryFromLocalChat(
 			images: dbMessage.generatedImages,
 			shouldProcess: !!dbMessage.generatedImages && index === lastImageIndex,
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
-			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE_VALIDATOR
+			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+			includeOpenRouterReasoningDetails: options?.includeOpenRouterReasoningDetails === true
 		});
 		if (imageParts.length > 0) {
 			genAiMessage.parts?.push(...imageParts);
@@ -1646,7 +1647,10 @@ async function buildSendContext(
 	const { history: chatHistory, pinnedHistoryIndices } = await constructGeminiChatHistoryFromLocalChat(
 		currentChat,
 		selectedPersonaForHistory,
-		{ enforceThoughtSignatures: shouldEnforceThoughtSignaturesInHistory }
+		{
+			enforceThoughtSignatures: shouldEnforceThoughtSignaturesInHistory,
+			includeOpenRouterReasoningDetails: !isPremiumEndpointPreferred && isOpenRouterModel(settings.model)
+		}
 	);
 
 	const userMessage: Message = {
@@ -2115,6 +2119,7 @@ async function handleTextChatOpenRouter(ctx: SendContext, state: TextChatRespons
 				thoughtSignature:
 					img.thoughtSignature ??
 					(ctx.shouldUseSkipThoughtSignature ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined),
+				thoughtSignatureReasoningDetail: img.thoughtSignatureReasoningDetail,
 				thought: undefined
 			});
 		}
@@ -2131,6 +2136,7 @@ async function handleTextChatOpenRouter(ctx: SendContext, state: TextChatRespons
 				thoughtSignature:
 					img.thoughtSignature ??
 					(ctx.shouldUseSkipThoughtSignature ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined),
+				thoughtSignatureReasoningDetail: img.thoughtSignatureReasoningDetail,
 				thought: undefined
 			});
 		}

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -372,10 +372,11 @@ function cloneFilesToFileList(files?: Iterable<File> | ArrayLike<File> | null): 
 		dt.items.add(file);
 	}
 	for (let index = 0; index < sourceFiles.length; index++) {
-		const sourceRef = (sourceFiles[index] as any)._blobRef;
+		const sourceMetadata = sourceFiles[index] as any;
 		const clonedFile = dt.files[index] as File | undefined;
-		if (sourceRef && clonedFile) {
-			(clonedFile as any)._blobRef = sourceRef;
+		if (!clonedFile) continue;
+		for (const key of Object.keys(sourceMetadata)) {
+			(clonedFile as any)[key] = sourceMetadata[key];
 		}
 	}
 	return dt.files;

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -2012,6 +2012,19 @@ async function handleTextChatPremium(ctx: SendContext, state: TextChatResponseSt
 				state.rawText += json.text;
 				if (ctx.thinkingContentElm) ctx.thinkingContentElm.textContent = state.thinking;
 				state.finishReason = json.finishReason;
+
+				if (Array.isArray(json.images) && json.images.length > 0) {
+					for (const img of json.images) {
+						state.generatedImages.push({
+							mimeType: img.mimeType,
+							base64: img.base64,
+							thoughtSignature:
+								img.thoughtSignature ??
+								(ctx.shouldUseSkipThoughtSignature ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined),
+							thought: undefined
+						});
+					}
+				}
 			} else {
 				state.finishReason = json.candidates?.[0]?.finishReason || json.promptFeedback?.blockReason;
 				for (const part of json.candidates?.[0]?.content?.parts || []) {

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -26,6 +26,7 @@ import {
 	getValidChatModel,
 	isGeminiModel,
 	isOpenRouterModel,
+	modelRequiresThinking,
 	modelSupportsThinking,
 	modelSupportsTemperature,
 	requiresThoughtSignaturesInHistory
@@ -587,15 +588,26 @@ function showGeminiProhibitedContentToast(args: { finishReason?: unknown; detail
 }
 
 function generateThinkingConfig(model: string, enableThinking: boolean, settings: any) {
-	if (!enableThinking && model !== ChatModel.NANO_BANANA) {
+	if (model === ChatModel.NANO_BANANA) {
+		return undefined;
+	}
+
+	if (modelRequiresThinking(model)) {
+		const thinkingBudget =
+			Number.isFinite(settings.thinkingBudget) && settings.thinkingBudget > 0 ? settings.thinkingBudget : 128;
+		return {
+			includeThoughts: enableThinking,
+			thinkingBudget
+		};
+	}
+
+	if (!enableThinking) {
 		return {
 			includeThoughts: false,
 			thinkingBudget: 0
 		};
 	}
-	if (model === ChatModel.NANO_BANANA) {
-		return undefined;
-	}
+
 	return {
 		includeThoughts: true,
 		thinkingBudget: settings.thinkingBudget

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -72,8 +72,6 @@ import {
 	buildPersonalityInstructionMessages
 } from "../utils/personalityMarkers";
 import {
-	findLastGeneratedImageIndex,
-	findLastAttachmentIndex,
 	processAttachmentsToParts,
 	processGeneratedImagesToParts,
 	renderGroundingToShadowDom,
@@ -932,9 +930,6 @@ export async function constructGeminiChatHistoryFromLocalChat(
 		await chatsService.saveChat(currentChat as any);
 	}
 
-	const lastImageIndex = findLastGeneratedImageIndex(currentChat.content);
-	const lastAttachmentIndex = findLastAttachmentIndex(currentChat.content);
-
 	for (let index = 0; index < currentChat.content.length; index++) {
 		const dbMessage = currentChat.content[index];
 
@@ -993,7 +988,7 @@ export async function constructGeminiChatHistoryFromLocalChat(
 
 			const attachmentParts = await processAttachmentsToParts({
 				attachments,
-				shouldProcess: attachments.length > 0 && index === lastAttachmentIndex
+				shouldProcess: attachments.length > 0
 			});
 			aggregatedParts.push(...attachmentParts);
 		}
@@ -1005,7 +1000,7 @@ export async function constructGeminiChatHistoryFromLocalChat(
 
 		const imageParts = await processGeneratedImagesToParts({
 			images: dbMessage.generatedImages,
-			shouldProcess: !!dbMessage.generatedImages && index === lastImageIndex,
+			shouldProcess: !!dbMessage.generatedImages,
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
 			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
 			suppressThoughtSignature: hasThoughtSignature

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -23,6 +23,7 @@ import type { DbPersonality } from "../types/Personality";
 import {
 	ChatModel,
 	getPreferredNarratorLocalModel,
+	getValidChatModel,
 	isGeminiModel,
 	isOpenRouterModel,
 	modelSupportsThinking,
@@ -1459,8 +1460,6 @@ function isViewingChat(chatId: string): boolean {
 async function performEarlyValidation(msg: string, options: SendOptions = {}): Promise<EarlyValidationResult> {
 	await ensureChatFullyHydratedForWrite(options.targetChatId);
 	const settings = settingsService.getSettings();
-	const shouldUseSkipThoughtSignature = settings.model === ChatModel.NANO_BANANA;
-	const shouldEnforceThoughtSignaturesInHistory = requiresThoughtSignaturesInHistory(settings.model);
 	const selectedPersonalityId = options.selectedPersonalityId ?? getSelectedPersonalityId();
 	const selectedPersonality = await personalityService.get(selectedPersonalityId);
 	const isInternetSearchEnabled =
@@ -1490,6 +1489,15 @@ async function performEarlyValidation(msg: string, options: SendOptions = {}): P
 	const tier = await supabaseService.getSubscriptionTier(subscription);
 	const hasSubscription = tier === "pro" || tier === "pro_plus" || tier === "max";
 	const isPremiumEndpointPreferred = hasSubscription && shouldPreferPremiumEndpoint();
+	if (isPremiumEndpointPreferred) {
+		settings.model = getValidChatModel(settings.model, {
+			hasGeminiAccess: true,
+			hasOpenRouterAccess: true,
+			isPremiumEndpointPreferred: true
+		});
+	}
+	const shouldUseSkipThoughtSignature = settings.model === ChatModel.NANO_BANANA;
+	const shouldEnforceThoughtSignaturesInHistory = requiresThoughtSignaturesInHistory(settings.model);
 	const imageGenerationAvailability = await supabaseService.isImageGenerationAvailable();
 	const isImagePremiumEndpointPreferred = imageGenerationAvailability.type === "all";
 	const isImageRequest = isImageModeActive() || isImageEditingActive();

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -80,6 +80,7 @@ import {
 	createErrorMessage,
 	UNRESTRICTED_SAFETY_SETTINGS
 } from "../utils/chatHistoryBuilder";
+import { resolveThoughtSignature } from "../utils/blobResolver";
 
 import { sendGroupChatRpg, type RpgInputArgs } from "./RpgGroupChat";
 import { sendGroupChatDynamic, type DynamicInputArgs } from "./DynamicGroupChat";
@@ -948,11 +949,7 @@ export async function constructGeminiChatHistoryFromLocalChat(
 				}
 			}
 			if (persona) {
-				const instructions = buildPersonalityInstructionMessages(persona, {
-					modelTextThoughtSignature: shouldEnforceThoughtSignatures
-						? SKIP_THOUGHT_SIGNATURE_VALIDATOR
-						: undefined
-				});
+				const instructions = buildPersonalityInstructionMessages(persona);
 				const startIndex = history.length;
 				history.push(...instructions);
 				if (markerInfo.personalityId === selectedPersonality.id) {
@@ -978,7 +975,12 @@ export async function constructGeminiChatHistoryFromLocalChat(
 
 			if (text.trim().length > 0) {
 				const partObj: any = { text };
-				const ts = shouldEnforceThoughtSignatures ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined;
+				const resolvedSignature = dbMessage.role === "model" ? await resolveThoughtSignature(part) : undefined;
+				const ts =
+					resolvedSignature ||
+					(dbMessage.role === "model" && shouldEnforceThoughtSignatures
+						? SKIP_THOUGHT_SIGNATURE_VALIDATOR
+						: undefined);
 				if (ts && !hasThoughtSignature) {
 					partObj.thoughtSignature = ts;
 					hasThoughtSignature = true;
@@ -2013,6 +2015,7 @@ async function handleTextChatPremium(ctx: SendContext, state: TextChatResponseSt
 		state.thinking = result.thinking;
 		state.rawText = result.text;
 		state.textSignature = result.textSignature;
+		state.responseParts = result.responseParts ?? [];
 		state.groundingContent = result.groundingContent;
 		state.generatedImages = result.images;
 
@@ -2064,14 +2067,26 @@ async function handleTextChatPremium(ctx: SendContext, state: TextChatResponseSt
 						}
 						state.rawText += part.text;
 					} else if (part.inlineData) {
-						state.generatedImages.push({
-							mimeType: part.inlineData.mimeType || "image/png",
-							base64: part.inlineData.data || "",
+						const imagePart = {
+							inlineData: {
+								data: part.inlineData.data || "",
+								mimeType: part.inlineData.mimeType || "image/png"
+							},
 							thoughtSignature:
 								part.thoughtSignature ??
 								(ctx.shouldUseSkipThoughtSignature ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined),
 							thought: part.thought
-						});
+						};
+						if (part.thought) {
+							state.responseParts.push(imagePart);
+						} else {
+							state.generatedImages.push({
+								mimeType: imagePart.inlineData.mimeType,
+								base64: imagePart.inlineData.data,
+								thoughtSignature: imagePart.thoughtSignature,
+								thought: undefined
+							});
+						}
 					}
 				}
 				if (json.candidates?.[0]?.groundingMetadata?.searchEntryPoint?.renderedContent) {

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -22,7 +22,7 @@ import type { Chat, DbChat } from "../types/Chat";
 import type { DbPersonality } from "../types/Personality";
 import {
 	ChatModel,
-	getPreferredNarratorLocalModel,
+	DEFAULT_OPENROUTER_TITLE_MODEL,
 	getValidChatModel,
 	isGeminiModel,
 	isOpenRouterModel,
@@ -1037,7 +1037,7 @@ async function createChatIfAbsentOpenRouter(apiKey: string, msg: string): Promis
 	const response = await requestOpenRouterCompletion({
 		apiKey,
 		request: buildOpenRouterRequest({
-			model: getPreferredNarratorLocalModel({ geminiApiKey: "", openRouterApiKey: apiKey }),
+			model: DEFAULT_OPENROUTER_TITLE_MODEL,
 			messages: [
 				{ role: "system", content: CHAT_TITLE_SYSTEM_INSTRUCTION },
 				{ role: "user", content: msg }

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -998,14 +998,12 @@ export async function constructGeminiChatHistoryFromLocalChat(
 
 			if (text.trim().length > 0) {
 				const partObj: any = { text };
-				const canUseStoredSignature =
-					dbMessage.role === "model" && !isOpenRouterModel(dbMessage.originModel || "");
+				const isModelMessage = dbMessage.role === "model";
+				const canUseStoredSignature = isModelMessage && !isOpenRouterModel(dbMessage.originModel || "");
 				const resolvedSignature = canUseStoredSignature ? await resolveThoughtSignature(part) : undefined;
 				const ts =
 					resolvedSignature ||
-					(canUseStoredSignature && shouldEnforceThoughtSignatures
-						? SKIP_THOUGHT_SIGNATURE_VALIDATOR
-						: undefined);
+					(isModelMessage && shouldEnforceThoughtSignatures ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined);
 				if (ts && !hasThoughtSignature) {
 					partObj.thoughtSignature = ts;
 					hasThoughtSignature = true;

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -976,6 +976,7 @@ export async function constructGeminiChatHistoryFromLocalChat(
 		if (dbMessage.hidden) continue;
 
 		const aggregatedParts: any[] = [];
+		let hasThoughtSignature = false;
 		for (const part of dbMessage.parts) {
 			const text = part.text || "";
 			const attachments = part.attachments || [];
@@ -990,9 +991,16 @@ export async function constructGeminiChatHistoryFromLocalChat(
 				if (part.thought) {
 					partObj.thought = true;
 				}
-				partObj.thoughtSignature =
+				if (options?.includeOpenRouterReasoningDetails === true && part.reasoningDetail) {
+					partObj.reasoningDetail = part.reasoningDetail;
+				}
+				const ts =
 					resolvedThoughtSignature ??
 					(!part.thought && shouldEnforceThoughtSignatures ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined);
+				if (ts && !hasThoughtSignature) {
+					partObj.thoughtSignature = ts;
+					hasThoughtSignature = true;
+				}
 				aggregatedParts.push(partObj);
 			}
 
@@ -1013,7 +1021,8 @@ export async function constructGeminiChatHistoryFromLocalChat(
 			shouldProcess: !!dbMessage.generatedImages && index === lastImageIndex,
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
 			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
-			includeOpenRouterReasoningDetails: options?.includeOpenRouterReasoningDetails === true
+			includeOpenRouterReasoningDetails: options?.includeOpenRouterReasoningDetails === true,
+			suppressThoughtSignature: hasThoughtSignature
 		});
 		if (imageParts.length > 0) {
 			genAiMessage.parts?.push(...imageParts);
@@ -1668,7 +1677,8 @@ async function buildSendContext(
 		{
 			enforceThoughtSignatures: shouldEnforceThoughtSignaturesInHistory,
 			includeOpenRouterReasoningDetails: !isPremiumEndpointPreferred && isOpenRouterModel(settings.model),
-			includeThoughtParts: !isPremiumEndpointPreferred && isGeminiModel(settings.model)
+			includeThoughtParts:
+				!isPremiumEndpointPreferred && (isGeminiModel(settings.model) || isOpenRouterModel(settings.model))
 		}
 	);
 
@@ -1868,8 +1878,9 @@ async function finalizeTextChatSuccess(
 	ensureTextSignature: () => void
 ): Promise<HTMLElement> {
 	ensureTextSignature();
-	const parts: Message["parts"] = state.responseParts.length
-		? state.responseParts.map((part) => ({ ...part }))
+	const responseParts = state.responseParts ?? [];
+	const parts: Message["parts"] = responseParts.length
+		? responseParts.map((part) => ({ ...part }))
 		: state.rawText.trim().length > 0 || state.textSignature
 			? [{ text: state.rawText, thoughtSignature: state.textSignature }]
 			: [];
@@ -2155,6 +2166,8 @@ async function handleTextChatOpenRouter(ctx: SendContext, state: TextChatRespons
 
 	state.rawText = result.text;
 	state.thinking = result.thinking;
+	state.textSignature = result.textSignature;
+	state.responseParts = result.responseParts ?? [];
 	state.finishReason = result.finishReason;
 	if (result.images && result.images.length > 0 && state.generatedImages.length === 0) {
 		for (const img of result.images) {
@@ -2228,7 +2241,7 @@ async function handleTextChatLocalSdk(ctx: SendContext, state: TextChatResponseS
 		state.thinking = result.thinking;
 		state.rawText = result.text;
 		state.textSignature = result.textSignature;
-		state.responseParts = result.responseParts;
+		state.responseParts = result.responseParts ?? [];
 		state.groundingContent = result.groundingContent;
 		state.generatedImages = result.images;
 
@@ -2253,7 +2266,7 @@ async function handleTextChatLocalSdk(ctx: SendContext, state: TextChatResponseS
 		state.thinking = result.thinking;
 		state.rawText = result.text;
 		state.textSignature = result.textSignature;
-		state.responseParts = result.responseParts;
+		state.responseParts = result.responseParts ?? [];
 		state.groundingContent = result.groundingContent;
 		state.generatedImages = result.images;
 

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -998,10 +998,12 @@ export async function constructGeminiChatHistoryFromLocalChat(
 
 			if (text.trim().length > 0) {
 				const partObj: any = { text };
-				const resolvedSignature = dbMessage.role === "model" ? await resolveThoughtSignature(part) : undefined;
+				const canUseStoredSignature =
+					dbMessage.role === "model" && !isOpenRouterModel(dbMessage.originModel || "");
+				const resolvedSignature = canUseStoredSignature ? await resolveThoughtSignature(part) : undefined;
 				const ts =
 					resolvedSignature ||
-					(dbMessage.role === "model" && shouldEnforceThoughtSignatures
+					(canUseStoredSignature && shouldEnforceThoughtSignatures
 						? SKIP_THOUGHT_SIGNATURE_VALIDATOR
 						: undefined);
 				if (ts && !hasThoughtSignature) {

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -80,7 +80,7 @@ import {
 	createErrorMessage,
 	UNRESTRICTED_SAFETY_SETTINGS
 } from "../utils/chatHistoryBuilder";
-import { resolveThoughtSignature } from "../utils/blobResolver";
+import { resolveAttachmentFile, resolveThoughtSignature } from "../utils/blobResolver";
 
 import { sendGroupChatRpg, type RpgInputArgs } from "./RpgGroupChat";
 import { sendGroupChatDynamic, type DynamicInputArgs } from "./DynamicGroupChat";
@@ -367,10 +367,32 @@ function getSelectedPersonalityId(): string {
 
 function cloneFilesToFileList(files?: Iterable<File> | ArrayLike<File> | null): FileList {
 	const dt = new DataTransfer();
-	for (const file of Array.from(files ?? [])) {
+	const sourceFiles = Array.from(files ?? []);
+	for (const file of sourceFiles) {
 		dt.items.add(file);
 	}
+	for (let index = 0; index < sourceFiles.length; index++) {
+		const sourceRef = (sourceFiles[index] as any)._blobRef;
+		const clonedFile = dt.files[index] as File | undefined;
+		if (sourceRef && clonedFile) {
+			(clonedFile as any)._blobRef = sourceRef;
+		}
+	}
 	return dt.files;
+}
+
+async function materializeFilesForRegenerate(files?: Iterable<File> | ArrayLike<File> | null): Promise<FileList> {
+	const resolvedFiles: File[] = [];
+	for (const file of Array.from(files ?? [])) {
+		const originalBlobRef = (file as any)._blobRef;
+		const resolvedFile = await resolveAttachmentFile(file);
+		if (originalBlobRef && resolvedFile.size === 0) {
+			throw new Error("Unable to restore the original attachment for regeneration.");
+		}
+		delete (resolvedFile as any)._blobRef;
+		resolvedFiles.push(resolvedFile);
+	}
+	return cloneFilesToFileList(resolvedFiles);
 }
 
 function createModelPlaceholderMessage(
@@ -1364,26 +1386,28 @@ export async function regenerate(modelMessageIndex: number): Promise<void> {
 		deletionStart = i;
 	}
 
-	chat.content = chat.content.slice(0, deletionStart);
-	pruneTrailingPersonalityMarkers(chat);
-	await chatsService.saveChat(chat as any);
-
-	const container = isViewingChat(targetChatId) ? document.querySelector<HTMLDivElement>(".message-container") : null;
-	if (container) {
-		const toRemove: Element[] = [];
-		for (const child of Array.from(container.children)) {
-			const indexAttr = child.getAttribute("data-chat-index");
-			if (!indexAttr) continue;
-			const chatIndex = Number.parseInt(indexAttr, 10);
-			if (!Number.isFinite(chatIndex)) continue;
-			if (chatIndex >= deletionStart) toRemove.push(child);
-		}
-		for (const node of toRemove) node.remove();
-	}
-
-	const attachments = cloneFilesToFileList(message.parts[0]?.attachments);
-
 	try {
+		const attachments = await materializeFilesForRegenerate(message.parts[0]?.attachments);
+
+		chat.content = chat.content.slice(0, deletionStart);
+		pruneTrailingPersonalityMarkers(chat);
+		await chatsService.saveChat(chat as any);
+
+		const container = isViewingChat(targetChatId)
+			? document.querySelector<HTMLDivElement>(".message-container")
+			: null;
+		if (container) {
+			const toRemove: Element[] = [];
+			for (const child of Array.from(container.children)) {
+				const indexAttr = child.getAttribute("data-chat-index");
+				if (!indexAttr) continue;
+				const chatIndex = Number.parseInt(indexAttr, 10);
+				if (!Number.isFinite(chatIndex)) continue;
+				if (chatIndex >= deletionStart) toRemove.push(child);
+			}
+			for (const node of toRemove) node.remove();
+		}
+
 		await send(message.parts[0]?.text || "", {
 			targetChatId,
 			selectedPersonalityId: targetPersonalityId,

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -382,6 +382,16 @@ function cloneFilesToFileList(files?: Iterable<File> | ArrayLike<File> | null): 
 	return dt.files;
 }
 
+function normalizeMessageAttachmentsForStorage(message: Message): Message {
+	return {
+		...message,
+		parts: message.parts.map((part) => ({
+			...part,
+			attachments: part.attachments ? Array.from(part.attachments) : part.attachments
+		}))
+	};
+}
+
 async function materializeFilesForRegenerate(files?: Iterable<File> | ArrayLike<File> | null): Promise<FileList> {
 	const resolvedFiles: File[] = [];
 	for (const file of Array.from(files ?? [])) {
@@ -533,9 +543,10 @@ export async function persistMessagesToChat(
 	messages: Message[]
 ): Promise<{ startIndex: number } | null> {
 	await ensureChatFullyHydratedForWrite(chatId);
+	const storableMessages = messages.map(normalizeMessageAttachmentsForStorage);
 	const startIndex = await chatsService.mutateChat(chatId, (chat) => {
 		const nextStartIndex = chat.content.length;
-		chat.content.push(...messages);
+		chat.content.push(...storableMessages);
 		chat.lastModified = new Date();
 		return nextStartIndex;
 	});
@@ -553,7 +564,7 @@ async function updateChatMessage(chatId: string, messageIndex: number, message: 
 	const didUpdate = await chatsService.mutateChat(chatId, (chat) => {
 		if (messageIndex < 0 || messageIndex >= chat.content.length) return undefined;
 
-		chat.content[messageIndex] = message;
+		chat.content[messageIndex] = normalizeMessageAttachmentsForStorage(message);
 		chat.lastModified = new Date();
 		return true;
 	});
@@ -1028,7 +1039,8 @@ export async function constructGeminiChatHistoryFromLocalChat(
 			shouldProcess: !!dbMessage.generatedImages,
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
 			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
-			suppressThoughtSignature: hasThoughtSignature
+			suppressThoughtSignature: hasThoughtSignature,
+			allowStoredThoughtSignatures: !isOpenRouterModel(dbMessage.originModel || "")
 		});
 		if (imageParts.length > 0) {
 			genAiMessage.parts?.push(...imageParts);

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -60,7 +60,6 @@ import { shouldPreferPremiumEndpoint } from "../components/static/ApiKeyInput.co
 import { getSelectedEditingModel } from "../components/static/ImageEditModelSelector.component";
 
 import { isAbortError, throwAbortError } from "../utils/abort";
-import { resolveThoughtSignature } from "../utils/blobResolver";
 import { dispatchAppEvent } from "../events";
 import { MODEL_IMAGE_LIMITS } from "../constants/ImageModels";
 import {
@@ -920,14 +919,11 @@ export async function constructGeminiChatHistoryFromLocalChat(
 	selectedPersonality: DbPersonality,
 	options?: {
 		enforceThoughtSignatures?: boolean;
-		includeOpenRouterReasoningDetails?: boolean;
-		includeThoughtParts?: boolean;
 	}
 ): Promise<GeminiHistoryBuildResult> {
 	const history: Content[] = [];
 	const pinnedHistoryIndices: number[] = [];
 	const shouldEnforceThoughtSignatures = options?.enforceThoughtSignatures === true;
-	const shouldIncludeThoughtParts = options?.includeThoughtParts === true;
 
 	const migrated = await migrateLegacyPersonalityMarkers(currentChat);
 	const backfilled = await backfillMissingPersonalityMarkers(currentChat);
@@ -981,22 +977,13 @@ export async function constructGeminiChatHistoryFromLocalChat(
 			const text = part.text || "";
 			const attachments = part.attachments || [];
 
-			if (part.thought && !shouldIncludeThoughtParts) {
+			if (part.thought) {
 				continue;
 			}
 
-			if (text.trim().length > 0 || part.thoughtSignature || part._thoughtSignatureRef) {
-				const resolvedThoughtSignature = await resolveThoughtSignature(part);
+			if (text.trim().length > 0) {
 				const partObj: any = { text };
-				if (part.thought) {
-					partObj.thought = true;
-				}
-				if (options?.includeOpenRouterReasoningDetails === true && part.reasoningDetail) {
-					partObj.reasoningDetail = part.reasoningDetail;
-				}
-				const ts =
-					resolvedThoughtSignature ??
-					(!part.thought && shouldEnforceThoughtSignatures ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined);
+				const ts = shouldEnforceThoughtSignatures ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined;
 				if (ts && !hasThoughtSignature) {
 					partObj.thoughtSignature = ts;
 					hasThoughtSignature = true;
@@ -1021,7 +1008,6 @@ export async function constructGeminiChatHistoryFromLocalChat(
 			shouldProcess: !!dbMessage.generatedImages && index === lastImageIndex,
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
 			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
-			includeOpenRouterReasoningDetails: options?.includeOpenRouterReasoningDetails === true,
 			suppressThoughtSignature: hasThoughtSignature
 		});
 		if (imageParts.length > 0) {
@@ -1675,10 +1661,7 @@ async function buildSendContext(
 		currentChat,
 		selectedPersonaForHistory,
 		{
-			enforceThoughtSignatures: shouldEnforceThoughtSignaturesInHistory,
-			includeOpenRouterReasoningDetails: !isPremiumEndpointPreferred && isOpenRouterModel(settings.model),
-			includeThoughtParts:
-				!isPremiumEndpointPreferred && (isGeminiModel(settings.model) || isOpenRouterModel(settings.model))
+			enforceThoughtSignatures: shouldEnforceThoughtSignaturesInHistory
 		}
 	);
 

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -747,15 +747,21 @@ function createInterruptedModelMessage(args: {
 	personalityId: string;
 	text: string;
 	textSignature?: string;
+	responseParts?: Message["parts"];
 	thinking?: string;
 	groundingContent?: string;
 	generatedImages?: GeneratedImage[];
 	originModel?: string;
 }): Message {
 	const hasImages = (args.generatedImages?.length ?? 0) > 0;
-	const parts: Array<{ text: string; thoughtSignature?: string }> = [];
+	const parts: Message["parts"] = args.responseParts?.length ? [...args.responseParts] : [];
 
-	if (args.text.trim().length > 0 || args.textSignature) {
+	if (parts.length > 0) {
+		const visiblePart = parts.find((part) => !part.thought);
+		if (visiblePart && args.textSignature && !visiblePart.thoughtSignature) {
+			visiblePart.thoughtSignature = args.textSignature;
+		}
+	} else if (args.text.trim().length > 0 || args.textSignature) {
 		parts.push({ text: args.text, thoughtSignature: args.textSignature });
 	} else if (!hasImages) {
 		parts.push({ text: "*Response interrupted.*" });
@@ -912,11 +918,16 @@ async function insertHiddenMessageIntoDom(message: Message, index: number): Prom
 export async function constructGeminiChatHistoryFromLocalChat(
 	currentChat: Chat,
 	selectedPersonality: DbPersonality,
-	options?: { enforceThoughtSignatures?: boolean; includeOpenRouterReasoningDetails?: boolean }
+	options?: {
+		enforceThoughtSignatures?: boolean;
+		includeOpenRouterReasoningDetails?: boolean;
+		includeThoughtParts?: boolean;
+	}
 ): Promise<GeminiHistoryBuildResult> {
 	const history: Content[] = [];
 	const pinnedHistoryIndices: number[] = [];
 	const shouldEnforceThoughtSignatures = options?.enforceThoughtSignatures === true;
+	const shouldIncludeThoughtParts = options?.includeThoughtParts === true;
 
 	const migrated = await migrateLegacyPersonalityMarkers(currentChat);
 	const backfilled = await backfillMissingPersonalityMarkers(currentChat);
@@ -969,12 +980,19 @@ export async function constructGeminiChatHistoryFromLocalChat(
 			const text = part.text || "";
 			const attachments = part.attachments || [];
 
+			if (part.thought && !shouldIncludeThoughtParts) {
+				continue;
+			}
+
 			if (text.trim().length > 0 || part.thoughtSignature || part._thoughtSignatureRef) {
 				const resolvedThoughtSignature = await resolveThoughtSignature(part);
 				const partObj: any = { text };
+				if (part.thought) {
+					partObj.thought = true;
+				}
 				partObj.thoughtSignature =
 					resolvedThoughtSignature ??
-					(shouldEnforceThoughtSignatures ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined);
+					(!part.thought && shouldEnforceThoughtSignatures ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined);
 				aggregatedParts.push(partObj);
 			}
 
@@ -1649,7 +1667,8 @@ async function buildSendContext(
 		selectedPersonaForHistory,
 		{
 			enforceThoughtSignatures: shouldEnforceThoughtSignaturesInHistory,
-			includeOpenRouterReasoningDetails: !isPremiumEndpointPreferred && isOpenRouterModel(settings.model)
+			includeOpenRouterReasoningDetails: !isPremiumEndpointPreferred && isOpenRouterModel(settings.model),
+			includeThoughtParts: !isPremiumEndpointPreferred && isGeminiModel(settings.model)
 		}
 	);
 
@@ -1741,6 +1760,7 @@ interface TextChatResponseState {
 	thinking: string;
 	rawText: string;
 	textSignature: string | undefined;
+	responseParts: Message["parts"];
 	finishReason: unknown;
 	groundingContent: string;
 	generatedImages: GeneratedImage[];
@@ -1751,6 +1771,7 @@ async function handleTextChat(ctx: SendContext): Promise<HTMLElement | undefined
 		thinking: "",
 		rawText: "",
 		textSignature: undefined,
+		responseParts: [],
 		finishReason: undefined,
 		groundingContent: "",
 		generatedImages: []
@@ -1809,6 +1830,7 @@ async function handleAbort(
 		personalityId: ctx.selectedPersonalityId,
 		text: state.rawText,
 		textSignature: state.textSignature,
+		responseParts: state.responseParts,
 		thinking: state.thinking,
 		groundingContent: state.groundingContent,
 		generatedImages: state.generatedImages,
@@ -1846,14 +1868,20 @@ async function finalizeTextChatSuccess(
 	ensureTextSignature: () => void
 ): Promise<HTMLElement> {
 	ensureTextSignature();
+	const parts: Message["parts"] = state.responseParts.length
+		? state.responseParts.map((part) => ({ ...part }))
+		: state.rawText.trim().length > 0 || state.textSignature
+			? [{ text: state.rawText, thoughtSignature: state.textSignature }]
+			: [];
+	const visiblePart = parts.find((part) => !part.thought);
+	if (visiblePart && state.textSignature && !visiblePart.thoughtSignature) {
+		visiblePart.thoughtSignature = state.textSignature;
+	}
 
 	const modelMessage: Message = {
 		role: "model",
 		personalityid: ctx.selectedPersonalityId,
-		parts:
-			state.rawText.trim().length > 0 || state.textSignature
-				? [{ text: state.rawText, thoughtSignature: state.textSignature }]
-				: [],
+		parts,
 		groundingContent: state.groundingContent || "",
 		thinking: state.thinking || undefined,
 		generatedImages: state.generatedImages.length > 0 ? state.generatedImages : undefined,
@@ -2200,6 +2228,7 @@ async function handleTextChatLocalSdk(ctx: SendContext, state: TextChatResponseS
 		state.thinking = result.thinking;
 		state.rawText = result.text;
 		state.textSignature = result.textSignature;
+		state.responseParts = result.responseParts;
 		state.groundingContent = result.groundingContent;
 		state.generatedImages = result.images;
 
@@ -2224,6 +2253,7 @@ async function handleTextChatLocalSdk(ctx: SendContext, state: TextChatResponseS
 		state.thinking = result.thinking;
 		state.rawText = result.text;
 		state.textSignature = result.textSignature;
+		state.responseParts = result.responseParts;
 		state.groundingContent = result.groundingContent;
 		state.generatedImages = result.images;
 

--- a/src/services/OpenRouter.service.ts
+++ b/src/services/OpenRouter.service.ts
@@ -184,7 +184,7 @@ function extractReasoningFromDetails(details: unknown): string {
 		.join("");
 }
 
-function extractThoughtSignatureFromDetails(details: unknown): string | undefined {
+export function extractThoughtSignatureFromDetails(details: unknown): string | undefined {
 	if (!Array.isArray(details)) return undefined;
 
 	const encryptedDetail = details.find((detail) => (detail as { type?: string }).type === "reasoning.encrypted");
@@ -195,7 +195,7 @@ function extractThoughtSignatureFromDetails(details: unknown): string | undefine
 	return undefined;
 }
 
-function extractImageDataFromOpenRouterImageUrl(img: any, thoughtSignature?: string) {
+export function extractImageDataFromOpenRouterImageUrl(img: any, thoughtSignature?: string) {
 	const url = img?.image_url?.url;
 	if (typeof url === "string" && url.startsWith("data:")) {
 		const match = url.match(/^data:([^;]+);base64,(.+)$/);

--- a/src/services/OpenRouter.service.ts
+++ b/src/services/OpenRouter.service.ts
@@ -12,12 +12,14 @@ import type {
 	StreamingChoice
 } from "../types/OpenRouterTypes";
 import { getChatModelDefinition, modelSupportsTemperature, type ChatModelDefinition } from "../types/Models";
-import type { GeneratedImage } from "../types/Message";
+import type { GeneratedImage, Message, ReasoningDetailMetadata } from "../types/Message";
 import * as helpers from "../utils/helpers";
 
 export interface OpenRouterCompletionResult {
 	text: string;
 	thinking: string;
+	textSignature?: string;
+	responseParts: Message["parts"];
 	finishReason?: unknown;
 	images?: {
 		mimeType: string;
@@ -194,6 +196,32 @@ function extractReasoningFromDetails(details: unknown): string {
 
 const FALLBACK_GEMINI_REASONING_DETAIL_FORMAT = "google-gemini-v1";
 
+function stripReasoningPayload(detail: OpenRouterReasoningDetail): ReasoningDetailMetadata {
+	const { data, text, summary, ...metadata } = detail;
+	return metadata;
+}
+
+function buildTextReasoningDetail(part: {
+	text: string;
+	reasoningDetail?: ReasoningDetailMetadata;
+}): OpenRouterReasoningDetail {
+	const metadata = part.reasoningDetail;
+	const type = metadata?.type || "reasoning.text";
+	const detail: OpenRouterReasoningDetail = {
+		...metadata,
+		type,
+		format: metadata?.format ?? FALLBACK_GEMINI_REASONING_DETAIL_FORMAT
+	};
+
+	if (type === "reasoning.summary") {
+		detail.summary = part.text;
+	} else {
+		detail.text = part.text;
+	}
+
+	return detail;
+}
+
 export function extractEncryptedReasoningDetailFromDetails(details: unknown): OpenRouterReasoningDetail | undefined {
 	if (!Array.isArray(details)) return undefined;
 
@@ -214,7 +242,7 @@ function getThoughtSignatureReasoningMetadata(
 	detail: OpenRouterReasoningDetail | undefined
 ): GeneratedImage["thoughtSignatureReasoningDetail"] {
 	if (!detail || detail.type !== "reasoning.encrypted") return undefined;
-	const { data, ...metadata } = detail;
+	const metadata = stripReasoningPayload(detail);
 
 	return {
 		...metadata,
@@ -225,10 +253,7 @@ function getThoughtSignatureReasoningMetadata(
 	};
 }
 
-function buildEncryptedReasoningDetail(
-	data: string,
-	metadata?: GeneratedImage["thoughtSignatureReasoningDetail"]
-): OpenRouterReasoningDetail {
+function buildEncryptedReasoningDetail(data: string, metadata?: ReasoningDetailMetadata): OpenRouterReasoningDetail {
 	return {
 		...metadata,
 		type: "reasoning.encrypted",
@@ -237,6 +262,93 @@ function buildEncryptedReasoningDetail(
 		format: metadata?.format ?? FALLBACK_GEMINI_REASONING_DETAIL_FORMAT,
 		index: metadata?.index
 	};
+}
+
+function getReasoningTextFromDetail(detail: OpenRouterReasoningDetail): string {
+	const value = detail as { text?: unknown; summary?: unknown };
+	if (typeof value.text === "string") return value.text;
+	if (typeof value.summary === "string") return value.summary;
+	return "";
+}
+
+function buildResponsePartsFromOpenRouter(args: {
+	text: string;
+	reasoningDetails: OpenRouterReasoningDetail[];
+	fallbackThinking?: string;
+}): { responseParts: Message["parts"]; textSignature?: string } {
+	const responseParts: Message["parts"] = [];
+	let encryptedDetail: OpenRouterReasoningDetail | undefined;
+	let hasReasoningTextPart = false;
+
+	for (const detail of args.reasoningDetails) {
+		if (detail.type === "reasoning.encrypted" && typeof detail.data === "string" && detail.data.length > 0) {
+			encryptedDetail = detail;
+			continue;
+		}
+
+		const reasoningText = getReasoningTextFromDetail(detail);
+		if (!reasoningText) continue;
+		hasReasoningTextPart = true;
+		responseParts.push({ text: reasoningText, thought: true, reasoningDetail: stripReasoningPayload(detail) });
+	}
+
+	if (!hasReasoningTextPart && args.reasoningDetails.length > 0 && args.fallbackThinking) {
+		responseParts.push({ text: args.fallbackThinking, thought: true });
+	}
+
+	const textSignature = encryptedDetail?.data;
+	if (args.text.trim().length > 0 || textSignature) {
+		responseParts.push({
+			text: args.text,
+			thoughtSignature: textSignature,
+			reasoningDetail: encryptedDetail ? stripReasoningPayload(encryptedDetail) : undefined
+		});
+	}
+
+	return { responseParts, textSignature };
+}
+
+function normalizeReasoningDetails(details: unknown): OpenRouterReasoningDetail[] {
+	if (!Array.isArray(details)) return [];
+	return details.filter((detail): detail is OpenRouterReasoningDetail => !!detail && typeof detail === "object");
+}
+
+function mergeReasoningDetails(
+	existing: OpenRouterReasoningDetail[],
+	incoming: OpenRouterReasoningDetail[]
+): OpenRouterReasoningDetail[] {
+	const merged = [...existing];
+
+	for (const detail of incoming) {
+		const index = typeof detail.index === "number" ? detail.index : undefined;
+		const existingIndex =
+			index === undefined ? -1 : merged.findIndex((item) => item.index === index && item.type === detail.type);
+
+		if (existingIndex < 0) {
+			merged.push({ ...detail });
+			continue;
+		}
+
+		const current = merged[existingIndex] as OpenRouterReasoningDetail;
+		merged[existingIndex] = {
+			...current,
+			...detail,
+			text:
+				typeof current.text === "string" || typeof detail.text === "string"
+					? `${current.text || ""}${detail.text || ""}`
+					: undefined,
+			summary:
+				typeof current.summary === "string" || typeof detail.summary === "string"
+					? `${current.summary || ""}${detail.summary || ""}`
+					: undefined,
+			data:
+				typeof current.data === "string" || typeof detail.data === "string"
+					? `${current.data || ""}${detail.data || ""}`
+					: undefined
+		};
+	}
+
+	return merged;
 }
 
 export function extractImageDataFromOpenRouterImageUrl(
@@ -286,17 +398,35 @@ export async function convertGeminiHistoryToOpenRouterMessages(history: Content[
 
 		for (const part of item?.parts || []) {
 			const thoughtSignature = (part as { thoughtSignature?: unknown })?.thoughtSignature;
+			if (role === "assistant" && (part as { thought?: unknown })?.thought === true) {
+				if (part?.text) {
+					reasoningDetails.push(
+						buildTextReasoningDetail({
+							text: String(part.text),
+							reasoningDetail: (part as { reasoningDetail?: ReasoningDetailMetadata }).reasoningDetail
+						})
+					);
+				}
+				continue;
+			}
+
 			if (role === "assistant" && typeof thoughtSignature === "string" && thoughtSignature.length > 0) {
-				reasoningDetails.push(
-					buildEncryptedReasoningDetail(
-						thoughtSignature,
-						(
-							part as {
-								thoughtSignatureReasoningDetail?: GeneratedImage["thoughtSignatureReasoningDetail"];
-							}
-						).thoughtSignatureReasoningDetail
-					)
+				const isDuplicate = reasoningDetails.some(
+					(detail) => detail.type === "reasoning.encrypted" && detail.data === thoughtSignature
 				);
+				if (!isDuplicate) {
+					reasoningDetails.push(
+						buildEncryptedReasoningDetail(
+							thoughtSignature,
+							(part as { reasoningDetail?: ReasoningDetailMetadata }).reasoningDetail ??
+								(
+									part as {
+										thoughtSignatureReasoningDetail?: GeneratedImage["thoughtSignatureReasoningDetail"];
+									}
+								).thoughtSignatureReasoningDetail
+						)
+					);
+				}
 			}
 
 			if (part?.text) {
@@ -314,8 +444,11 @@ export async function convertGeminiHistoryToOpenRouterMessages(history: Content[
 			}
 		}
 
-		if (contentParts.length === 0) continue;
-		const message: OpenRouterMessage = { role, content: collapseContentParts(contentParts) };
+		if (contentParts.length === 0 && reasoningDetails.length === 0) continue;
+		const message: OpenRouterMessage = {
+			role,
+			content: contentParts.length > 0 ? collapseContentParts(contentParts) : ""
+		};
 		if (role === "assistant" && reasoningDetails.length > 0) {
 			message.reasoning_details = reasoningDetails;
 		}
@@ -456,11 +589,17 @@ export async function requestOpenRouterCompletion(args: OpenRouterCompletionArgs
 			response,
 			signal: args.signal,
 			onText: args.onText,
-			onThinking: args.onThinking
+			onThinking: args.onThinking,
+			onImage: args.onImage
 		});
 	}
 
-	return await processOpenRouterJson({ response, onText: args.onText, onThinking: args.onThinking });
+	return await processOpenRouterJson({
+		response,
+		onText: args.onText,
+		onThinking: args.onThinking,
+		onImage: args.onImage
+	});
 }
 
 async function processOpenRouterJson(args: {
@@ -488,10 +627,16 @@ async function processOpenRouterJson(args: {
 	}
 
 	const text = extractContentText(choice?.message?.content);
-	const thinking = choice?.message?.reasoning || extractReasoningFromDetails(choice?.message?.reasoning_details);
-	const encryptedReasoningDetail = extractEncryptedReasoningDetailFromDetails(choice?.message?.reasoning_details);
+	const reasoningDetails = normalizeReasoningDetails(choice?.message?.reasoning_details);
+	const thinking = choice?.message?.reasoning || extractReasoningFromDetails(reasoningDetails);
+	const encryptedReasoningDetail = extractEncryptedReasoningDetailFromDetails(reasoningDetails);
 	const thoughtSignature = encryptedReasoningDetail?.data;
 	const thoughtSignatureReasoningDetail = getThoughtSignatureReasoningMetadata(encryptedReasoningDetail);
+	const { responseParts, textSignature } = buildResponsePartsFromOpenRouter({
+		text,
+		reasoningDetails,
+		fallbackThinking: thinking
+	});
 
 	const images: OpenRouterCompletionResult["images"] = [];
 	for (const img of choice?.message?.images || []) {
@@ -522,6 +667,8 @@ async function processOpenRouterJson(args: {
 	return {
 		text,
 		thinking,
+		textSignature,
+		responseParts,
 		finishReason: choice?.finish_reason,
 		images
 	};
@@ -535,7 +682,7 @@ async function processOpenRouterStream(args: {
 	onImage?: OpenRouterCompletionArgs["onImage"];
 }): Promise<OpenRouterCompletionResult> {
 	if (!args.response.body) {
-		return { text: "", thinking: "" };
+		return { text: "", thinking: "", responseParts: [] };
 	}
 
 	const reader = args.response.body.getReader();
@@ -547,6 +694,7 @@ async function processOpenRouterStream(args: {
 	let finishReason: unknown;
 	let thoughtSignature: string | undefined;
 	let thoughtSignatureReasoningDetail: GeneratedImage["thoughtSignatureReasoningDetail"];
+	let reasoningDetails: OpenRouterReasoningDetail[] = [];
 	const images: OpenRouterCompletionResult["images"] = [];
 
 	while (true) {
@@ -605,9 +753,12 @@ async function processOpenRouterStream(args: {
 				await args.onThinking?.({ thinking, delta: thinkingDelta });
 			}
 
-			const encryptedReasoningDetail = extractEncryptedReasoningDetailFromDetails(
-				choice.delta?.reasoning_details
-			);
+			const deltaReasoningDetails = normalizeReasoningDetails(choice.delta?.reasoning_details);
+			if (deltaReasoningDetails.length > 0) {
+				reasoningDetails = mergeReasoningDetails(reasoningDetails, deltaReasoningDetails);
+			}
+
+			const encryptedReasoningDetail = extractEncryptedReasoningDetailFromDetails(deltaReasoningDetails);
 			if (encryptedReasoningDetail) {
 				thoughtSignature = encryptedReasoningDetail.data;
 				thoughtSignatureReasoningDetail = getThoughtSignatureReasoningMetadata(encryptedReasoningDetail);
@@ -630,7 +781,13 @@ async function processOpenRouterStream(args: {
 		}
 	}
 
-	return { text, thinking, finishReason, images };
+	const responsePartResult = buildResponsePartsFromOpenRouter({
+		text,
+		reasoningDetails,
+		fallbackThinking: thinking
+	});
+
+	return { text, thinking, finishReason, images, ...responsePartResult };
 }
 
 export function getOpenRouterModelDefinition(model: string): ChatModelDefinition | undefined {

--- a/src/services/OpenRouter.service.ts
+++ b/src/services/OpenRouter.service.ts
@@ -206,7 +206,10 @@ function extractReasoningFromDetails(details: unknown): string {
 }
 
 function stripReasoningPayload(detail: OpenRouterReasoningDetail): ReasoningDetailMetadata {
-	const { data, text, summary, ...metadata } = detail;
+	const metadata: ReasoningDetailMetadata = { ...detail };
+	delete metadata["data"];
+	delete metadata["text"];
+	delete metadata["summary"];
 	return metadata;
 }
 

--- a/src/services/OpenRouter.service.ts
+++ b/src/services/OpenRouter.service.ts
@@ -229,21 +229,6 @@ export function extractThoughtSignatureFromDetails(details: unknown): string | u
 	return extractEncryptedReasoningDetailFromDetails(details)?.data;
 }
 
-function getThoughtSignatureReasoningMetadata(
-	detail: OpenRouterReasoningDetail | undefined
-): GeneratedImage["thoughtSignatureReasoningDetail"] {
-	if (!detail || detail.type !== "reasoning.encrypted") return undefined;
-	const metadata = stripReasoningPayload(detail);
-
-	return {
-		...metadata,
-		type: "reasoning.encrypted",
-		id: metadata.id,
-		format: metadata.format,
-		index: metadata.index
-	};
-}
-
 function getReasoningTextFromDetail(detail: OpenRouterReasoningDetail): string {
 	const value = detail as { text?: unknown; summary?: unknown };
 	if (typeof value.text === "string") return value.text;
@@ -255,14 +240,12 @@ function buildResponsePartsFromOpenRouter(args: {
 	text: string;
 	reasoningDetails: OpenRouterReasoningDetail[];
 	fallbackThinking?: string;
-}): { responseParts: Message["parts"]; textSignature?: string } {
+}): { responseParts: Message["parts"] } {
 	const responseParts: Message["parts"] = [];
-	let encryptedDetail: OpenRouterReasoningDetail | undefined;
 	let hasReasoningTextPart = false;
 
 	for (const detail of args.reasoningDetails) {
 		if (detail.type === "reasoning.encrypted" && typeof detail.data === "string" && detail.data.length > 0) {
-			encryptedDetail = detail;
 			continue;
 		}
 
@@ -276,16 +259,13 @@ function buildResponsePartsFromOpenRouter(args: {
 		responseParts.push({ text: args.fallbackThinking, thought: true });
 	}
 
-	const textSignature = encryptedDetail?.data;
-	if (args.text.trim().length > 0 || textSignature) {
+	if (args.text.trim().length > 0) {
 		responseParts.push({
-			text: args.text,
-			thoughtSignature: textSignature,
-			reasoningDetail: encryptedDetail ? stripReasoningPayload(encryptedDetail) : undefined
+			text: args.text
 		});
 	}
 
-	return { responseParts, textSignature };
+	return { responseParts };
 }
 
 function normalizeReasoningDetails(details: unknown): OpenRouterReasoningDetail[] {
@@ -578,10 +558,7 @@ async function processOpenRouterJson(args: {
 	const text = extractContentText(choice?.message?.content);
 	const reasoningDetails = normalizeReasoningDetails(choice?.message?.reasoning_details);
 	const thinking = choice?.message?.reasoning || extractReasoningFromDetails(reasoningDetails);
-	const encryptedReasoningDetail = extractEncryptedReasoningDetailFromDetails(reasoningDetails);
-	const thoughtSignature = encryptedReasoningDetail?.data;
-	const thoughtSignatureReasoningDetail = getThoughtSignatureReasoningMetadata(encryptedReasoningDetail);
-	const { responseParts, textSignature } = buildResponsePartsFromOpenRouter({
+	const { responseParts } = buildResponsePartsFromOpenRouter({
 		text,
 		reasoningDetails,
 		fallbackThinking: thinking
@@ -589,11 +566,7 @@ async function processOpenRouterJson(args: {
 
 	const images: OpenRouterCompletionResult["images"] = [];
 	for (const img of choice?.message?.images || []) {
-		const extracted = extractImageDataFromOpenRouterImageUrl(
-			img,
-			thoughtSignature,
-			thoughtSignatureReasoningDetail
-		);
+		const extracted = extractImageDataFromOpenRouterImageUrl(img);
 		if (extracted) {
 			images.push(extracted);
 		}
@@ -616,7 +589,6 @@ async function processOpenRouterJson(args: {
 	return {
 		text,
 		thinking,
-		textSignature,
 		responseParts,
 		finishReason: choice?.finish_reason,
 		images
@@ -641,8 +613,6 @@ async function processOpenRouterStream(args: {
 	let text = "";
 	let thinking = "";
 	let finishReason: unknown;
-	let thoughtSignature: string | undefined;
-	let thoughtSignatureReasoningDetail: GeneratedImage["thoughtSignatureReasoningDetail"];
 	let reasoningDetails: OpenRouterReasoningDetail[] = [];
 	const images: OpenRouterCompletionResult["images"] = [];
 
@@ -707,19 +677,9 @@ async function processOpenRouterStream(args: {
 				reasoningDetails = mergeReasoningDetails(reasoningDetails, deltaReasoningDetails);
 			}
 
-			const encryptedReasoningDetail = extractEncryptedReasoningDetailFromDetails(deltaReasoningDetails);
-			if (encryptedReasoningDetail) {
-				thoughtSignature = encryptedReasoningDetail.data;
-				thoughtSignatureReasoningDetail = getThoughtSignatureReasoningMetadata(encryptedReasoningDetail);
-			}
-
 			const deltaImages = choice.delta?.images || [];
 			for (const img of deltaImages) {
-				const imageObj = extractImageDataFromOpenRouterImageUrl(
-					img,
-					thoughtSignature,
-					thoughtSignatureReasoningDetail
-				);
+				const imageObj = extractImageDataFromOpenRouterImageUrl(img);
 				if (imageObj) {
 					images.push(imageObj);
 					if (args.onImage) {

--- a/src/services/OpenRouter.service.ts
+++ b/src/services/OpenRouter.service.ts
@@ -17,6 +17,11 @@ export interface OpenRouterCompletionResult {
 	text: string;
 	thinking: string;
 	finishReason?: unknown;
+	images?: {
+		mimeType: string;
+		base64: string;
+		thoughtSignature?: string;
+	}[];
 }
 
 export interface OpenRouterCompletionArgs {
@@ -25,6 +30,7 @@ export interface OpenRouterCompletionArgs {
 	signal?: AbortSignal;
 	onText?: (args: { text: string; delta: string }) => void | Promise<void>;
 	onThinking?: (args: { thinking: string; delta: string }) => void | Promise<void>;
+	onImage?: (image: { mimeType: string; base64: string; thoughtSignature?: string }) => void | Promise<void>;
 }
 
 function getHeaders(apiKey: string): Record<string, string> {
@@ -170,11 +176,38 @@ function extractReasoningFromDetails(details: unknown): string {
 
 	return details
 		.map((detail) => {
-			const value = detail as { text?: string; summary?: string };
+			const value = detail as { type?: string; text?: string; summary?: string };
+			if (value.type === "reasoning.encrypted") return "";
 			return value.text || value.summary || "";
 		})
 		.filter(Boolean)
 		.join("");
+}
+
+function extractThoughtSignatureFromDetails(details: unknown): string | undefined {
+	if (!Array.isArray(details)) return undefined;
+
+	const encryptedDetail = details.find((detail) => (detail as { type?: string }).type === "reasoning.encrypted");
+	if (encryptedDetail) {
+		return (encryptedDetail as { data?: string }).data;
+	}
+
+	return undefined;
+}
+
+function extractImageDataFromOpenRouterImageUrl(img: any, thoughtSignature?: string) {
+	const url = img?.image_url?.url;
+	if (typeof url === "string" && url.startsWith("data:")) {
+		const match = url.match(/^data:([^;]+);base64,(.+)$/);
+		if (match) {
+			return {
+				mimeType: match[1],
+				base64: match[2],
+				thoughtSignature
+			};
+		}
+	}
+	return undefined;
 }
 
 function extractContentText(content: unknown): string {
@@ -326,7 +359,8 @@ export function buildOpenRouterRequest(args: {
 		}),
 		plugins: buildOpenRouterPlugins({ isInternetSearchEnabled: args.isInternetSearchEnabled }),
 		response_format: args.responseFormat,
-		provider: definition?.provider === "openrouter" ? { require_parameters: false } : undefined
+		provider: definition?.provider === "openrouter" ? { require_parameters: false } : undefined,
+		modalities: definition?.supportsImageOutput ? ["text", "image"] : undefined
 	};
 }
 
@@ -365,6 +399,7 @@ async function processOpenRouterJson(args: {
 	response: Response;
 	onText?: OpenRouterCompletionArgs["onText"];
 	onThinking?: OpenRouterCompletionArgs["onThinking"];
+	onImage?: OpenRouterCompletionArgs["onImage"];
 }): Promise<OpenRouterCompletionResult> {
 	const payload = (await args.response.json()) as OpenRouterResponse;
 	const choice = payload.choices?.[0] as
@@ -375,6 +410,7 @@ async function processOpenRouterJson(args: {
 					content?: unknown;
 					reasoning?: string | null;
 					reasoning_details?: unknown;
+					images?: unknown[];
 				};
 		  }
 		| undefined;
@@ -385,6 +421,15 @@ async function processOpenRouterJson(args: {
 
 	const text = extractContentText(choice?.message?.content);
 	const thinking = choice?.message?.reasoning || extractReasoningFromDetails(choice?.message?.reasoning_details);
+	const thoughtSignature = extractThoughtSignatureFromDetails(choice?.message?.reasoning_details);
+
+	const images: { mimeType: string; base64: string; thoughtSignature?: string }[] = [];
+	for (const img of choice?.message?.images || []) {
+		const extracted = extractImageDataFromOpenRouterImageUrl(img, thoughtSignature);
+		if (extracted) {
+			images.push(extracted);
+		}
+	}
 
 	if (text && args.onText) {
 		await args.onText({ text, delta: text });
@@ -394,10 +439,17 @@ async function processOpenRouterJson(args: {
 		await args.onThinking({ thinking, delta: thinking });
 	}
 
+	for (const image of images) {
+		if (args.onImage) {
+			await args.onImage(image);
+		}
+	}
+
 	return {
 		text,
 		thinking,
-		finishReason: choice?.finish_reason
+		finishReason: choice?.finish_reason,
+		images
 	};
 }
 
@@ -406,6 +458,7 @@ async function processOpenRouterStream(args: {
 	signal?: AbortSignal;
 	onText?: OpenRouterCompletionArgs["onText"];
 	onThinking?: OpenRouterCompletionArgs["onThinking"];
+	onImage?: OpenRouterCompletionArgs["onImage"];
 }): Promise<OpenRouterCompletionResult> {
 	if (!args.response.body) {
 		return { text: "", thinking: "" };
@@ -418,6 +471,8 @@ async function processOpenRouterStream(args: {
 	let text = "";
 	let thinking = "";
 	let finishReason: unknown;
+	let thoughtSignature: string | undefined;
+	const images: { mimeType: string; base64: string; thoughtSignature?: string }[] = [];
 
 	while (true) {
 		if (args.signal?.aborted) {
@@ -474,10 +529,26 @@ async function processOpenRouterStream(args: {
 				thinking += thinkingDelta;
 				await args.onThinking?.({ thinking, delta: thinkingDelta });
 			}
+
+			const extractedThoughtSignature = extractThoughtSignatureFromDetails(choice.delta?.reasoning_details);
+			if (extractedThoughtSignature) {
+				thoughtSignature = extractedThoughtSignature;
+			}
+
+			const deltaImages = choice.delta?.images || [];
+			for (const img of deltaImages) {
+				const imageObj = extractImageDataFromOpenRouterImageUrl(img, thoughtSignature);
+				if (imageObj) {
+					images.push(imageObj);
+					if (args.onImage) {
+						await args.onImage(imageObj);
+					}
+				}
+			}
 		}
 	}
 
-	return { text, thinking, finishReason };
+	return { text, thinking, finishReason, images };
 }
 
 export function getOpenRouterModelDefinition(model: string): ChatModelDefinition | undefined {

--- a/src/services/OpenRouter.service.ts
+++ b/src/services/OpenRouter.service.ts
@@ -181,6 +181,17 @@ function collapseContentParts(parts: ContentPart[]): string | ContentPart[] {
 	return parts;
 }
 
+function getOpenRouterHistoryRole(args: {
+	role: ReturnType<typeof normalizeMessageRole>;
+	contentParts: ContentPart[];
+}): ReturnType<typeof normalizeMessageRole> {
+	if (args.role === "assistant" && args.contentParts.some((part) => part.type === "image_url")) {
+		return "user";
+	}
+
+	return args.role;
+}
+
 function extractReasoningFromDetails(details: unknown): string {
 	if (!Array.isArray(details)) return "";
 
@@ -194,32 +205,9 @@ function extractReasoningFromDetails(details: unknown): string {
 		.join("");
 }
 
-const FALLBACK_GEMINI_REASONING_DETAIL_FORMAT = "google-gemini-v1";
-
 function stripReasoningPayload(detail: OpenRouterReasoningDetail): ReasoningDetailMetadata {
 	const { data, text, summary, ...metadata } = detail;
 	return metadata;
-}
-
-function buildTextReasoningDetail(part: {
-	text: string;
-	reasoningDetail?: ReasoningDetailMetadata;
-}): OpenRouterReasoningDetail {
-	const metadata = part.reasoningDetail;
-	const type = metadata?.type || "reasoning.text";
-	const detail: OpenRouterReasoningDetail = {
-		...metadata,
-		type,
-		format: metadata?.format ?? FALLBACK_GEMINI_REASONING_DETAIL_FORMAT
-	};
-
-	if (type === "reasoning.summary") {
-		detail.summary = part.text;
-	} else {
-		detail.text = part.text;
-	}
-
-	return detail;
 }
 
 export function extractEncryptedReasoningDetailFromDetails(details: unknown): OpenRouterReasoningDetail | undefined {
@@ -250,17 +238,6 @@ function getThoughtSignatureReasoningMetadata(
 		id: metadata.id,
 		format: metadata.format,
 		index: metadata.index
-	};
-}
-
-function buildEncryptedReasoningDetail(data: string, metadata?: ReasoningDetailMetadata): OpenRouterReasoningDetail {
-	return {
-		...metadata,
-		type: "reasoning.encrypted",
-		data,
-		id: metadata?.id,
-		format: metadata?.format ?? FALLBACK_GEMINI_REASONING_DETAIL_FORMAT,
-		index: metadata?.index
 	};
 }
 
@@ -394,39 +371,10 @@ export async function convertGeminiHistoryToOpenRouterMessages(history: Content[
 	for (const item of history || []) {
 		const role = normalizeMessageRole(item?.role);
 		const contentParts: ContentPart[] = [];
-		const reasoningDetails: OpenRouterReasoningDetail[] = [];
 
 		for (const part of item?.parts || []) {
-			const thoughtSignature = (part as { thoughtSignature?: unknown })?.thoughtSignature;
-			if (role === "assistant" && (part as { thought?: unknown })?.thought === true) {
-				if (part?.text) {
-					reasoningDetails.push(
-						buildTextReasoningDetail({
-							text: String(part.text),
-							reasoningDetail: (part as { reasoningDetail?: ReasoningDetailMetadata }).reasoningDetail
-						})
-					);
-				}
+			if ((part as { thought?: unknown })?.thought === true) {
 				continue;
-			}
-
-			if (role === "assistant" && typeof thoughtSignature === "string" && thoughtSignature.length > 0) {
-				const isDuplicate = reasoningDetails.some(
-					(detail) => detail.type === "reasoning.encrypted" && detail.data === thoughtSignature
-				);
-				if (!isDuplicate) {
-					reasoningDetails.push(
-						buildEncryptedReasoningDetail(
-							thoughtSignature,
-							(part as { reasoningDetail?: ReasoningDetailMetadata }).reasoningDetail ??
-								(
-									part as {
-										thoughtSignatureReasoningDetail?: GeneratedImage["thoughtSignatureReasoningDetail"];
-									}
-								).thoughtSignatureReasoningDetail
-						)
-					);
-				}
 			}
 
 			if (part?.text) {
@@ -444,14 +392,12 @@ export async function convertGeminiHistoryToOpenRouterMessages(history: Content[
 			}
 		}
 
-		if (contentParts.length === 0 && reasoningDetails.length === 0) continue;
+		if (contentParts.length === 0) continue;
+		const requestRole = getOpenRouterHistoryRole({ role, contentParts });
 		const message: OpenRouterMessage = {
-			role,
+			role: requestRole,
 			content: contentParts.length > 0 ? collapseContentParts(contentParts) : ""
 		};
-		if (role === "assistant" && reasoningDetails.length > 0) {
-			message.reasoning_details = reasoningDetails;
-		}
 		messages.push(message);
 	}
 

--- a/src/services/OpenRouter.service.ts
+++ b/src/services/OpenRouter.service.ts
@@ -6,11 +6,13 @@ import type {
 	ImageContentPart,
 	Message as OpenRouterMessage,
 	Plugin,
+	ReasoningDetail as OpenRouterReasoningDetail,
 	Request as OpenRouterRequest,
 	Response as OpenRouterResponse,
 	StreamingChoice
 } from "../types/OpenRouterTypes";
 import { getChatModelDefinition, modelSupportsTemperature, type ChatModelDefinition } from "../types/Models";
+import type { GeneratedImage } from "../types/Message";
 import * as helpers from "../utils/helpers";
 
 export interface OpenRouterCompletionResult {
@@ -21,6 +23,7 @@ export interface OpenRouterCompletionResult {
 		mimeType: string;
 		base64: string;
 		thoughtSignature?: string;
+		thoughtSignatureReasoningDetail?: GeneratedImage["thoughtSignatureReasoningDetail"];
 	}[];
 }
 
@@ -30,7 +33,12 @@ export interface OpenRouterCompletionArgs {
 	signal?: AbortSignal;
 	onText?: (args: { text: string; delta: string }) => void | Promise<void>;
 	onThinking?: (args: { thinking: string; delta: string }) => void | Promise<void>;
-	onImage?: (image: { mimeType: string; base64: string; thoughtSignature?: string }) => void | Promise<void>;
+	onImage?: (image: {
+		mimeType: string;
+		base64: string;
+		thoughtSignature?: string;
+		thoughtSignatureReasoningDetail?: GeneratedImage["thoughtSignatureReasoningDetail"];
+	}) => void | Promise<void>;
 }
 
 function getHeaders(apiKey: string): Record<string, string> {
@@ -184,18 +192,58 @@ function extractReasoningFromDetails(details: unknown): string {
 		.join("");
 }
 
-export function extractThoughtSignatureFromDetails(details: unknown): string | undefined {
+const FALLBACK_GEMINI_REASONING_DETAIL_FORMAT = "google-gemini-v1";
+
+export function extractEncryptedReasoningDetailFromDetails(details: unknown): OpenRouterReasoningDetail | undefined {
 	if (!Array.isArray(details)) return undefined;
 
 	const encryptedDetail = details.find((detail) => (detail as { type?: string }).type === "reasoning.encrypted");
-	if (encryptedDetail) {
-		return (encryptedDetail as { data?: string }).data;
+	const data = (encryptedDetail as { data?: unknown } | undefined)?.data;
+	if (encryptedDetail && typeof data === "string" && data.length > 0) {
+		return { ...(encryptedDetail as OpenRouterReasoningDetail), type: "reasoning.encrypted", data };
 	}
 
 	return undefined;
 }
 
-export function extractImageDataFromOpenRouterImageUrl(img: any, thoughtSignature?: string) {
+export function extractThoughtSignatureFromDetails(details: unknown): string | undefined {
+	return extractEncryptedReasoningDetailFromDetails(details)?.data;
+}
+
+function getThoughtSignatureReasoningMetadata(
+	detail: OpenRouterReasoningDetail | undefined
+): GeneratedImage["thoughtSignatureReasoningDetail"] {
+	if (!detail || detail.type !== "reasoning.encrypted") return undefined;
+	const { data, ...metadata } = detail;
+
+	return {
+		...metadata,
+		type: "reasoning.encrypted",
+		id: metadata.id,
+		format: metadata.format,
+		index: metadata.index
+	};
+}
+
+function buildEncryptedReasoningDetail(
+	data: string,
+	metadata?: GeneratedImage["thoughtSignatureReasoningDetail"]
+): OpenRouterReasoningDetail {
+	return {
+		...metadata,
+		type: "reasoning.encrypted",
+		data,
+		id: metadata?.id,
+		format: metadata?.format ?? FALLBACK_GEMINI_REASONING_DETAIL_FORMAT,
+		index: metadata?.index
+	};
+}
+
+export function extractImageDataFromOpenRouterImageUrl(
+	img: any,
+	thoughtSignature?: string,
+	thoughtSignatureReasoningDetail?: GeneratedImage["thoughtSignatureReasoningDetail"]
+) {
 	const url = img?.image_url?.url;
 	if (typeof url === "string" && url.startsWith("data:")) {
 		const match = url.match(/^data:([^;]+);base64,(.+)$/);
@@ -203,7 +251,8 @@ export function extractImageDataFromOpenRouterImageUrl(img: any, thoughtSignatur
 			return {
 				mimeType: match[1],
 				base64: match[2],
-				thoughtSignature
+				thoughtSignature,
+				thoughtSignatureReasoningDetail
 			};
 		}
 	}
@@ -233,8 +282,23 @@ export async function convertGeminiHistoryToOpenRouterMessages(history: Content[
 	for (const item of history || []) {
 		const role = normalizeMessageRole(item?.role);
 		const contentParts: ContentPart[] = [];
+		const reasoningDetails: OpenRouterReasoningDetail[] = [];
 
 		for (const part of item?.parts || []) {
+			const thoughtSignature = (part as { thoughtSignature?: unknown })?.thoughtSignature;
+			if (role === "assistant" && typeof thoughtSignature === "string" && thoughtSignature.length > 0) {
+				reasoningDetails.push(
+					buildEncryptedReasoningDetail(
+						thoughtSignature,
+						(
+							part as {
+								thoughtSignatureReasoningDetail?: GeneratedImage["thoughtSignatureReasoningDetail"];
+							}
+						).thoughtSignatureReasoningDetail
+					)
+				);
+			}
+
 			if (part?.text) {
 				appendTextPart(contentParts, String(part.text));
 				continue;
@@ -251,7 +315,11 @@ export async function convertGeminiHistoryToOpenRouterMessages(history: Content[
 		}
 
 		if (contentParts.length === 0) continue;
-		messages.push({ role, content: collapseContentParts(contentParts) });
+		const message: OpenRouterMessage = { role, content: collapseContentParts(contentParts) };
+		if (role === "assistant" && reasoningDetails.length > 0) {
+			message.reasoning_details = reasoningDetails;
+		}
+		messages.push(message);
 	}
 
 	return messages;
@@ -421,11 +489,17 @@ async function processOpenRouterJson(args: {
 
 	const text = extractContentText(choice?.message?.content);
 	const thinking = choice?.message?.reasoning || extractReasoningFromDetails(choice?.message?.reasoning_details);
-	const thoughtSignature = extractThoughtSignatureFromDetails(choice?.message?.reasoning_details);
+	const encryptedReasoningDetail = extractEncryptedReasoningDetailFromDetails(choice?.message?.reasoning_details);
+	const thoughtSignature = encryptedReasoningDetail?.data;
+	const thoughtSignatureReasoningDetail = getThoughtSignatureReasoningMetadata(encryptedReasoningDetail);
 
-	const images: { mimeType: string; base64: string; thoughtSignature?: string }[] = [];
+	const images: OpenRouterCompletionResult["images"] = [];
 	for (const img of choice?.message?.images || []) {
-		const extracted = extractImageDataFromOpenRouterImageUrl(img, thoughtSignature);
+		const extracted = extractImageDataFromOpenRouterImageUrl(
+			img,
+			thoughtSignature,
+			thoughtSignatureReasoningDetail
+		);
 		if (extracted) {
 			images.push(extracted);
 		}
@@ -472,7 +546,8 @@ async function processOpenRouterStream(args: {
 	let thinking = "";
 	let finishReason: unknown;
 	let thoughtSignature: string | undefined;
-	const images: { mimeType: string; base64: string; thoughtSignature?: string }[] = [];
+	let thoughtSignatureReasoningDetail: GeneratedImage["thoughtSignatureReasoningDetail"];
+	const images: OpenRouterCompletionResult["images"] = [];
 
 	while (true) {
 		if (args.signal?.aborted) {
@@ -530,14 +605,21 @@ async function processOpenRouterStream(args: {
 				await args.onThinking?.({ thinking, delta: thinkingDelta });
 			}
 
-			const extractedThoughtSignature = extractThoughtSignatureFromDetails(choice.delta?.reasoning_details);
-			if (extractedThoughtSignature) {
-				thoughtSignature = extractedThoughtSignature;
+			const encryptedReasoningDetail = extractEncryptedReasoningDetailFromDetails(
+				choice.delta?.reasoning_details
+			);
+			if (encryptedReasoningDetail) {
+				thoughtSignature = encryptedReasoningDetail.data;
+				thoughtSignatureReasoningDetail = getThoughtSignatureReasoningMetadata(encryptedReasoningDetail);
 			}
 
 			const deltaImages = choice.delta?.images || [];
 			for (const img of deltaImages) {
-				const imageObj = extractImageDataFromOpenRouterImageUrl(img, thoughtSignature);
+				const imageObj = extractImageDataFromOpenRouterImageUrl(
+					img,
+					thoughtSignature,
+					thoughtSignatureReasoningDetail
+				);
 				if (imageObj) {
 					images.push(imageObj);
 					if (args.onImage) {

--- a/src/services/PremiumEndpointResponseProcessor.service.ts
+++ b/src/services/PremiumEndpointResponseProcessor.service.ts
@@ -126,7 +126,6 @@ async function applyFallbackDelta(args: {
 		text: string;
 		thinking: string;
 		images: GeneratedImage[];
-		textSignature?: string;
 		thoughtSignature?: string;
 		thoughtSignatureReasoningDetail?: GeneratedImage["thoughtSignatureReasoningDetail"];
 	};
@@ -157,7 +156,6 @@ async function applyFallbackDelta(args: {
 	if (encryptedReasoningDetail) {
 		const { data, ...metadata } = encryptedReasoningDetail;
 		state.thoughtSignature = data;
-		state.textSignature = data;
 		state.thoughtSignatureReasoningDetail = {
 			...metadata,
 			type: "reasoning.encrypted",
@@ -178,10 +176,7 @@ async function applyFallbackDelta(args: {
 			const genImage: GeneratedImage = {
 				mimeType: imageObj.mimeType,
 				base64: imageObj.base64,
-				thoughtSignature:
-					imageObj.thoughtSignature ??
-					(process.useSkipThoughtSignature ? process.skipThoughtSignatureValidator : undefined),
-				thoughtSignatureReasoningDetail: imageObj.thoughtSignatureReasoningDetail
+				thoughtSignature: process.useSkipThoughtSignature ? process.skipThoughtSignatureValidator : undefined
 			};
 			state.images.push(genImage);
 			await process.callbacks?.onImage?.(genImage);

--- a/src/services/PremiumEndpointResponseProcessor.service.ts
+++ b/src/services/PremiumEndpointResponseProcessor.service.ts
@@ -1,6 +1,6 @@
 import type { GenerateContentResponse } from "@google/genai";
 import type { Response as OpenRouterResponse, StreamingChoice } from "../types/OpenRouterTypes";
-import type { GeneratedImage } from "../types/Message";
+import type { GeneratedImage, Message } from "../types/Message";
 import type {
 	PremiumEndpointProcessArgs,
 	PremiumEndpointProcessResult
@@ -30,18 +30,32 @@ function getGroundingRenderedContent(payload: any): string {
 
 function pushInlineImage(args: {
 	images: GeneratedImage[];
+	responseParts: Message["parts"];
 	part: any;
 	useSkipThoughtSignature: boolean;
 	skipThoughtSignatureValidator: string;
 }): void {
-	const { images, part, useSkipThoughtSignature, skipThoughtSignatureValidator } = args;
+	const { images, responseParts, part, useSkipThoughtSignature, skipThoughtSignatureValidator } = args;
+	const thoughtSignature =
+		part.thoughtSignature ?? (useSkipThoughtSignature ? skipThoughtSignatureValidator : undefined);
+
+	if (part.thought) {
+		responseParts.push({
+			inlineData: {
+				data: part.inlineData?.data || "",
+				mimeType: part.inlineData?.mimeType || "image/png"
+			},
+			thoughtSignature,
+			thought: true
+		});
+		return;
+	}
 
 	images.push({
 		mimeType: part.inlineData?.mimeType || "image/png",
 		base64: part.inlineData?.data || "",
-		thoughtSignature:
-			part.thoughtSignature ?? (useSkipThoughtSignature ? skipThoughtSignatureValidator : undefined),
-		thought: part.thought
+		thoughtSignature,
+		thought: undefined
 	});
 }
 
@@ -55,6 +69,7 @@ async function applyGeminiPayload(args: {
 		finishReason?: unknown;
 		groundingContent: string;
 		images: GeneratedImage[];
+		responseParts: Message["parts"];
 	};
 }): Promise<void> {
 	const { payload, process, state } = args;
@@ -83,13 +98,17 @@ async function applyGeminiPayload(args: {
 			state.text += delta;
 			await process.callbacks?.onText?.({ delta, text: state.text });
 		} else if (part?.inlineData) {
+			const imageCountBefore = state.images.length;
 			pushInlineImage({
 				images: state.images,
+				responseParts: state.responseParts,
 				part,
 				useSkipThoughtSignature: process.useSkipThoughtSignature,
 				skipThoughtSignatureValidator: process.skipThoughtSignatureValidator
 			});
-			process.callbacks?.onImage?.(state.images[state.images.length - 1]);
+			if (state.images.length > imageCountBefore) {
+				process.callbacks?.onImage?.(state.images[state.images.length - 1]);
+			}
 		}
 	}
 
@@ -181,6 +200,7 @@ export async function processPremiumEndpointSse(args: {
 			thinking: "",
 			groundingContent: "",
 			images: [],
+			responseParts: [],
 			wasAborted: false,
 			wasFallbackMode: false
 		};
@@ -199,11 +219,13 @@ export async function processPremiumEndpointSse(args: {
 		finishReason?: unknown;
 		groundingContent: string;
 		images: GeneratedImage[];
+		responseParts: Message["parts"];
 	} = {
 		text: "",
 		thinking: "",
 		groundingContent: "",
-		images: []
+		images: [],
+		responseParts: []
 	};
 
 	let buffer = "";
@@ -268,6 +290,7 @@ export async function processPremiumEndpointSse(args: {
 					finishReason: state.finishReason,
 					groundingContent: state.groundingContent,
 					images: state.images,
+					responseParts: state.responseParts,
 					wasAborted,
 					wasFallbackMode
 				};
@@ -303,6 +326,7 @@ export async function processPremiumEndpointSse(args: {
 				state.finishReason = undefined;
 				state.groundingContent = "";
 				state.images = [];
+				state.responseParts = [];
 				process.callbacks?.onFallbackStart?.(fallbackMeta);
 				continue;
 			}
@@ -328,6 +352,7 @@ export async function processPremiumEndpointSse(args: {
 		finishReason: state.finishReason,
 		groundingContent: state.groundingContent,
 		images: state.images,
+		responseParts: state.responseParts,
 		wasAborted,
 		wasFallbackMode
 	};

--- a/src/services/PremiumEndpointResponseProcessor.service.ts
+++ b/src/services/PremiumEndpointResponseProcessor.service.ts
@@ -126,6 +126,7 @@ async function applyFallbackDelta(args: {
 		text: string;
 		thinking: string;
 		images: GeneratedImage[];
+		textSignature?: string;
 		thoughtSignature?: string;
 		thoughtSignatureReasoningDetail?: GeneratedImage["thoughtSignatureReasoningDetail"];
 	};
@@ -156,6 +157,7 @@ async function applyFallbackDelta(args: {
 	if (encryptedReasoningDetail) {
 		const { data, ...metadata } = encryptedReasoningDetail;
 		state.thoughtSignature = data;
+		state.textSignature = data;
 		state.thoughtSignatureReasoningDetail = {
 			...metadata,
 			type: "reasoning.encrypted",

--- a/src/services/PremiumEndpointResponseProcessor.service.ts
+++ b/src/services/PremiumEndpointResponseProcessor.service.ts
@@ -5,6 +5,7 @@ import type {
 	PremiumEndpointProcessArgs,
 	PremiumEndpointProcessResult
 } from "../types/PremiumEndpointResponseProcessor";
+import { extractImageDataFromOpenRouterImageUrl, extractThoughtSignatureFromDetails } from "./OpenRouter.service";
 
 function throwAbortError(): never {
 	const err = new Error("Aborted");
@@ -102,6 +103,8 @@ async function applyFallbackDelta(args: {
 	state: {
 		text: string;
 		thinking: string;
+		images: GeneratedImage[];
+		thoughtSignature?: string;
 	};
 }): Promise<void> {
 	const { data, process, state } = args;
@@ -124,6 +127,27 @@ async function applyFallbackDelta(args: {
 		const delta = String(deltaObj.reasoning);
 		state.thinking += delta;
 		await process.callbacks?.onThinking?.({ delta, thinking: state.thinking });
+	}
+
+	const extractedThoughtSignature = extractThoughtSignatureFromDetails(deltaObj?.reasoning_details);
+	if (extractedThoughtSignature) {
+		state.thoughtSignature = extractedThoughtSignature;
+	}
+
+	const deltaImages = deltaObj?.images || [];
+	for (const img of deltaImages) {
+		const imageObj = extractImageDataFromOpenRouterImageUrl(img, state.thoughtSignature);
+		if (imageObj) {
+			const genImage: GeneratedImage = {
+				mimeType: imageObj.mimeType,
+				base64: imageObj.base64,
+				thoughtSignature:
+					imageObj.thoughtSignature ??
+					(process.useSkipThoughtSignature ? process.skipThoughtSignatureValidator : undefined)
+			};
+			state.images.push(genImage);
+			await process.callbacks?.onImage?.(genImage);
+		}
 	}
 }
 
@@ -153,6 +177,7 @@ export async function processPremiumEndpointSse(args: {
 		thinking: string;
 		requestId?: string;
 		textSignature?: string;
+		thoughtSignature?: string;
 		finishReason?: unknown;
 		groundingContent: string;
 		images: GeneratedImage[];

--- a/src/services/PremiumEndpointResponseProcessor.service.ts
+++ b/src/services/PremiumEndpointResponseProcessor.service.ts
@@ -5,7 +5,10 @@ import type {
 	PremiumEndpointProcessArgs,
 	PremiumEndpointProcessResult
 } from "../types/PremiumEndpointResponseProcessor";
-import { extractImageDataFromOpenRouterImageUrl, extractThoughtSignatureFromDetails } from "./OpenRouter.service";
+import {
+	extractEncryptedReasoningDetailFromDetails,
+	extractImageDataFromOpenRouterImageUrl
+} from "./OpenRouter.service";
 
 function throwAbortError(): never {
 	const err = new Error("Aborted");
@@ -105,6 +108,7 @@ async function applyFallbackDelta(args: {
 		thinking: string;
 		images: GeneratedImage[];
 		thoughtSignature?: string;
+		thoughtSignatureReasoningDetail?: GeneratedImage["thoughtSignatureReasoningDetail"];
 	};
 }): Promise<void> {
 	const { data, process, state } = args;
@@ -129,21 +133,34 @@ async function applyFallbackDelta(args: {
 		await process.callbacks?.onThinking?.({ delta, thinking: state.thinking });
 	}
 
-	const extractedThoughtSignature = extractThoughtSignatureFromDetails(deltaObj?.reasoning_details);
-	if (extractedThoughtSignature) {
-		state.thoughtSignature = extractedThoughtSignature;
+	const encryptedReasoningDetail = extractEncryptedReasoningDetailFromDetails(deltaObj?.reasoning_details);
+	if (encryptedReasoningDetail) {
+		const { data, ...metadata } = encryptedReasoningDetail;
+		state.thoughtSignature = data;
+		state.thoughtSignatureReasoningDetail = {
+			...metadata,
+			type: "reasoning.encrypted",
+			id: metadata.id,
+			format: metadata.format,
+			index: metadata.index
+		};
 	}
 
 	const deltaImages = deltaObj?.images || [];
 	for (const img of deltaImages) {
-		const imageObj = extractImageDataFromOpenRouterImageUrl(img, state.thoughtSignature);
+		const imageObj = extractImageDataFromOpenRouterImageUrl(
+			img,
+			state.thoughtSignature,
+			state.thoughtSignatureReasoningDetail
+		);
 		if (imageObj) {
 			const genImage: GeneratedImage = {
 				mimeType: imageObj.mimeType,
 				base64: imageObj.base64,
 				thoughtSignature:
 					imageObj.thoughtSignature ??
-					(process.useSkipThoughtSignature ? process.skipThoughtSignatureValidator : undefined)
+					(process.useSkipThoughtSignature ? process.skipThoughtSignatureValidator : undefined),
+				thoughtSignatureReasoningDetail: imageObj.thoughtSignatureReasoningDetail
 			};
 			state.images.push(genImage);
 			await process.callbacks?.onImage?.(genImage);
@@ -178,6 +195,7 @@ export async function processPremiumEndpointSse(args: {
 		requestId?: string;
 		textSignature?: string;
 		thoughtSignature?: string;
+		thoughtSignatureReasoningDetail?: GeneratedImage["thoughtSignatureReasoningDetail"];
 		finishReason?: unknown;
 		groundingContent: string;
 		images: GeneratedImage[];

--- a/src/services/RpgGroupChat.ts
+++ b/src/services/RpgGroupChat.ts
@@ -1973,14 +1973,12 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 
 			if (text.trim().length > 0) {
 				const partObj: any = { text: maybePrefixSpeaker(text, speaker) };
-				const canUseStoredSignature =
-					dbMessage.role === "model" && !isOpenRouterModel(dbMessage.originModel || "");
+				const isModelMessage = dbMessage.role === "model";
+				const canUseStoredSignature = isModelMessage && !isOpenRouterModel(dbMessage.originModel || "");
 				const resolvedSignature = canUseStoredSignature ? await resolveThoughtSignature(part) : undefined;
 				const ts =
 					resolvedSignature ||
-					(canUseStoredSignature && shouldEnforceThoughtSignatures
-						? SKIP_THOUGHT_SIGNATURE_VALIDATOR
-						: undefined);
+					(isModelMessage && shouldEnforceThoughtSignatures ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined);
 				if (ts && !hasThoughtSignature) {
 					partObj.thoughtSignature = ts;
 					hasThoughtSignature = true;

--- a/src/services/RpgGroupChat.ts
+++ b/src/services/RpgGroupChat.ts
@@ -2001,6 +2001,9 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
 			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
 			suppressThoughtSignature: hasThoughtSignature,
+			// Mirror the single-chat builder: OpenRouter image signatures are
+			// incompatible with Gemini, so disallow reuse (see the
+			// SKIP_THOUGHT_SIGNATURE_VALIDATOR doc in Message.service.ts).
 			allowStoredThoughtSignatures: !isOpenRouterModel(dbMessage.originModel || "")
 		});
 		if (imageParts.length > 0) {

--- a/src/services/RpgGroupChat.ts
+++ b/src/services/RpgGroupChat.ts
@@ -66,7 +66,6 @@ import {
 	processGeneratedImagesToParts,
 	extractTextAndThinkingFromResponse
 } from "../utils/chatHistoryBuilder";
-import { resolveThoughtSignature } from "../utils/blobResolver";
 
 import { throwAbortError } from "../utils/abort";
 import { dispatchAppEvent } from "../events";
@@ -738,9 +737,7 @@ async function executeParticipantTurn(args: {
 	const { history } = await constructGeminiChatHistoryForGroupChatRpg(chatSnapshot, {
 		speakerNameById: ctx.speakerNameById,
 		userName: ctx.userName,
-		enforceThoughtSignatures: ctx.shouldEnforceThoughtSignaturesInHistory,
-		includeThoughtParts: !ctx.isPremiumEndpointPreferred,
-		includeOpenRouterReasoningDetails: !ctx.isPremiumEndpointPreferred && isOpenRouterModel(ctx.settings.model)
+		enforceThoughtSignatures: ctx.shouldEnforceThoughtSignaturesInHistory
 	});
 
 	const useIndependentAction = shouldTriggerIndependentAction(meta.independence);
@@ -1231,9 +1228,7 @@ async function handleNarratorBeforeFirst(ctx: RpgContext): Promise<void> {
 		const { history: beforeHistory } = await constructGeminiChatHistoryForGroupChatRpg(ctx.workingChat, {
 			speakerNameById: ctx.speakerNameById,
 			userName: ctx.userName,
-			enforceThoughtSignatures: false,
-			includeThoughtParts: !ctx.isPremiumEndpointPreferred,
-			includeOpenRouterReasoningDetails: !ctx.isPremiumEndpointPreferred && isOpenRouterModel(ctx.settings.model)
+			enforceThoughtSignatures: false
 		});
 
 		const before = await generateNarratorMessage({
@@ -1293,9 +1288,7 @@ async function handleNarratorInterjection(ctx: RpgContext): Promise<void> {
 	const { history: interjectionHistory } = await constructGeminiChatHistoryForGroupChatRpg(chatForInterjection, {
 		speakerNameById: ctx.speakerNameById,
 		userName: ctx.userName,
-		enforceThoughtSignatures: false,
-		includeThoughtParts: !ctx.isPremiumEndpointPreferred,
-		includeOpenRouterReasoningDetails: !ctx.isPremiumEndpointPreferred && isOpenRouterModel(ctx.settings.model)
+		enforceThoughtSignatures: false
 	});
 
 	const interjection = await generateNarratorMessage({
@@ -1362,9 +1355,7 @@ async function handleNarratorAfterRound(ctx: RpgContext): Promise<void> {
 		const { history: afterHistory } = await constructGeminiChatHistoryForGroupChatRpg(chatForAfter, {
 			speakerNameById: ctx.speakerNameById,
 			userName: ctx.userName,
-			enforceThoughtSignatures: false,
-			includeThoughtParts: !ctx.isPremiumEndpointPreferred,
-			includeOpenRouterReasoningDetails: !ctx.isPremiumEndpointPreferred && isOpenRouterModel(ctx.settings.model)
+			enforceThoughtSignatures: false
 		});
 
 		const after = await generateNarratorMessageResilient({
@@ -1952,14 +1943,11 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 		speakerNameById: Map<string, string>;
 		userName: string;
 		enforceThoughtSignatures?: boolean;
-		includeThoughtParts?: boolean;
-		includeOpenRouterReasoningDetails?: boolean;
 	}
 ): Promise<{ history: Content[]; pinnedHistoryIndices: number[] }> {
 	const history: Content[] = [];
 	const pinnedHistoryIndices: number[] = [];
 	const shouldEnforceThoughtSignatures = args.enforceThoughtSignatures === true;
-	const shouldIncludeThoughtParts = args.includeThoughtParts === true;
 
 	const speakerNameForMessage = (m: Message): string => {
 		if (m.role === "user") return (args.userName || "User").toString();
@@ -1983,22 +1971,13 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 			const text = (part.text || "").toString();
 			const attachments = part.attachments || [];
 
-			if (part.thought && !shouldIncludeThoughtParts) {
+			if (part.thought) {
 				continue;
 			}
 
-			if (text.trim().length > 0 || part.thoughtSignature || part._thoughtSignatureRef) {
-				const resolvedThoughtSignature = await resolveThoughtSignature(part);
-				const partObj: any = { text: part.thought ? text : maybePrefixSpeaker(text, speaker) };
-				if (part.thought) {
-					partObj.thought = true;
-				}
-				if (args.includeOpenRouterReasoningDetails === true && part.reasoningDetail) {
-					partObj.reasoningDetail = part.reasoningDetail;
-				}
-				const ts =
-					resolvedThoughtSignature ??
-					(!part.thought && shouldEnforceThoughtSignatures ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined);
+			if (text.trim().length > 0) {
+				const partObj: any = { text: maybePrefixSpeaker(text, speaker) };
+				const ts = shouldEnforceThoughtSignatures ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined;
 				if (ts && !hasThoughtSignature) {
 					partObj.thoughtSignature = ts;
 					hasThoughtSignature = true;
@@ -2020,7 +1999,6 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 			shouldProcess: !!dbMessage.generatedImages && index === lastImageIndex,
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
 			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
-			includeOpenRouterReasoningDetails: args.includeOpenRouterReasoningDetails === true,
 			suppressThoughtSignature: hasThoughtSignature
 		});
 		if (imageParts.length > 0) {

--- a/src/services/RpgGroupChat.ts
+++ b/src/services/RpgGroupChat.ts
@@ -1973,10 +1973,12 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 
 			if (text.trim().length > 0) {
 				const partObj: any = { text: maybePrefixSpeaker(text, speaker) };
-				const resolvedSignature = dbMessage.role === "model" ? await resolveThoughtSignature(part) : undefined;
+				const canUseStoredSignature =
+					dbMessage.role === "model" && !isOpenRouterModel(dbMessage.originModel || "");
+				const resolvedSignature = canUseStoredSignature ? await resolveThoughtSignature(part) : undefined;
 				const ts =
 					resolvedSignature ||
-					(dbMessage.role === "model" && shouldEnforceThoughtSignatures
+					(canUseStoredSignature && shouldEnforceThoughtSignatures
 						? SKIP_THOUGHT_SIGNATURE_VALIDATOR
 						: undefined);
 				if (ts && !hasThoughtSignature) {

--- a/src/services/RpgGroupChat.ts
+++ b/src/services/RpgGroupChat.ts
@@ -60,8 +60,6 @@ import {
 } from "../utils/chatHistory";
 
 import {
-	findLastGeneratedImageIndex,
-	findLastAttachmentIndex,
 	processAttachmentsToParts,
 	processGeneratedImagesToParts,
 	extractTextAndThinkingFromResponse
@@ -1956,9 +1954,6 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 		return args.speakerNameById.get(id) ?? "Unknown";
 	};
 
-	const lastImageIndex = findLastGeneratedImageIndex(currentChat.content);
-	const lastAttachmentIndex = findLastAttachmentIndex(currentChat.content);
-
 	for (let index = 0; index < currentChat.content.length; index++) {
 		const dbMessage = currentChat.content[index];
 		if (dbMessage.hidden) continue;
@@ -1987,7 +1982,7 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 
 			const attachmentParts = await processAttachmentsToParts({
 				attachments,
-				shouldProcess: attachments.length > 0 && index === lastAttachmentIndex
+				shouldProcess: attachments.length > 0
 			});
 			aggregatedParts.push(...attachmentParts);
 		}
@@ -1996,7 +1991,7 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 
 		const imageParts = await processGeneratedImagesToParts({
 			images: dbMessage.generatedImages,
-			shouldProcess: !!dbMessage.generatedImages && index === lastImageIndex,
+			shouldProcess: !!dbMessage.generatedImages,
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
 			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
 			suppressThoughtSignature: hasThoughtSignature

--- a/src/services/RpgGroupChat.ts
+++ b/src/services/RpgGroupChat.ts
@@ -2000,7 +2000,8 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 			shouldProcess: !!dbMessage.generatedImages,
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
 			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
-			suppressThoughtSignature: hasThoughtSignature
+			suppressThoughtSignature: hasThoughtSignature,
+			allowStoredThoughtSignatures: !isOpenRouterModel(dbMessage.originModel || "")
 		});
 		if (imageParts.length > 0) {
 			genAiMessage.parts?.push(...imageParts);

--- a/src/services/RpgGroupChat.ts
+++ b/src/services/RpgGroupChat.ts
@@ -13,6 +13,7 @@ import type { Message } from "../types/Message";
 import type { DbChat } from "../types/Chat";
 import {
 	ChatModel,
+	getPremiumEndpointChatModel,
 	getPreferredNarratorLocalModel,
 	isOpenRouterModel,
 	modelSupportsTemperature,
@@ -1468,7 +1469,7 @@ async function generateNarratorMessage(args: NarratorGenerationArgs): Promise<Na
 	).trim();
 
 	const narratorModel = isPremiumEndpointPreferred
-		? ChatModel.FLASH
+		? (getPremiumEndpointChatModel(ChatModel.FLASH) ?? ChatModel.FLASH)
 		: getPreferredNarratorLocalModel({
 				geminiApiKey: settings.geminiApiKey || settings.apiKey,
 				openRouterApiKey: settings.openRouterApiKey

--- a/src/services/RpgGroupChat.ts
+++ b/src/services/RpgGroupChat.ts
@@ -738,7 +738,8 @@ async function executeParticipantTurn(args: {
 	const { history } = await constructGeminiChatHistoryForGroupChatRpg(chatSnapshot, {
 		speakerNameById: ctx.speakerNameById,
 		userName: ctx.userName,
-		enforceThoughtSignatures: ctx.shouldEnforceThoughtSignaturesInHistory
+		enforceThoughtSignatures: ctx.shouldEnforceThoughtSignaturesInHistory,
+		includeThoughtParts: !ctx.isPremiumEndpointPreferred && !isOpenRouterModel(ctx.settings.model)
 	});
 
 	const useIndependentAction = shouldTriggerIndependentAction(meta.independence);
@@ -1229,7 +1230,8 @@ async function handleNarratorBeforeFirst(ctx: RpgContext): Promise<void> {
 		const { history: beforeHistory } = await constructGeminiChatHistoryForGroupChatRpg(ctx.workingChat, {
 			speakerNameById: ctx.speakerNameById,
 			userName: ctx.userName,
-			enforceThoughtSignatures: false
+			enforceThoughtSignatures: false,
+			includeThoughtParts: !ctx.isPremiumEndpointPreferred && !isOpenRouterModel(ctx.settings.model)
 		});
 
 		const before = await generateNarratorMessage({
@@ -1289,7 +1291,8 @@ async function handleNarratorInterjection(ctx: RpgContext): Promise<void> {
 	const { history: interjectionHistory } = await constructGeminiChatHistoryForGroupChatRpg(chatForInterjection, {
 		speakerNameById: ctx.speakerNameById,
 		userName: ctx.userName,
-		enforceThoughtSignatures: false
+		enforceThoughtSignatures: false,
+		includeThoughtParts: !ctx.isPremiumEndpointPreferred && !isOpenRouterModel(ctx.settings.model)
 	});
 
 	const interjection = await generateNarratorMessage({
@@ -1356,7 +1359,8 @@ async function handleNarratorAfterRound(ctx: RpgContext): Promise<void> {
 		const { history: afterHistory } = await constructGeminiChatHistoryForGroupChatRpg(chatForAfter, {
 			speakerNameById: ctx.speakerNameById,
 			userName: ctx.userName,
-			enforceThoughtSignatures: false
+			enforceThoughtSignatures: false,
+			includeThoughtParts: !ctx.isPremiumEndpointPreferred && !isOpenRouterModel(ctx.settings.model)
 		});
 
 		const after = await generateNarratorMessageResilient({
@@ -1944,11 +1948,13 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 		speakerNameById: Map<string, string>;
 		userName: string;
 		enforceThoughtSignatures?: boolean;
+		includeThoughtParts?: boolean;
 	}
 ): Promise<{ history: Content[]; pinnedHistoryIndices: number[] }> {
 	const history: Content[] = [];
 	const pinnedHistoryIndices: number[] = [];
 	const shouldEnforceThoughtSignatures = args.enforceThoughtSignatures === true;
+	const shouldIncludeThoughtParts = args.includeThoughtParts === true;
 
 	const speakerNameForMessage = (m: Message): string => {
 		if (m.role === "user") return (args.userName || "User").toString();
@@ -1971,12 +1977,19 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 			const text = (part.text || "").toString();
 			const attachments = part.attachments || [];
 
+			if (part.thought && !shouldIncludeThoughtParts) {
+				continue;
+			}
+
 			if (text.trim().length > 0 || part.thoughtSignature || part._thoughtSignatureRef) {
 				const resolvedThoughtSignature = await resolveThoughtSignature(part);
-				const partObj: any = { text: maybePrefixSpeaker(text, speaker) };
+				const partObj: any = { text: part.thought ? text : maybePrefixSpeaker(text, speaker) };
+				if (part.thought) {
+					partObj.thought = true;
+				}
 				partObj.thoughtSignature =
 					resolvedThoughtSignature ??
-					(shouldEnforceThoughtSignatures ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined);
+					(!part.thought && shouldEnforceThoughtSignatures ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined);
 				aggregatedParts.push(partObj);
 			}
 

--- a/src/services/RpgGroupChat.ts
+++ b/src/services/RpgGroupChat.ts
@@ -66,6 +66,7 @@ import {
 } from "../utils/chatHistoryBuilder";
 
 import { throwAbortError } from "../utils/abort";
+import { resolveThoughtSignature } from "../utils/blobResolver";
 import { dispatchAppEvent } from "../events";
 
 import {
@@ -1972,7 +1973,12 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 
 			if (text.trim().length > 0) {
 				const partObj: any = { text: maybePrefixSpeaker(text, speaker) };
-				const ts = shouldEnforceThoughtSignatures ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined;
+				const resolvedSignature = dbMessage.role === "model" ? await resolveThoughtSignature(part) : undefined;
+				const ts =
+					resolvedSignature ||
+					(dbMessage.role === "model" && shouldEnforceThoughtSignatures
+						? SKIP_THOUGHT_SIGNATURE_VALIDATOR
+						: undefined);
 				if (ts && !hasThoughtSignature) {
 					partObj.thoughtSignature = ts;
 					hasThoughtSignature = true;

--- a/src/services/RpgGroupChat.ts
+++ b/src/services/RpgGroupChat.ts
@@ -739,7 +739,8 @@ async function executeParticipantTurn(args: {
 		speakerNameById: ctx.speakerNameById,
 		userName: ctx.userName,
 		enforceThoughtSignatures: ctx.shouldEnforceThoughtSignaturesInHistory,
-		includeThoughtParts: !ctx.isPremiumEndpointPreferred && !isOpenRouterModel(ctx.settings.model)
+		includeThoughtParts: !ctx.isPremiumEndpointPreferred,
+		includeOpenRouterReasoningDetails: !ctx.isPremiumEndpointPreferred && isOpenRouterModel(ctx.settings.model)
 	});
 
 	const useIndependentAction = shouldTriggerIndependentAction(meta.independence);
@@ -1231,7 +1232,8 @@ async function handleNarratorBeforeFirst(ctx: RpgContext): Promise<void> {
 			speakerNameById: ctx.speakerNameById,
 			userName: ctx.userName,
 			enforceThoughtSignatures: false,
-			includeThoughtParts: !ctx.isPremiumEndpointPreferred && !isOpenRouterModel(ctx.settings.model)
+			includeThoughtParts: !ctx.isPremiumEndpointPreferred,
+			includeOpenRouterReasoningDetails: !ctx.isPremiumEndpointPreferred && isOpenRouterModel(ctx.settings.model)
 		});
 
 		const before = await generateNarratorMessage({
@@ -1292,7 +1294,8 @@ async function handleNarratorInterjection(ctx: RpgContext): Promise<void> {
 		speakerNameById: ctx.speakerNameById,
 		userName: ctx.userName,
 		enforceThoughtSignatures: false,
-		includeThoughtParts: !ctx.isPremiumEndpointPreferred && !isOpenRouterModel(ctx.settings.model)
+		includeThoughtParts: !ctx.isPremiumEndpointPreferred,
+		includeOpenRouterReasoningDetails: !ctx.isPremiumEndpointPreferred && isOpenRouterModel(ctx.settings.model)
 	});
 
 	const interjection = await generateNarratorMessage({
@@ -1360,7 +1363,8 @@ async function handleNarratorAfterRound(ctx: RpgContext): Promise<void> {
 			speakerNameById: ctx.speakerNameById,
 			userName: ctx.userName,
 			enforceThoughtSignatures: false,
-			includeThoughtParts: !ctx.isPremiumEndpointPreferred && !isOpenRouterModel(ctx.settings.model)
+			includeThoughtParts: !ctx.isPremiumEndpointPreferred,
+			includeOpenRouterReasoningDetails: !ctx.isPremiumEndpointPreferred && isOpenRouterModel(ctx.settings.model)
 		});
 
 		const after = await generateNarratorMessageResilient({
@@ -1949,6 +1953,7 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 		userName: string;
 		enforceThoughtSignatures?: boolean;
 		includeThoughtParts?: boolean;
+		includeOpenRouterReasoningDetails?: boolean;
 	}
 ): Promise<{ history: Content[]; pinnedHistoryIndices: number[] }> {
 	const history: Content[] = [];
@@ -1972,6 +1977,7 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 
 		const aggregatedParts: any[] = [];
 		const speaker = speakerNameForMessage(dbMessage);
+		let hasThoughtSignature = false;
 
 		for (const part of dbMessage.parts) {
 			const text = (part.text || "").toString();
@@ -1987,9 +1993,16 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 				if (part.thought) {
 					partObj.thought = true;
 				}
-				partObj.thoughtSignature =
+				if (args.includeOpenRouterReasoningDetails === true && part.reasoningDetail) {
+					partObj.reasoningDetail = part.reasoningDetail;
+				}
+				const ts =
 					resolvedThoughtSignature ??
 					(!part.thought && shouldEnforceThoughtSignatures ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined);
+				if (ts && !hasThoughtSignature) {
+					partObj.thoughtSignature = ts;
+					hasThoughtSignature = true;
+				}
 				aggregatedParts.push(partObj);
 			}
 
@@ -2006,7 +2019,9 @@ async function constructGeminiChatHistoryForGroupChatRpg(
 			images: dbMessage.generatedImages,
 			shouldProcess: !!dbMessage.generatedImages && index === lastImageIndex,
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
-			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE_VALIDATOR
+			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+			includeOpenRouterReasoningDetails: args.includeOpenRouterReasoningDetails === true,
+			suppressThoughtSignature: hasThoughtSignature
 		});
 		if (imageParts.length > 0) {
 			genAiMessage.parts?.push(...imageParts);

--- a/src/services/Settings.service.ts
+++ b/src/services/Settings.service.ts
@@ -75,13 +75,18 @@ const DEFAULT_UI_SCALE = 1;
 let isLoadingSettings = false;
 
 function getCurrentModelAccess() {
+	const hasModelOptions = Array.from(modelSelect.options).some((option) => option.value);
+	const isPremiumModelList = hasModelOptions && modelSelect.querySelector("optgroup") === null;
 	return {
 		hasGeminiAccess:
+			isPremiumModelList ||
 			geminiApiKeyInput.value.trim().length > 0 ||
 			(localStorage.getItem(SETTINGS_STORAGE_KEYS.API_KEY) || "").trim().length > 0,
 		hasOpenRouterAccess:
+			isPremiumModelList ||
 			openRouterApiKeyInput.value.trim().length > 0 ||
-			(localStorage.getItem(SETTINGS_STORAGE_KEYS.OPENROUTER_API_KEY) || "").trim().length > 0
+			(localStorage.getItem(SETTINGS_STORAGE_KEYS.OPENROUTER_API_KEY) || "").trim().length > 0,
+		isPremiumEndpointPreferred: isPremiumModelList
 	};
 }
 

--- a/src/services/Supabase.service.ts
+++ b/src/services/Supabase.service.ts
@@ -27,7 +27,7 @@ let userCache: SupabaseUser | null = null;
 let hydratedSessionUserId: string | null = null;
 
 export const SUPABASE_URL = "https://hglcltvwunzynnzduauy.supabase.co";
-export const PRO_REQUEST_FUNCTION_NAME = "handle-pro-request-x";
+export const PRO_REQUEST_FUNCTION_NAME = "handle-pro-request";
 export const PRO_REQUEST_ENDPOINT = `${SUPABASE_URL}/functions/v1/${PRO_REQUEST_FUNCTION_NAME}`;
 const SUPABASE_ANON_KEY =
 	"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhnbGNsdHZ3dW56eW5uemR1YXV5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM3MTIzOTIsImV4cCI6MjA2OTI4ODM5Mn0.q4VZu-0vEZVdjSXAhlSogB9ihfPVwero0S4UFVCvMDQ";

--- a/src/services/Sync.service.ts
+++ b/src/services/Sync.service.ts
@@ -1210,8 +1210,10 @@ function deserializeMessage(message: any): Message {
 		generatedImages = message.generatedImages.map((img: any) => {
 			const imageRef = isBlobReference(img.base64) ? img.base64 : undefined;
 			const thoughtSignatureRef = isBlobReference(img.thoughtSignature) ? img.thoughtSignature : undefined;
+			const { _blobRef, _thoughtSignatureRef, ...rest } = img;
 
 			return {
+				...rest,
 				mimeType: img.mimeType,
 				base64: imageRef ? "" : typeof img.base64 === "string" ? img.base64 : "",
 				thoughtSignature: thoughtSignatureRef

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3446,6 +3446,28 @@ body.full-width-chat .message-container {
 	font-family: inherit;
 }
 
+.message-thinking .thought-images {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	margin-top: 0.5rem;
+}
+
+.message-thinking .thought-image-wrapper {
+	display: inline-flex;
+	max-width: min(16rem, 100%);
+	background: #00000018;
+	border-radius: 0.4rem;
+	overflow: hidden;
+}
+
+.message-thinking .thought-image {
+	display: block;
+	max-width: 100%;
+	height: auto;
+	object-fit: contain;
+}
+
 /* Settings specific */
 /* Generated images in assistant messages */
 .message-images {

--- a/src/types/GeminiResponseProcessor.ts
+++ b/src/types/GeminiResponseProcessor.ts
@@ -1,4 +1,4 @@
-import type { GeneratedImage } from "./Message";
+import type { GeneratedImage, Message } from "./Message";
 
 export type GeminiAbortMode = "throw" | "return";
 
@@ -23,6 +23,7 @@ export type GeminiLocalSdkProcessResult = {
 	text: string;
 	thinking: string;
 	textSignature?: string;
+	responseParts: Message["parts"];
 	finishReason?: unknown;
 	groundingContent: string;
 	images: GeneratedImage[];

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -69,7 +69,11 @@ export interface MessageDebugInfo {
 export interface Message {
 	role: "user" | "model";
 	parts: Array<{
-		text: string;
+		text?: string;
+		inlineData?: {
+			data: string;
+			mimeType: string;
+		};
 		thought?: boolean;
 		reasoningDetail?: ReasoningDetailMetadata;
 		attachments?: FileList | File[];

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -61,6 +61,7 @@ export interface Message {
 	role: "user" | "model";
 	parts: Array<{
 		text: string;
+		thought?: boolean;
 		attachments?: FileList | File[];
 		thoughtSignature?: string;
 		_thoughtSignatureRef?: BlobReference;

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -1,6 +1,15 @@
 import type { BlobReference } from "./BlobReference";
 import type { ReasoningDetailFormat } from "./OpenRouterTypes";
 
+export interface ReasoningDetailMetadata {
+	type?: string;
+	id?: string | null;
+	format?: ReasoningDetailFormat;
+	index?: number;
+	signature?: string | null;
+	[key: string]: unknown;
+}
+
 /**
  * Text and thinking content extracted from a model response.
  */
@@ -62,6 +71,7 @@ export interface Message {
 	parts: Array<{
 		text: string;
 		thought?: boolean;
+		reasoningDetail?: ReasoningDetailMetadata;
 		attachments?: FileList | File[];
 		thoughtSignature?: string;
 		_thoughtSignatureRef?: BlobReference;

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -1,4 +1,5 @@
 import type { BlobReference } from "./BlobReference";
+import type { ReasoningDetailFormat } from "./OpenRouterTypes";
 
 /**
  * Text and thinking content extracted from a model response.
@@ -12,6 +13,13 @@ export interface GeneratedImage {
 	mimeType: string;
 	base64: string; // raw base64 bytes without data: prefix
 	thoughtSignature?: string;
+	thoughtSignatureReasoningDetail?: {
+		type: "reasoning.encrypted";
+		id?: string | null;
+		format?: ReasoningDetailFormat;
+		index?: number;
+		[key: string]: unknown;
+	};
 	thought?: boolean;
 	/**
 	 * Runtime-only blob reference for images stored in encrypted blob storage.

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -63,6 +63,7 @@ export interface ChatModelAccess {
 export const DEFAULT_GEMINI_CHAT_MODEL = ChatModel.FLASH;
 export const DEFAULT_OPENROUTER_CHAT_MODEL = "openai/gpt-5.4";
 export const DEFAULT_OPENROUTER_NARRATOR_MODEL = DEFAULT_OPENROUTER_CHAT_MODEL;
+export const DEFAULT_OPENROUTER_TITLE_MODEL = "z-ai/glm-5";
 const UI_DISABLED_CHAT_MODELS = new Set(["openai/gpt-5.4-pro"]);
 
 const GEMINI_TO_OPENROUTER_CHAT_MODEL_IDS = new Map<string, string>([

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -102,6 +102,7 @@ export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 		mega: false,
 		roleplayModeSuggester: true,
 		supportsThinking: true,
+		requiresThinking: true,
 		supportsTemperature: true,
 		supportsImageInput: true,
 		supportsFileInput: true,

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -40,7 +40,9 @@ export type ModelProvider = "gemini" | "openrouter";
 export interface ChatModelDefinition {
 	id: string;
 	label: string;
+	premiumLabel?: string;
 	provider: ModelProvider;
+	localOnly?: boolean;
 	mega?: boolean;
 	supportsThinking: boolean;
 	requiresThinking?: boolean;
@@ -55,12 +57,23 @@ export interface ChatModelDefinition {
 export interface ChatModelAccess {
 	hasGeminiAccess: boolean;
 	hasOpenRouterAccess: boolean;
+	isPremiumEndpointPreferred?: boolean;
 }
 
 export const DEFAULT_GEMINI_CHAT_MODEL = ChatModel.FLASH;
 export const DEFAULT_OPENROUTER_CHAT_MODEL = "openai/gpt-5.4";
 export const DEFAULT_OPENROUTER_NARRATOR_MODEL = DEFAULT_OPENROUTER_CHAT_MODEL;
 const UI_DISABLED_CHAT_MODELS = new Set(["openai/gpt-5.4-pro"]);
+
+const GEMINI_TO_OPENROUTER_CHAT_MODEL_IDS = new Map<string, string>([
+	[ChatModel.FLASH_LITE, "google/gemini-3.1-flash-lite"],
+	[ChatModel.FLASH_3_PREV, "google/gemini-3-flash-preview"],
+	[ChatModel.FLASH, "google/gemini-3.5-flash"],
+	[ChatModel.FLASH_2_5, "google/gemini-2.5-flash"],
+	[ChatModel.FLASH_LITE_2_5, "google/gemini-2.5-flash-lite"],
+	[ChatModel.PRO, "google/gemini-3.1-pro-preview"],
+	[ChatModel.PRO_2_5, "google/gemini-2.5-pro"]
+]);
 
 export function requiresThoughtSignaturesInHistory(model: string): boolean {
 	return model === ChatModel.NANO_BANANA_PRO || model === ChatModel.NANO_BANANA_2;
@@ -71,6 +84,7 @@ export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 		id: ChatModel.FLASH_LITE,
 		label: "Gemini 3.1 Flash Lite",
 		provider: "gemini",
+		localOnly: true,
 		mega: false,
 		roleplayModeSuggester: true,
 		supportsThinking: true,
@@ -83,6 +97,7 @@ export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 		id: ChatModel.FLASH,
 		label: "Gemini 3.5 Flash",
 		provider: "gemini",
+		localOnly: true,
 		mega: false,
 		roleplayModeSuggester: true,
 		supportsThinking: true,
@@ -95,6 +110,7 @@ export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 		id: ChatModel.FLASH_3_PREV,
 		label: "Gemini 3 Flash Preview",
 		provider: "gemini",
+		localOnly: true,
 		mega: false,
 		roleplayModeSuggester: true,
 		supportsThinking: true,
@@ -107,6 +123,7 @@ export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 		id: ChatModel.PRO,
 		label: "Gemini 3.1 Pro Preview",
 		provider: "gemini",
+		localOnly: true,
 		mega: false,
 		roleplayModeSuggester: true,
 		supportsThinking: true,
@@ -121,6 +138,7 @@ export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 		id: ChatModel.PRO_2_5,
 		label: "Gemini 2.5 Pro",
 		provider: "gemini",
+		localOnly: true,
 		mega: false,
 		supportsThinking: true,
 		requiresThinking: true,
@@ -133,6 +151,7 @@ export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 		id: ChatModel.FLASH_2_5,
 		label: "Gemini 2.5 Flash",
 		provider: "gemini",
+		localOnly: true,
 		mega: false,
 		supportsThinking: false,
 		supportsTemperature: true,
@@ -144,6 +163,7 @@ export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 		id: ChatModel.FLASH_LITE_2_5,
 		label: "Gemini 2.5 Flash Lite",
 		provider: "gemini",
+		localOnly: true,
 		mega: false,
 		supportsThinking: false,
 		supportsTemperature: true,
@@ -175,7 +195,28 @@ export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 	}
 ];
 
+function openRouterGeminiVariant(localModelId: ChatModel, openRouterModelId: string): ChatModelDefinition {
+	const localModel = GEMINI_CHAT_MODELS.find((model) => model.id === localModelId);
+	if (!localModel) throw new Error(`Missing local Gemini model: ${localModelId}`);
+
+	return {
+		...localModel,
+		id: openRouterModelId,
+		label: `${localModel.label} via OpenRouter`,
+		premiumLabel: localModel.label,
+		provider: "openrouter",
+		localOnly: undefined
+	};
+}
+
 export const OPENROUTER_CHAT_MODELS: ChatModelDefinition[] = [
+	openRouterGeminiVariant(ChatModel.FLASH_LITE, "google/gemini-3.1-flash-lite"),
+	openRouterGeminiVariant(ChatModel.FLASH_3_PREV, "google/gemini-3-flash-preview"),
+	openRouterGeminiVariant(ChatModel.FLASH, "google/gemini-3.5-flash"),
+	openRouterGeminiVariant(ChatModel.FLASH_2_5, "google/gemini-2.5-flash"),
+	openRouterGeminiVariant(ChatModel.FLASH_LITE_2_5, "google/gemini-2.5-flash-lite"),
+	openRouterGeminiVariant(ChatModel.PRO, "google/gemini-3.1-pro-preview"),
+	openRouterGeminiVariant(ChatModel.PRO_2_5, "google/gemini-2.5-pro"),
 	{
 		id: "openai/gpt-5.4",
 		label: "GPT-5.4",
@@ -351,6 +392,10 @@ export function getAccessibleChatModels(access: ChatModelAccess): ChatModelDefin
 			return false;
 		}
 
+		if (access.isPremiumEndpointPreferred && model.localOnly) {
+			return false;
+		}
+
 		if (model.provider === "gemini") return access.hasGeminiAccess;
 		return access.hasOpenRouterAccess;
 	});
@@ -360,8 +405,19 @@ export function getAccessibleRoleplaySuggestionModels(access: ChatModelAccess): 
 	return getAccessibleChatModels(access).filter((model) => model.roleplayModeSuggester === true);
 }
 
-export function formatChatModelLabel(model: Pick<ChatModelDefinition, "label" | "mega">): string {
-	return model.mega ? `${model.label} [MEGA]` : model.label;
+export function formatChatModelLabel(
+	model: Pick<ChatModelDefinition, "label" | "premiumLabel" | "mega">,
+	options: { usePremiumLabel?: boolean } = {}
+): string {
+	const label = options.usePremiumLabel ? (model.premiumLabel ?? model.label) : model.label;
+	return model.mega ? `${label} [MEGA]` : label;
+}
+
+export function getPremiumEndpointChatModel(model: string | null | undefined): string | undefined {
+	if (!model) return undefined;
+	const definition = getChatModelDefinition(model);
+	if (!definition?.localOnly) return model;
+	return GEMINI_TO_OPENROUTER_CHAT_MODEL_IDS.get(model);
 }
 
 const imageModelLabelMap = new Map<string, string>([
@@ -385,6 +441,10 @@ export function formatOriginModelLabel(originModel: string | null | undefined): 
 }
 
 export function getDefaultChatModel(access: ChatModelAccess): string {
+	if (access.isPremiumEndpointPreferred && access.hasOpenRouterAccess) {
+		return getPremiumEndpointChatModel(DEFAULT_GEMINI_CHAT_MODEL) ?? DEFAULT_OPENROUTER_CHAT_MODEL;
+	}
+
 	if (access.hasGeminiAccess) {
 		return DEFAULT_GEMINI_CHAT_MODEL;
 	}
@@ -398,8 +458,9 @@ export function getDefaultChatModel(access: ChatModelAccess): string {
 
 export function getValidChatModel(model: string | null | undefined, access: ChatModelAccess): string {
 	const availableModels = getAccessibleChatModels(access);
-	if (model && availableModels.some((candidate) => candidate.id === model)) {
-		return model;
+	const preferredModel = access.isPremiumEndpointPreferred ? getPremiumEndpointChatModel(model) : model;
+	if (preferredModel && availableModels.some((candidate) => candidate.id === preferredModel)) {
+		return preferredModel;
 	}
 
 	return availableModels[0]?.id ?? getDefaultChatModel(access);
@@ -407,8 +468,9 @@ export function getValidChatModel(model: string | null | undefined, access: Chat
 
 export function getValidRoleplaySuggestionModel(model: string | null | undefined, access: ChatModelAccess): string {
 	const availableModels = getAccessibleRoleplaySuggestionModels(access);
-	if (model && availableModels.some((candidate) => candidate.id === model)) {
-		return model;
+	const preferredModel = access.isPremiumEndpointPreferred ? getPremiumEndpointChatModel(model) : model;
+	if (preferredModel && availableModels.some((candidate) => candidate.id === preferredModel)) {
+		return preferredModel;
 	}
 
 	return availableModels[0]?.id ?? getDefaultChatModel(access);

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -195,6 +195,7 @@ export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 		localOnly: true,
 		mega: false,
 		supportsThinking: true,
+		requiresThinking: true,
 		supportsTemperature: true,
 		supportsImageInput: true,
 		supportsFileInput: true,

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -93,7 +93,7 @@ export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 		roleplayModeSuggester: true,
 		supportsThinking: true,
 		supportsTemperature: true,
-		supportsImageInput: false,
+		supportsImageInput: true,
 		supportsFileInput: true,
 		supportsImageOutput: false
 	},

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -11,6 +11,16 @@ export enum ChatModel {
 	FLASH_LITE_2_5 = "gemini-2.5-flash-lite"
 }
 
+const GEMINI_TO_OPENROUTER_CHAT_MODEL_IDS = new Map<string, string>([
+	[ChatModel.FLASH_LITE, "google/gemini-3.1-flash-lite"],
+	[ChatModel.FLASH_3_PREV, "google/gemini-3-flash-preview"],
+	[ChatModel.FLASH, "google/gemini-3.5-flash"],
+	[ChatModel.FLASH_2_5, "google/gemini-2.5-flash"],
+	[ChatModel.FLASH_LITE_2_5, "google/gemini-2.5-flash-lite"],
+	[ChatModel.PRO, "google/gemini-3.1-pro-preview"],
+	[ChatModel.PRO_2_5, "google/gemini-2.5-pro"]
+]);
+
 export enum ImageModel {
 	ULTRA = "imagen-4.0-ultra-generate-001",
 	ILLUSTRIOUS = "illustrious",
@@ -65,16 +75,6 @@ export const DEFAULT_OPENROUTER_CHAT_MODEL = "openai/gpt-5.4";
 export const DEFAULT_OPENROUTER_NARRATOR_MODEL = DEFAULT_OPENROUTER_CHAT_MODEL;
 export const DEFAULT_OPENROUTER_TITLE_MODEL = "z-ai/glm-5";
 const UI_DISABLED_CHAT_MODELS = new Set(["openai/gpt-5.4-pro"]);
-
-const GEMINI_TO_OPENROUTER_CHAT_MODEL_IDS = new Map<string, string>([
-	[ChatModel.FLASH_LITE, "google/gemini-3.1-flash-lite"],
-	[ChatModel.FLASH_3_PREV, "google/gemini-3-flash-preview"],
-	[ChatModel.FLASH, "google/gemini-3.5-flash"],
-	[ChatModel.FLASH_2_5, "google/gemini-2.5-flash"],
-	[ChatModel.FLASH_LITE_2_5, "google/gemini-2.5-flash-lite"],
-	[ChatModel.PRO, "google/gemini-3.1-pro-preview"],
-	[ChatModel.PRO_2_5, "google/gemini-2.5-pro"]
-]);
 
 export function requiresThoughtSignaturesInHistory(model: string): boolean {
 	return model === ChatModel.NANO_BANANA_PRO || model === ChatModel.NANO_BANANA_2;

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -177,6 +177,18 @@ export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 		supportsImageOutput: false
 	},
 	{
+		id: ChatModel.NANO_BANANA,
+		label: "Gemini 2.5 Flash Image (Nano Banana)",
+		provider: "gemini",
+		localOnly: true,
+		mega: false,
+		supportsThinking: true,
+		supportsTemperature: true,
+		supportsImageInput: true,
+		supportsFileInput: true,
+		supportsImageOutput: true
+	},
+	{
 		id: ChatModel.NANO_BANANA_PRO,
 		label: "Gemini 3.0 Pro Image (Nano Banana Pro)",
 		provider: "gemini",
@@ -216,19 +228,6 @@ function openRouterGeminiVariant(localModelId: ChatModel, openRouterModelId: str
 	};
 }
 
-const OPENROUTER_NANO_BANANA_MODEL: ChatModelDefinition = {
-	id: "google/gemini-2.5-flash-image",
-	label: "Gemini 2.5 Flash Image (Nano Banana) via OpenRouter",
-	premiumLabel: "Gemini 2.5 Flash Image (Nano Banana)",
-	provider: "openrouter",
-	mega: false,
-	supportsThinking: true,
-	supportsTemperature: true,
-	supportsImageInput: true,
-	supportsFileInput: true,
-	supportsImageOutput: true
-};
-
 export const OPENROUTER_CHAT_MODELS: ChatModelDefinition[] = [
 	openRouterGeminiVariant(ChatModel.FLASH_LITE, "google/gemini-3.1-flash-lite"),
 	openRouterGeminiVariant(ChatModel.FLASH_3_PREV, "google/gemini-3-flash-preview"),
@@ -237,7 +236,7 @@ export const OPENROUTER_CHAT_MODELS: ChatModelDefinition[] = [
 	openRouterGeminiVariant(ChatModel.FLASH_LITE_2_5, "google/gemini-2.5-flash-lite"),
 	openRouterGeminiVariant(ChatModel.PRO, "google/gemini-3.1-pro-preview"),
 	openRouterGeminiVariant(ChatModel.PRO_2_5, "google/gemini-2.5-pro"),
-	OPENROUTER_NANO_BANANA_MODEL,
+	openRouterGeminiVariant(ChatModel.NANO_BANANA, "google/gemini-2.5-flash-image"),
 	openRouterGeminiVariant(ChatModel.NANO_BANANA_PRO, "google/gemini-3-pro-image-preview"),
 	openRouterGeminiVariant(ChatModel.NANO_BANANA_2, "google/gemini-3.1-flash-image-preview"),
 	{

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -18,7 +18,10 @@ const GEMINI_TO_OPENROUTER_CHAT_MODEL_IDS = new Map<string, string>([
 	[ChatModel.FLASH_2_5, "google/gemini-2.5-flash"],
 	[ChatModel.FLASH_LITE_2_5, "google/gemini-2.5-flash-lite"],
 	[ChatModel.PRO, "google/gemini-3.1-pro-preview"],
-	[ChatModel.PRO_2_5, "google/gemini-2.5-pro"]
+	[ChatModel.PRO_2_5, "google/gemini-2.5-pro"],
+	[ChatModel.NANO_BANANA, "google/gemini-2.5-flash-image"],
+	[ChatModel.NANO_BANANA_PRO, "google/gemini-3-pro-image-preview"],
+	[ChatModel.NANO_BANANA_2, "google/gemini-3.1-flash-image-preview"]
 ]);
 
 export enum ImageModel {
@@ -177,6 +180,7 @@ export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 		id: ChatModel.NANO_BANANA_PRO,
 		label: "Gemini 3.0 Pro Image (Nano Banana Pro)",
 		provider: "gemini",
+		localOnly: true,
 		mega: false,
 		supportsThinking: true,
 		supportsTemperature: true,
@@ -188,6 +192,7 @@ export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 		id: ChatModel.NANO_BANANA_2,
 		label: "Gemini 3.1 Flash Image (Nano Banana 2)",
 		provider: "gemini",
+		localOnly: true,
 		mega: false,
 		supportsThinking: true,
 		supportsTemperature: true,
@@ -211,6 +216,19 @@ function openRouterGeminiVariant(localModelId: ChatModel, openRouterModelId: str
 	};
 }
 
+const OPENROUTER_NANO_BANANA_MODEL: ChatModelDefinition = {
+	id: "google/gemini-2.5-flash-image",
+	label: "Gemini 2.5 Flash Image (Nano Banana) via OpenRouter",
+	premiumLabel: "Gemini 2.5 Flash Image (Nano Banana)",
+	provider: "openrouter",
+	mega: false,
+	supportsThinking: true,
+	supportsTemperature: true,
+	supportsImageInput: true,
+	supportsFileInput: true,
+	supportsImageOutput: true
+};
+
 export const OPENROUTER_CHAT_MODELS: ChatModelDefinition[] = [
 	openRouterGeminiVariant(ChatModel.FLASH_LITE, "google/gemini-3.1-flash-lite"),
 	openRouterGeminiVariant(ChatModel.FLASH_3_PREV, "google/gemini-3-flash-preview"),
@@ -219,6 +237,9 @@ export const OPENROUTER_CHAT_MODELS: ChatModelDefinition[] = [
 	openRouterGeminiVariant(ChatModel.FLASH_LITE_2_5, "google/gemini-2.5-flash-lite"),
 	openRouterGeminiVariant(ChatModel.PRO, "google/gemini-3.1-pro-preview"),
 	openRouterGeminiVariant(ChatModel.PRO_2_5, "google/gemini-2.5-pro"),
+	OPENROUTER_NANO_BANANA_MODEL,
+	openRouterGeminiVariant(ChatModel.NANO_BANANA_PRO, "google/gemini-3-pro-image-preview"),
+	openRouterGeminiVariant(ChatModel.NANO_BANANA_2, "google/gemini-3.1-flash-image-preview"),
 	{
 		id: "openai/gpt-5.4",
 		label: "GPT-5.4",
@@ -418,8 +439,10 @@ export function formatChatModelLabel(
 export function getPremiumEndpointChatModel(model: string | null | undefined): string | undefined {
 	if (!model) return undefined;
 	const definition = getChatModelDefinition(model);
+	const mappedModel = GEMINI_TO_OPENROUTER_CHAT_MODEL_IDS.get(model);
+	if (mappedModel && (definition?.localOnly || !definition)) return mappedModel;
 	if (!definition?.localOnly) return model;
-	return GEMINI_TO_OPENROUTER_CHAT_MODEL_IDS.get(model);
+	return mappedModel;
 }
 
 const imageModelLabelMap = new Map<string, string>([

--- a/src/types/OpenRouterTypes.ts
+++ b/src/types/OpenRouterTypes.ts
@@ -49,6 +49,8 @@ export type Request = {
 	// https://platform.openai.com/docs/guides/latency-optimization#use-predicted-outputs
 	prediction?: { type: "content"; content: string };
 
+	modalities?: string[]; // E.g., ["text", "image"]
+
 	// OpenRouter-only parameters
 	// See "Prompt Transforms" section: openrouter.ai/docs/transforms
 	transforms?: string[];
@@ -272,6 +274,12 @@ export type NonStreamingChoice = {
 		reasoning?: string | null;
 		reasoning_details?: ReasoningDetail[];
 		tool_calls?: ToolCall[];
+		images?: {
+			type: "image_url";
+			image_url: {
+				url: string;
+			};
+		}[];
 	};
 	error?: ErrorResponse;
 };
@@ -284,6 +292,13 @@ export type StreamingChoice = {
 		role?: string;
 		tool_calls?: ToolCall[];
 		reasoning?: string; // Optional chain-of-thought / reasoning text
+		reasoning_details?: ReasoningDetail[];
+		images?: {
+			type: "image_url";
+			image_url: {
+				url: string;
+			};
+		}[];
 	};
 	error?: ErrorResponse;
 };

--- a/src/types/OpenRouterTypes.ts
+++ b/src/types/OpenRouterTypes.ts
@@ -104,6 +104,7 @@ export type ReasoningDetail =
 			id?: string | null;
 			format: ReasoningDetailFormat;
 			index?: number;
+			[key: string]: unknown;
 	  }
 	| {
 			type?: string;
@@ -114,6 +115,7 @@ export type ReasoningDetail =
 			id?: string | null;
 			format?: ReasoningDetailFormat;
 			index?: number;
+			[key: string]: unknown;
 	  };
 
 export type Message =

--- a/src/types/OpenRouterTypes.ts
+++ b/src/types/OpenRouterTypes.ts
@@ -88,11 +88,40 @@ export type FileContentPart = {
 
 export type ContentPart = TextContent | ImageContentPart | FileContentPart;
 
+export type ReasoningDetailFormat =
+	| "unknown"
+	| "openai-responses-v1"
+	| "azure-openai-responses-v1"
+	| "xai-responses-v1"
+	| "anthropic-claude-v1"
+	| "google-gemini-v1"
+	| (string & {});
+
+export type ReasoningDetail =
+	| {
+			type: "reasoning.encrypted";
+			data: string;
+			id?: string | null;
+			format: ReasoningDetailFormat;
+			index?: number;
+	  }
+	| {
+			type?: string;
+			text?: string;
+			summary?: string;
+			data?: string;
+			signature?: string | null;
+			id?: string | null;
+			format?: ReasoningDetailFormat;
+			index?: number;
+	  };
+
 export type Message =
 	| {
 			role: "user" | "assistant" | "system" | "developer";
 			// ContentParts are only for the "user" role:
 			content: string | ContentPart[];
+			reasoning_details?: ReasoningDetail[];
 			// If "name" is included, it will be prepended like this
 			// for non-OpenAI models: `{name}: {content}`
 			name?: string;
@@ -328,10 +357,3 @@ type ResponseUsage = {
 };
 //alias to any for now
 type FunctionCall = any; // See "Tool Calling" section
-
-type ReasoningDetail = {
-	type?: string;
-	text?: string;
-	summary?: string;
-	data?: string;
-};

--- a/src/types/PremiumEndpointResponseProcessor.ts
+++ b/src/types/PremiumEndpointResponseProcessor.ts
@@ -1,4 +1,4 @@
-import type { GeneratedImage } from "./Message";
+import type { GeneratedImage, Message } from "./Message";
 
 export type PremiumEndpointAbortMode = "throw" | "return";
 
@@ -35,6 +35,7 @@ export type PremiumEndpointProcessResult = {
 	finishReason?: unknown;
 	groundingContent: string;
 	images: GeneratedImage[];
+	responseParts: Message["parts"];
 	wasAborted: boolean;
 	wasFallbackMode: boolean;
 };

--- a/src/utils/chatHistoryBuilder.ts
+++ b/src/utils/chatHistoryBuilder.ts
@@ -110,6 +110,7 @@ export interface GeneratedImageProcessingConfig {
 	enforceThoughtSignatures: boolean;
 	skipThoughtSignatureValidator: string;
 	includeOpenRouterReasoningDetails?: boolean;
+	suppressThoughtSignature?: boolean;
 }
 
 /**
@@ -122,7 +123,8 @@ export async function processGeneratedImagesToParts(config: GeneratedImageProces
 		shouldProcess,
 		enforceThoughtSignatures,
 		skipThoughtSignatureValidator,
-		includeOpenRouterReasoningDetails
+		includeOpenRouterReasoningDetails,
+		suppressThoughtSignature
 	} = config;
 
 	if (!shouldProcess || !images || images.length === 0) {
@@ -146,8 +148,10 @@ export async function processGeneratedImagesToParts(config: GeneratedImageProces
 		const part: any = {
 			inlineData: { data: base64, mimeType: img.mimeType }
 		};
-		part.thoughtSignature =
-			resolvedThoughtSignature ?? (enforceThoughtSignatures ? skipThoughtSignatureValidator : undefined);
+		if (!suppressThoughtSignature) {
+			part.thoughtSignature =
+				resolvedThoughtSignature ?? (enforceThoughtSignatures ? skipThoughtSignatureValidator : undefined);
+		}
 		if (includeOpenRouterReasoningDetails && img.thoughtSignatureReasoningDetail) {
 			part.thoughtSignatureReasoningDetail = img.thoughtSignatureReasoningDetail;
 		}

--- a/src/utils/chatHistoryBuilder.ts
+++ b/src/utils/chatHistoryBuilder.ts
@@ -109,6 +109,7 @@ export interface GeneratedImageProcessingConfig {
 	shouldProcess: boolean;
 	enforceThoughtSignatures: boolean;
 	skipThoughtSignatureValidator: string;
+	includeOpenRouterReasoningDetails?: boolean;
 }
 
 /**
@@ -116,7 +117,13 @@ export interface GeneratedImageProcessingConfig {
  * Returns an array of parts ready to be added to a message.
  */
 export async function processGeneratedImagesToParts(config: GeneratedImageProcessingConfig): Promise<any[]> {
-	const { images, shouldProcess, enforceThoughtSignatures, skipThoughtSignatureValidator } = config;
+	const {
+		images,
+		shouldProcess,
+		enforceThoughtSignatures,
+		skipThoughtSignatureValidator,
+		includeOpenRouterReasoningDetails
+	} = config;
 
 	if (!shouldProcess || !images || images.length === 0) {
 		return [];
@@ -141,6 +148,9 @@ export async function processGeneratedImagesToParts(config: GeneratedImageProces
 		};
 		part.thoughtSignature =
 			resolvedThoughtSignature ?? (enforceThoughtSignatures ? skipThoughtSignatureValidator : undefined);
+		if (includeOpenRouterReasoningDetails && img.thoughtSignatureReasoningDetail) {
+			part.thoughtSignatureReasoningDetail = img.thoughtSignatureReasoningDetail;
+		}
 		if (img.thought) {
 			part.thought = img.thought;
 		}

--- a/src/utils/chatHistoryBuilder.ts
+++ b/src/utils/chatHistoryBuilder.ts
@@ -11,7 +11,7 @@
 
 import type { Message, GeneratedImage } from "../types/Message";
 import * as helpers from "./helpers";
-import { resolveAttachmentFile, resolveGeneratedImageSrc } from "./blobResolver";
+import { resolveAttachmentFile, resolveGeneratedImageSrc, resolveThoughtSignature } from "./blobResolver";
 
 // ================================================================================
 // PART PROCESSING
@@ -42,6 +42,9 @@ export async function processAttachmentsToParts(config: AttachmentProcessingConf
 	for (const attachment of Array.from(attachments)) {
 		const resolvedAttachment = await resolveAttachmentFile(attachment);
 		const base64 = await helpers.fileToBase64(resolvedAttachment);
+		if (!base64) {
+			continue;
+		}
 		const mimeType = resolvedAttachment.type || "application/octet-stream";
 		parts.push(await createPartFromBase64(base64, mimeType));
 	}
@@ -74,6 +77,10 @@ export async function processGeneratedImagesToParts(config: GeneratedImageProces
 
 	const parts: any[] = [];
 	for (const img of images) {
+		if (img.thought) {
+			continue;
+		}
+
 		let base64 = img.base64 || "";
 		if (base64.length === 0 && img._blobRef) {
 			const dataUri = await resolveGeneratedImageSrc(img);
@@ -87,7 +94,10 @@ export async function processGeneratedImagesToParts(config: GeneratedImageProces
 		const part: any = {
 			inlineData: { data: base64, mimeType: img.mimeType }
 		};
-		if (!suppressThoughtSignature) {
+		const thoughtSignature = await resolveThoughtSignature(img);
+		if (thoughtSignature) {
+			part.thoughtSignature = thoughtSignature;
+		} else if (!suppressThoughtSignature) {
 			part.thoughtSignature = enforceThoughtSignatures ? skipThoughtSignatureValidator : undefined;
 		}
 		parts.push(part);

--- a/src/utils/chatHistoryBuilder.ts
+++ b/src/utils/chatHistoryBuilder.ts
@@ -60,7 +60,19 @@ export interface GeneratedImageProcessingConfig {
 	shouldProcess: boolean;
 	enforceThoughtSignatures: boolean;
 	skipThoughtSignatureValidator: string;
+	/**
+	 * The owning model message already emitted the skip-validator sentinel on an
+	 * earlier part. When true we avoid stamping that synthetic fallback again on
+	 * image parts. This does NOT suppress real stored signatures — if an image has
+	 * a valid (allowed) `thoughtSignature` it is always emitted.
+	 */
 	suppressThoughtSignature?: boolean;
+	/**
+	 * Whether the image's stored `thoughtSignature` may be replayed to Gemini.
+	 * Set to false for OpenRouter-origin images: their encrypted reasoning
+	 * signatures are incompatible with the Gemini SDK, so we drop them and
+	 * substitute the skip-validator sentinel when Gemini requires a signature.
+	 */
 	allowStoredThoughtSignatures?: boolean;
 }
 
@@ -101,6 +113,13 @@ export async function processGeneratedImagesToParts(config: GeneratedImageProces
 		const part: any = {
 			inlineData: { data: base64, mimeType: img.mimeType }
 		};
+		// Thought-signature resolution (see SKIP_THOUGHT_SIGNATURE_VALIDATOR doc in
+		// Message.service.ts for the full quirk list):
+		// - Use the stored Gemini signature only when allowed (non-OpenRouter origin).
+		// - Otherwise emit the skip-validator sentinel when Gemini enforces signatures.
+		//   We force the skip-validator even if `suppressThoughtSignature` is set when
+		//   stored signatures are disallowed, because Gemini validates the image part's
+		//   signature independently of the text part.
 		const thoughtSignature = allowStoredThoughtSignatures ? await resolveThoughtSignature(img) : undefined;
 		if (thoughtSignature) {
 			part.thoughtSignature = thoughtSignature;

--- a/src/utils/chatHistoryBuilder.ts
+++ b/src/utils/chatHistoryBuilder.ts
@@ -61,6 +61,7 @@ export interface GeneratedImageProcessingConfig {
 	enforceThoughtSignatures: boolean;
 	skipThoughtSignatureValidator: string;
 	suppressThoughtSignature?: boolean;
+	allowStoredThoughtSignatures?: boolean;
 }
 
 /**
@@ -68,8 +69,14 @@ export interface GeneratedImageProcessingConfig {
  * Returns an array of parts ready to be added to a message.
  */
 export async function processGeneratedImagesToParts(config: GeneratedImageProcessingConfig): Promise<any[]> {
-	const { images, shouldProcess, enforceThoughtSignatures, skipThoughtSignatureValidator, suppressThoughtSignature } =
-		config;
+	const {
+		images,
+		shouldProcess,
+		enforceThoughtSignatures,
+		skipThoughtSignatureValidator,
+		suppressThoughtSignature,
+		allowStoredThoughtSignatures = true
+	} = config;
 
 	if (!shouldProcess || !images || images.length === 0) {
 		return [];
@@ -94,10 +101,10 @@ export async function processGeneratedImagesToParts(config: GeneratedImageProces
 		const part: any = {
 			inlineData: { data: base64, mimeType: img.mimeType }
 		};
-		const thoughtSignature = await resolveThoughtSignature(img);
+		const thoughtSignature = allowStoredThoughtSignatures ? await resolveThoughtSignature(img) : undefined;
 		if (thoughtSignature) {
 			part.thoughtSignature = thoughtSignature;
-		} else if (!suppressThoughtSignature) {
+		} else if (!suppressThoughtSignature || !allowStoredThoughtSignatures) {
 			part.thoughtSignature = enforceThoughtSignatures ? skipThoughtSignatureValidator : undefined;
 		}
 		parts.push(part);

--- a/src/utils/chatHistoryBuilder.ts
+++ b/src/utils/chatHistoryBuilder.ts
@@ -11,7 +11,7 @@
 
 import type { Message, GeneratedImage } from "../types/Message";
 import * as helpers from "./helpers";
-import { resolveAttachmentFile, resolveGeneratedImageSrc, resolveThoughtSignature } from "./blobResolver";
+import { resolveAttachmentFile, resolveGeneratedImageSrc } from "./blobResolver";
 
 // ================================================================================
 // INDEX FINDING
@@ -109,7 +109,6 @@ export interface GeneratedImageProcessingConfig {
 	shouldProcess: boolean;
 	enforceThoughtSignatures: boolean;
 	skipThoughtSignatureValidator: string;
-	includeOpenRouterReasoningDetails?: boolean;
 	suppressThoughtSignature?: boolean;
 }
 
@@ -118,14 +117,8 @@ export interface GeneratedImageProcessingConfig {
  * Returns an array of parts ready to be added to a message.
  */
 export async function processGeneratedImagesToParts(config: GeneratedImageProcessingConfig): Promise<any[]> {
-	const {
-		images,
-		shouldProcess,
-		enforceThoughtSignatures,
-		skipThoughtSignatureValidator,
-		includeOpenRouterReasoningDetails,
-		suppressThoughtSignature
-	} = config;
+	const { images, shouldProcess, enforceThoughtSignatures, skipThoughtSignatureValidator, suppressThoughtSignature } =
+		config;
 
 	if (!shouldProcess || !images || images.length === 0) {
 		return [];
@@ -143,20 +136,11 @@ export async function processGeneratedImagesToParts(config: GeneratedImageProces
 			continue;
 		}
 
-		const resolvedThoughtSignature = await resolveThoughtSignature(img);
-
 		const part: any = {
 			inlineData: { data: base64, mimeType: img.mimeType }
 		};
 		if (!suppressThoughtSignature) {
-			part.thoughtSignature =
-				resolvedThoughtSignature ?? (enforceThoughtSignatures ? skipThoughtSignatureValidator : undefined);
-		}
-		if (includeOpenRouterReasoningDetails && img.thoughtSignatureReasoningDetail) {
-			part.thoughtSignatureReasoningDetail = img.thoughtSignatureReasoningDetail;
-		}
-		if (img.thought) {
-			part.thought = img.thought;
+			part.thoughtSignature = enforceThoughtSignatures ? skipThoughtSignatureValidator : undefined;
 		}
 		parts.push(part);
 	}

--- a/src/utils/chatHistoryBuilder.ts
+++ b/src/utils/chatHistoryBuilder.ts
@@ -14,58 +14,6 @@ import * as helpers from "./helpers";
 import { resolveAttachmentFile, resolveGeneratedImageSrc } from "./blobResolver";
 
 // ================================================================================
-// INDEX FINDING
-// ================================================================================
-
-/**
- * Finds the index of the last visible message containing generated images.
- * Returns -1 if no such message exists.
- */
-export function findLastGeneratedImageIndex(content: Message[]): number {
-	for (let i = content.length - 1; i >= 0; i--) {
-		const message = content[i];
-		if (message.hidden) continue;
-		if (message.generatedImages && message.generatedImages.length > 0) {
-			return i;
-		}
-	}
-	return -1;
-}
-
-/**
- * Finds the index of the last visible message containing attachments.
- * Returns -1 if no such message exists.
- */
-export function findLastAttachmentIndex(content: Message[]): number {
-	for (let i = content.length - 1; i >= 0; i--) {
-		const message = content[i];
-		if (message.hidden) continue;
-		if (message.parts.some((part) => part.attachments && part.attachments.length > 0)) {
-			return i;
-		}
-	}
-	return -1;
-}
-
-/**
- * Result of finding relevant message indices for history construction.
- */
-export interface MessageIndices {
-	lastImageIndex: number;
-	lastAttachmentIndex: number;
-}
-
-/**
- * Finds both last image and last attachment indices in one pass.
- */
-export function findMediaIndices(content: Message[]): MessageIndices {
-	return {
-		lastImageIndex: findLastGeneratedImageIndex(content),
-		lastAttachmentIndex: findLastAttachmentIndex(content)
-	};
-}
-
-// ================================================================================
 // PART PROCESSING
 // ================================================================================
 

--- a/src/utils/groupChatHistory.ts
+++ b/src/utils/groupChatHistory.ts
@@ -47,14 +47,12 @@ export async function constructGeminiChatHistoryForGroupChat(
 
 			if (text.trim().length > 0) {
 				const partObj: any = { text: maybePrefixSpeaker(text, speaker) };
-				const canUseStoredSignature =
-					dbMessage.role === "model" && !isOpenRouterModel(dbMessage.originModel || "");
+				const isModelMessage = dbMessage.role === "model";
+				const canUseStoredSignature = isModelMessage && !isOpenRouterModel(dbMessage.originModel || "");
 				const resolvedSignature = canUseStoredSignature ? await resolveThoughtSignature(part) : undefined;
 				const ts =
 					resolvedSignature ||
-					(canUseStoredSignature && shouldEnforceThoughtSignatures
-						? args.skipThoughtSignatureValidator
-						: undefined);
+					(isModelMessage && shouldEnforceThoughtSignatures ? args.skipThoughtSignatureValidator : undefined);
 				if (ts && !hasThoughtSignature) {
 					partObj.thoughtSignature = ts;
 					hasThoughtSignature = true;

--- a/src/utils/groupChatHistory.ts
+++ b/src/utils/groupChatHistory.ts
@@ -19,6 +19,7 @@ export async function constructGeminiChatHistoryForGroupChat(
 		speakerNameById: Map<string, string>;
 		userName: string;
 		enforceThoughtSignatures?: boolean;
+		includeOpenRouterReasoningDetails?: boolean;
 		skipThoughtSignatureValidator: string;
 	}
 ): Promise<{ history: Content[]; pinnedHistoryIndices: number[] }> {
@@ -69,7 +70,8 @@ export async function constructGeminiChatHistoryForGroupChat(
 			images: dbMessage.generatedImages,
 			shouldProcess: !!dbMessage.generatedImages && index === lastImageIndex,
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
-			skipThoughtSignatureValidator: args.skipThoughtSignatureValidator
+			skipThoughtSignatureValidator: args.skipThoughtSignatureValidator,
+			includeOpenRouterReasoningDetails: args.includeOpenRouterReasoningDetails === true
 		});
 		if (imageParts.length > 0) {
 			genAiMessage.parts?.push(...imageParts);

--- a/src/utils/groupChatHistory.ts
+++ b/src/utils/groupChatHistory.ts
@@ -6,6 +6,7 @@ import type { DbChat } from "../types/Chat";
 import { NARRATOR_PERSONALITY_ID } from "./personalityMarkers";
 import { maybePrefixSpeaker } from "./chatHistory";
 import { processAttachmentsToParts, processGeneratedImagesToParts } from "./chatHistoryBuilder";
+import { resolveThoughtSignature } from "./blobResolver";
 
 export async function constructGeminiChatHistoryForGroupChat(
 	currentChat: DbChat,
@@ -45,7 +46,12 @@ export async function constructGeminiChatHistoryForGroupChat(
 
 			if (text.trim().length > 0) {
 				const partObj: any = { text: maybePrefixSpeaker(text, speaker) };
-				const ts = shouldEnforceThoughtSignatures ? args.skipThoughtSignatureValidator : undefined;
+				const resolvedSignature = dbMessage.role === "model" ? await resolveThoughtSignature(part) : undefined;
+				const ts =
+					resolvedSignature ||
+					(dbMessage.role === "model" && shouldEnforceThoughtSignatures
+						? args.skipThoughtSignatureValidator
+						: undefined);
 				if (ts && !hasThoughtSignature) {
 					partObj.thoughtSignature = ts;
 					hasThoughtSignature = true;

--- a/src/utils/groupChatHistory.ts
+++ b/src/utils/groupChatHistory.ts
@@ -5,12 +5,7 @@ import type { DbChat } from "../types/Chat";
 
 import { NARRATOR_PERSONALITY_ID } from "./personalityMarkers";
 import { maybePrefixSpeaker } from "./chatHistory";
-import {
-	findLastAttachmentIndex,
-	findLastGeneratedImageIndex,
-	processAttachmentsToParts,
-	processGeneratedImagesToParts
-} from "./chatHistoryBuilder";
+import { processAttachmentsToParts, processGeneratedImagesToParts } from "./chatHistoryBuilder";
 
 export async function constructGeminiChatHistoryForGroupChat(
 	currentChat: DbChat,
@@ -31,9 +26,6 @@ export async function constructGeminiChatHistoryForGroupChat(
 		const id = (m.personalityid ?? "").toString();
 		return args.speakerNameById.get(id) ?? "Unknown";
 	};
-
-	const lastImageIndex = findLastGeneratedImageIndex(currentChat.content);
-	const lastAttachmentIndex = findLastAttachmentIndex(currentChat.content);
 
 	for (let index = 0; index < currentChat.content.length; index++) {
 		const dbMessage = currentChat.content[index];
@@ -63,7 +55,7 @@ export async function constructGeminiChatHistoryForGroupChat(
 
 			const attachmentParts = await processAttachmentsToParts({
 				attachments,
-				shouldProcess: attachments.length > 0 && index === lastAttachmentIndex
+				shouldProcess: attachments.length > 0
 			});
 			aggregatedParts.push(...attachmentParts);
 		}
@@ -72,7 +64,7 @@ export async function constructGeminiChatHistoryForGroupChat(
 
 		const imageParts = await processGeneratedImagesToParts({
 			images: dbMessage.generatedImages,
-			shouldProcess: !!dbMessage.generatedImages && index === lastImageIndex,
+			shouldProcess: !!dbMessage.generatedImages,
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
 			skipThoughtSignatureValidator: args.skipThoughtSignatureValidator,
 			suppressThoughtSignature: hasThoughtSignature

--- a/src/utils/groupChatHistory.ts
+++ b/src/utils/groupChatHistory.ts
@@ -75,6 +75,9 @@ export async function constructGeminiChatHistoryForGroupChat(
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
 			skipThoughtSignatureValidator: args.skipThoughtSignatureValidator,
 			suppressThoughtSignature: hasThoughtSignature,
+			// Mirror the single-chat builder: OpenRouter image signatures are
+			// incompatible with Gemini, so disallow reuse (see the
+			// SKIP_THOUGHT_SIGNATURE_VALIDATOR doc in Message.service.ts).
 			allowStoredThoughtSignatures: !isOpenRouterModel(dbMessage.originModel || "")
 		});
 		if (imageParts.length > 0) {

--- a/src/utils/groupChatHistory.ts
+++ b/src/utils/groupChatHistory.ts
@@ -7,6 +7,7 @@ import { NARRATOR_PERSONALITY_ID } from "./personalityMarkers";
 import { maybePrefixSpeaker } from "./chatHistory";
 import { processAttachmentsToParts, processGeneratedImagesToParts } from "./chatHistoryBuilder";
 import { resolveThoughtSignature } from "./blobResolver";
+import { isOpenRouterModel } from "../types/Models";
 
 export async function constructGeminiChatHistoryForGroupChat(
 	currentChat: DbChat,
@@ -46,10 +47,12 @@ export async function constructGeminiChatHistoryForGroupChat(
 
 			if (text.trim().length > 0) {
 				const partObj: any = { text: maybePrefixSpeaker(text, speaker) };
-				const resolvedSignature = dbMessage.role === "model" ? await resolveThoughtSignature(part) : undefined;
+				const canUseStoredSignature =
+					dbMessage.role === "model" && !isOpenRouterModel(dbMessage.originModel || "");
+				const resolvedSignature = canUseStoredSignature ? await resolveThoughtSignature(part) : undefined;
 				const ts =
 					resolvedSignature ||
-					(dbMessage.role === "model" && shouldEnforceThoughtSignatures
+					(canUseStoredSignature && shouldEnforceThoughtSignatures
 						? args.skipThoughtSignatureValidator
 						: undefined);
 				if (ts && !hasThoughtSignature) {

--- a/src/utils/groupChatHistory.ts
+++ b/src/utils/groupChatHistory.ts
@@ -45,6 +45,7 @@ export async function constructGeminiChatHistoryForGroupChat(
 
 		const aggregatedParts: any[] = [];
 		const speaker = speakerNameForMessage(dbMessage);
+		let hasThoughtSignature = false;
 
 		for (const part of dbMessage.parts) {
 			const text = (part.text || "").toString();
@@ -60,9 +61,16 @@ export async function constructGeminiChatHistoryForGroupChat(
 				if (part.thought) {
 					partObj.thought = true;
 				}
-				partObj.thoughtSignature =
+				if (args.includeOpenRouterReasoningDetails === true && part.reasoningDetail) {
+					partObj.reasoningDetail = part.reasoningDetail;
+				}
+				const ts =
 					resolvedThoughtSignature ??
 					(!part.thought && shouldEnforceThoughtSignatures ? args.skipThoughtSignatureValidator : undefined);
+				if (ts && !hasThoughtSignature) {
+					partObj.thoughtSignature = ts;
+					hasThoughtSignature = true;
+				}
 				aggregatedParts.push(partObj);
 			}
 
@@ -80,7 +88,8 @@ export async function constructGeminiChatHistoryForGroupChat(
 			shouldProcess: !!dbMessage.generatedImages && index === lastImageIndex,
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
 			skipThoughtSignatureValidator: args.skipThoughtSignatureValidator,
-			includeOpenRouterReasoningDetails: args.includeOpenRouterReasoningDetails === true
+			includeOpenRouterReasoningDetails: args.includeOpenRouterReasoningDetails === true,
+			suppressThoughtSignature: hasThoughtSignature
 		});
 		if (imageParts.length > 0) {
 			genAiMessage.parts?.push(...imageParts);

--- a/src/utils/groupChatHistory.ts
+++ b/src/utils/groupChatHistory.ts
@@ -74,7 +74,8 @@ export async function constructGeminiChatHistoryForGroupChat(
 			shouldProcess: !!dbMessage.generatedImages,
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
 			skipThoughtSignatureValidator: args.skipThoughtSignatureValidator,
-			suppressThoughtSignature: hasThoughtSignature
+			suppressThoughtSignature: hasThoughtSignature,
+			allowStoredThoughtSignatures: !isOpenRouterModel(dbMessage.originModel || "")
 		});
 		if (imageParts.length > 0) {
 			genAiMessage.parts?.push(...imageParts);

--- a/src/utils/groupChatHistory.ts
+++ b/src/utils/groupChatHistory.ts
@@ -20,12 +20,14 @@ export async function constructGeminiChatHistoryForGroupChat(
 		userName: string;
 		enforceThoughtSignatures?: boolean;
 		includeOpenRouterReasoningDetails?: boolean;
+		includeThoughtParts?: boolean;
 		skipThoughtSignatureValidator: string;
 	}
 ): Promise<{ history: Content[]; pinnedHistoryIndices: number[] }> {
 	const history: Content[] = [];
 	const pinnedHistoryIndices: number[] = [];
 	const shouldEnforceThoughtSignatures = args.enforceThoughtSignatures === true;
+	const shouldIncludeThoughtParts = args.includeThoughtParts === true;
 
 	const speakerNameForMessage = (m: Message): string => {
 		if (m.role === "user") return (args.userName || "User").toString();
@@ -48,12 +50,19 @@ export async function constructGeminiChatHistoryForGroupChat(
 			const text = (part.text || "").toString();
 			const attachments = part.attachments || [];
 
+			if (part.thought && !shouldIncludeThoughtParts) {
+				continue;
+			}
+
 			if (text.trim().length > 0 || part.thoughtSignature || part._thoughtSignatureRef) {
 				const resolvedThoughtSignature = await resolveThoughtSignature(part);
-				const partObj: any = { text: maybePrefixSpeaker(text, speaker) };
+				const partObj: any = { text: part.thought ? text : maybePrefixSpeaker(text, speaker) };
+				if (part.thought) {
+					partObj.thought = true;
+				}
 				partObj.thoughtSignature =
 					resolvedThoughtSignature ??
-					(shouldEnforceThoughtSignatures ? args.skipThoughtSignatureValidator : undefined);
+					(!part.thought && shouldEnforceThoughtSignatures ? args.skipThoughtSignatureValidator : undefined);
 				aggregatedParts.push(partObj);
 			}
 

--- a/src/utils/groupChatHistory.ts
+++ b/src/utils/groupChatHistory.ts
@@ -11,7 +11,6 @@ import {
 	processAttachmentsToParts,
 	processGeneratedImagesToParts
 } from "./chatHistoryBuilder";
-import { resolveThoughtSignature } from "./blobResolver";
 
 export async function constructGeminiChatHistoryForGroupChat(
 	currentChat: DbChat,
@@ -19,15 +18,12 @@ export async function constructGeminiChatHistoryForGroupChat(
 		speakerNameById: Map<string, string>;
 		userName: string;
 		enforceThoughtSignatures?: boolean;
-		includeOpenRouterReasoningDetails?: boolean;
-		includeThoughtParts?: boolean;
 		skipThoughtSignatureValidator: string;
 	}
 ): Promise<{ history: Content[]; pinnedHistoryIndices: number[] }> {
 	const history: Content[] = [];
 	const pinnedHistoryIndices: number[] = [];
 	const shouldEnforceThoughtSignatures = args.enforceThoughtSignatures === true;
-	const shouldIncludeThoughtParts = args.includeThoughtParts === true;
 
 	const speakerNameForMessage = (m: Message): string => {
 		if (m.role === "user") return (args.userName || "User").toString();
@@ -51,22 +47,13 @@ export async function constructGeminiChatHistoryForGroupChat(
 			const text = (part.text || "").toString();
 			const attachments = part.attachments || [];
 
-			if (part.thought && !shouldIncludeThoughtParts) {
+			if (part.thought) {
 				continue;
 			}
 
-			if (text.trim().length > 0 || part.thoughtSignature || part._thoughtSignatureRef) {
-				const resolvedThoughtSignature = await resolveThoughtSignature(part);
-				const partObj: any = { text: part.thought ? text : maybePrefixSpeaker(text, speaker) };
-				if (part.thought) {
-					partObj.thought = true;
-				}
-				if (args.includeOpenRouterReasoningDetails === true && part.reasoningDetail) {
-					partObj.reasoningDetail = part.reasoningDetail;
-				}
-				const ts =
-					resolvedThoughtSignature ??
-					(!part.thought && shouldEnforceThoughtSignatures ? args.skipThoughtSignatureValidator : undefined);
+			if (text.trim().length > 0) {
+				const partObj: any = { text: maybePrefixSpeaker(text, speaker) };
+				const ts = shouldEnforceThoughtSignatures ? args.skipThoughtSignatureValidator : undefined;
 				if (ts && !hasThoughtSignature) {
 					partObj.thoughtSignature = ts;
 					hasThoughtSignature = true;
@@ -88,7 +75,6 @@ export async function constructGeminiChatHistoryForGroupChat(
 			shouldProcess: !!dbMessage.generatedImages && index === lastImageIndex,
 			enforceThoughtSignatures: shouldEnforceThoughtSignatures,
 			skipThoughtSignatureValidator: args.skipThoughtSignatureValidator,
-			includeOpenRouterReasoningDetails: args.includeOpenRouterReasoningDetails === true,
 			suppressThoughtSignature: hasThoughtSignature
 		});
 		if (imageParts.length > 0) {

--- a/tests/integration/messages/roleplay-composer-model-dropdown.test.ts
+++ b/tests/integration/messages/roleplay-composer-model-dropdown.test.ts
@@ -135,9 +135,13 @@ describe("roleplay suggestion model dropdown", () => {
 
 		const expectedModels = [
 			"Gemini 3.1 Flash Lite",
+			"Gemini 3.1 Flash Lite via OpenRouter",
 			"Gemini 3 Flash Preview",
+			"Gemini 3 Flash Preview via OpenRouter",
 			"Gemini 3.5 Flash",
+			"Gemini 3.5 Flash via OpenRouter",
 			"Gemini 3.1 Pro Preview",
+			"Gemini 3.1 Pro Preview via OpenRouter",
 			"GPT-OSS 120B",
 			"Claude Sonnet 4.6",
 			"GLM 5",

--- a/tests/integration/settings/premium-endpoint-sync.test.ts
+++ b/tests/integration/settings/premium-endpoint-sync.test.ts
@@ -84,7 +84,7 @@ describe("premium endpoint synced settings", () => {
 
 	it("reapplies model-driven thinking constraints after synced settings replace stale local state", async () => {
 		localStorage.setItem(SETTINGS_STORAGE_KEYS.API_KEY, "local-gemini-key");
-		localStorage.setItem(SETTINGS_STORAGE_KEYS.MODEL, "gemini-3.5-flash");
+		localStorage.setItem(SETTINGS_STORAGE_KEYS.MODEL, "gemini-3-flash-preview");
 		localStorage.setItem(SETTINGS_STORAGE_KEYS.ENABLE_THINKING, "false");
 
 		await import("../../../src/components/static/ModelSelector.component");
@@ -99,7 +99,7 @@ describe("premium endpoint synced settings", () => {
 		const thinkingBudget = document.querySelector<HTMLInputElement>("#thinkingBudget");
 		const thinkingHint = document.querySelector<HTMLDivElement>("#thinking-required-hint");
 
-		expect(modelSelect?.value).toBe("gemini-3.5-flash");
+		expect(modelSelect?.value).toBe("gemini-3-flash-preview");
 		expect(thinkingSelect?.value).toBe("disabled");
 		expect(thinkingSelect?.disabled).toBe(false);
 		expect(thinkingBudget?.disabled).toBe(true);

--- a/tests/unit/chat-history-builder.test.ts
+++ b/tests/unit/chat-history-builder.test.ts
@@ -4,14 +4,20 @@ vi.mock("../../src/utils/helpers", () => ({
 	fileToBase64: vi.fn()
 }));
 
+vi.mock("@google/genai", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@google/genai")>()),
+	createPartFromBase64: vi.fn(async (data: string, mimeType: string) => ({ inlineData: { data, mimeType } }))
+}));
+
 vi.mock("../../src/utils/blobResolver", () => ({
 	resolveAttachmentFile: vi.fn(),
 	resolveGeneratedImageSrc: vi.fn(),
 	resolveThoughtSignature: vi.fn(async (target: { thoughtSignature?: string }) => target.thoughtSignature)
 }));
 
-import { processGeneratedImagesToParts } from "../../src/utils/chatHistoryBuilder";
-import { resolveThoughtSignature } from "../../src/utils/blobResolver";
+import { processAttachmentsToParts, processGeneratedImagesToParts } from "../../src/utils/chatHistoryBuilder";
+import { fileToBase64 } from "../../src/utils/helpers";
+import { resolveAttachmentFile, resolveThoughtSignature } from "../../src/utils/blobResolver";
 
 describe("processGeneratedImagesToParts", () => {
 	it("preserves stored generated-image thought signatures for Gemini history", async () => {
@@ -73,5 +79,31 @@ describe("processGeneratedImagesToParts", () => {
 				thoughtSignature: undefined
 			}
 		]);
+	});
+});
+
+describe("processAttachmentsToParts", () => {
+	it("resolves blob-backed attachments before creating Gemini inline data", async () => {
+		const placeholder = new File([], "image.png", { type: "image/png" });
+		const resolved = new File([new Uint8Array([1, 2, 3])], "image.png", { type: "image/png" });
+		(placeholder as any)._blobRef = { blobId: "blob-1", path: "sync/blob-1", size: 3, mimeType: "image/png" };
+		vi.mocked(resolveAttachmentFile).mockResolvedValueOnce(resolved);
+		vi.mocked(fileToBase64).mockResolvedValueOnce("resolved-image-base64");
+
+		const parts = await processAttachmentsToParts({ attachments: [placeholder], shouldProcess: true });
+
+		expect(resolveAttachmentFile).toHaveBeenCalledWith(placeholder);
+		expect(fileToBase64).toHaveBeenCalledWith(resolved);
+		expect(parts).toEqual([{ inlineData: { data: "resolved-image-base64", mimeType: "image/png" } }]);
+	});
+
+	it("skips attachments that resolve to empty base64", async () => {
+		const unresolved = new File([], "image.png", { type: "image/png" });
+		vi.mocked(resolveAttachmentFile).mockResolvedValueOnce(unresolved);
+		vi.mocked(fileToBase64).mockResolvedValueOnce("");
+
+		const parts = await processAttachmentsToParts({ attachments: [unresolved], shouldProcess: true });
+
+		expect(parts).toEqual([]);
 	});
 });

--- a/tests/unit/chat-history-builder.test.ts
+++ b/tests/unit/chat-history-builder.test.ts
@@ -80,6 +80,30 @@ describe("processGeneratedImagesToParts", () => {
 			}
 		]);
 	});
+
+	it("uses the skip validator when stored generated-image signatures are disallowed", async () => {
+		const parts = await processGeneratedImagesToParts({
+			images: [
+				{
+					mimeType: "image/png",
+					base64: "openrouter-image-base64",
+					thoughtSignature: "openrouter-encrypted-signature"
+				}
+			],
+			shouldProcess: true,
+			enforceThoughtSignatures: true,
+			skipThoughtSignatureValidator: "skip_thought_signature_validator",
+			suppressThoughtSignature: true,
+			allowStoredThoughtSignatures: false
+		});
+
+		expect(parts).toEqual([
+			{
+				inlineData: { data: "openrouter-image-base64", mimeType: "image/png" },
+				thoughtSignature: "skip_thought_signature_validator"
+			}
+		]);
+	});
 });
 
 describe("processAttachmentsToParts", () => {

--- a/tests/unit/chat-history-builder.test.ts
+++ b/tests/unit/chat-history-builder.test.ts
@@ -5,7 +5,7 @@ vi.mock("../../src/utils/helpers", () => ({
 }));
 
 vi.mock("@google/genai", async (importOriginal) => ({
-	...(await importOriginal<typeof import("@google/genai")>()),
+	...(await importOriginal()),
 	createPartFromBase64: vi.fn(async (data: string, mimeType: string) => ({ inlineData: { data, mimeType } }))
 }));
 

--- a/tests/unit/chat-history-builder.test.ts
+++ b/tests/unit/chat-history-builder.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/utils/helpers", () => ({
+	fileToBase64: vi.fn()
+}));
+
+vi.mock("../../src/utils/blobResolver", () => ({
+	resolveAttachmentFile: vi.fn(),
+	resolveGeneratedImageSrc: vi.fn(),
+	resolveThoughtSignature: vi.fn(async (target: { thoughtSignature?: string }) => target.thoughtSignature)
+}));
+
+import { processGeneratedImagesToParts } from "../../src/utils/chatHistoryBuilder";
+import { resolveThoughtSignature } from "../../src/utils/blobResolver";
+
+describe("processGeneratedImagesToParts", () => {
+	it("preserves stored generated-image thought signatures for Gemini history", async () => {
+		const parts = await processGeneratedImagesToParts({
+			images: [
+				{
+					mimeType: "image/png",
+					base64: "generated-image-base64",
+					thoughtSignature: "provider-image-signature"
+				}
+			],
+			shouldProcess: true,
+			enforceThoughtSignatures: true,
+			skipThoughtSignatureValidator: "skip_thought_signature_validator",
+			suppressThoughtSignature: true
+		});
+
+		expect(parts).toEqual([
+			{
+				inlineData: { data: "generated-image-base64", mimeType: "image/png" },
+				thoughtSignature: "provider-image-signature"
+			}
+		]);
+		expect(resolveThoughtSignature).toHaveBeenCalledWith(
+			expect.objectContaining({ thoughtSignature: "provider-image-signature" })
+		);
+	});
+
+	it("falls back to the skip validator only when no stored image signature exists", async () => {
+		const parts = await processGeneratedImagesToParts({
+			images: [{ mimeType: "image/png", base64: "generated-image-base64" }],
+			shouldProcess: true,
+			enforceThoughtSignatures: true,
+			skipThoughtSignatureValidator: "skip_thought_signature_validator"
+		});
+
+		expect(parts).toEqual([
+			{
+				inlineData: { data: "generated-image-base64", mimeType: "image/png" },
+				thoughtSignature: "skip_thought_signature_validator"
+			}
+		]);
+	});
+
+	it("does not include thought images in rebuilt Gemini history", async () => {
+		const parts = await processGeneratedImagesToParts({
+			images: [
+				{ mimeType: "image/png", base64: "thought-image-base64", thought: true },
+				{ mimeType: "image/png", base64: "visible-image-base64" }
+			],
+			shouldProcess: true,
+			enforceThoughtSignatures: false,
+			skipThoughtSignatureValidator: "skip_thought_signature_validator"
+		});
+
+		expect(parts).toEqual([
+			{
+				inlineData: { data: "visible-image-base64", mimeType: "image/png" },
+				thoughtSignature: undefined
+			}
+		]);
+	});
+});

--- a/tests/unit/gemini-response-processor.test.ts
+++ b/tests/unit/gemini-response-processor.test.ts
@@ -62,4 +62,49 @@ describe("Gemini response processing", () => {
 		expect(result.thinking).toBe("");
 		expect(result.responseParts[0]).toEqual({ text: "hidden reasoning", thought: true });
 	});
+
+	it("keeps thought inline images out of visible generated images", async () => {
+		const result = await processGeminiLocalSdkResponse({
+			response: {
+				candidates: [
+					{
+						content: {
+							parts: [
+								{
+									inlineData: { data: "thought-image-base64", mimeType: "image/jpeg" },
+									thought: true
+								},
+								{
+									inlineData: { data: "visible-image-base64", mimeType: "image/jpeg" },
+									thoughtSignature: "visible-image-signature"
+								}
+							]
+						}
+					}
+				]
+			} as any,
+			process: {
+				includeThoughts: true,
+				useSkipThoughtSignature: false,
+				skipThoughtSignatureValidator: "skip_thought_signature_validator",
+				abortMode: "return",
+				throwOnBlocked: false
+			}
+		});
+
+		expect(result.responseParts).toEqual([
+			{
+				inlineData: { data: "thought-image-base64", mimeType: "image/jpeg" },
+				thought: true
+			}
+		]);
+		expect(result.images).toEqual([
+			{
+				mimeType: "image/jpeg",
+				base64: "visible-image-base64",
+				thoughtSignature: "visible-image-signature",
+				thought: undefined
+			}
+		]);
+	});
 });

--- a/tests/unit/gemini-response-processor.test.ts
+++ b/tests/unit/gemini-response-processor.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { processGeminiLocalSdkResponse } from "../../src/services/GeminiResponseProcessor.service";
+
+describe("Gemini response processing", () => {
+	it("preserves thought parts separately from visible answer text", async () => {
+		const result = await processGeminiLocalSdkResponse({
+			response: {
+				candidates: [
+					{
+						content: {
+							parts: [
+								{ text: "hidden reasoning", thought: true },
+								{ text: "visible answer", thoughtSignature: "answer-signature" }
+							]
+						},
+						finishReason: "STOP"
+					}
+				]
+			} as any,
+			process: {
+				includeThoughts: true,
+				useSkipThoughtSignature: false,
+				skipThoughtSignatureValidator: "skip_thought_signature_validator",
+				abortMode: "return",
+				throwOnBlocked: false
+			}
+		});
+
+		expect(result.thinking).toBe("hidden reasoning");
+		expect(result.text).toBe("visible answer");
+		expect(result.textSignature).toBe("answer-signature");
+		expect(result.responseParts).toEqual([
+			{ text: "hidden reasoning", thought: true },
+			{ text: "visible answer", thoughtSignature: "answer-signature" }
+		]);
+	});
+
+	it("keeps thought parts for history when reasoning display is disabled", async () => {
+		const result = await processGeminiLocalSdkResponse({
+			response: {
+				candidates: [
+					{
+						content: {
+							parts: [
+								{ text: "hidden reasoning", thought: true },
+								{ text: "visible answer", thoughtSignature: "answer-signature" }
+							]
+						}
+					}
+				]
+			} as any,
+			process: {
+				includeThoughts: false,
+				useSkipThoughtSignature: false,
+				skipThoughtSignatureValidator: "skip_thought_signature_validator",
+				abortMode: "return",
+				throwOnBlocked: false
+			}
+		});
+
+		expect(result.thinking).toBe("");
+		expect(result.responseParts[0]).toEqual({ text: "hidden reasoning", thought: true });
+	});
+});

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -4,6 +4,7 @@ import {
 	DEFAULT_OPENROUTER_TITLE_MODEL,
 	getAccessibleRoleplaySuggestionModels,
 	getValidRoleplaySuggestionModel,
+	modelRequiresThinking,
 	type ChatModelAccess
 } from "../../src/types/Models";
 
@@ -14,6 +15,11 @@ describe("default model roles", () => {
 });
 
 describe("roleplay suggestion models", () => {
+	it("requires thinking for Gemini 3.5 Flash local and OpenRouter variants", () => {
+		expect(modelRequiresThinking("gemini-3.5-flash")).toBe(true);
+		expect(modelRequiresThinking("google/gemini-3.5-flash")).toBe(true);
+	});
+
 	it("includes only models flagged for roleplay suggestions", () => {
 		const fullAccess: ChatModelAccess = { hasGeminiAccess: true, hasOpenRouterAccess: true };
 

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	DEFAULT_OPENROUTER_TITLE_MODEL,
 	getAccessibleRoleplaySuggestionModels,
 	getValidRoleplaySuggestionModel,
 	type ChatModelAccess
 } from "../../src/types/Models";
+
+describe("default model roles", () => {
+	it("uses GLM 5 for local OpenRouter chat title generation", () => {
+		expect(DEFAULT_OPENROUTER_TITLE_MODEL).toBe("z-ai/glm-5");
+	});
+});
 
 describe("roleplay suggestion models", () => {
 	it("includes only models flagged for roleplay suggestions", () => {

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -63,6 +63,11 @@ describe("roleplay suggestion models", () => {
 		expect(modelRequiresThinking("google/gemini-3.5-flash")).toBe(true);
 	});
 
+	it("requires thinking for Nano Banana Pro local and OpenRouter variants", () => {
+		expect(modelRequiresThinking("gemini-3-pro-image-preview")).toBe(true);
+		expect(modelRequiresThinking("google/gemini-3-pro-image-preview")).toBe(true);
+	});
+
 	it("includes only models flagged for roleplay suggestions", () => {
 		const fullAccess: ChatModelAccess = { hasGeminiAccess: true, hasOpenRouterAccess: true };
 

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { getAccessibleRoleplaySuggestionModels, type ChatModelAccess } from "../../src/types/Models";
+import {
+	getAccessibleRoleplaySuggestionModels,
+	getValidRoleplaySuggestionModel,
+	type ChatModelAccess
+} from "../../src/types/Models";
 
 describe("roleplay suggestion models", () => {
 	it("includes only models flagged for roleplay suggestions", () => {
@@ -8,9 +12,13 @@ describe("roleplay suggestion models", () => {
 
 		const expectedModels = [
 			"Gemini 3.1 Flash Lite",
+			"Gemini 3.1 Flash Lite via OpenRouter",
 			"Gemini 3 Flash Preview",
+			"Gemini 3 Flash Preview via OpenRouter",
 			"Gemini 3.5 Flash",
+			"Gemini 3.5 Flash via OpenRouter",
 			"Gemini 3.1 Pro Preview",
+			"Gemini 3.1 Pro Preview via OpenRouter",
 			"GPT-OSS 120B",
 			"Claude Sonnet 4.6",
 			"GLM 5",
@@ -20,5 +28,15 @@ describe("roleplay suggestion models", () => {
 		const receivedModels = getAccessibleRoleplaySuggestionModels(fullAccess).map((model) => model.label);
 
 		expect(receivedModels.sort()).toEqual(expectedModels.sort());
+	});
+
+	it("maps local-only Gemini suggestion models to OpenRouter variants for premium endpoint access", () => {
+		const premiumAccess: ChatModelAccess = {
+			hasGeminiAccess: true,
+			hasOpenRouterAccess: true,
+			isPremiumEndpointPreferred: true
+		};
+
+		expect(getValidRoleplaySuggestionModel("gemini-3.5-flash", premiumAccess)).toBe("google/gemini-3.5-flash");
 	});
 });

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
 	DEFAULT_OPENROUTER_TITLE_MODEL,
 	getAccessibleRoleplaySuggestionModels,
+	getChatModelDefinition,
+	getPremiumEndpointChatModel,
+	getValidChatModel,
 	getValidRoleplaySuggestionModel,
 	modelRequiresThinking,
 	type ChatModelAccess
@@ -11,6 +14,38 @@ import {
 describe("default model roles", () => {
 	it("uses GLM 5 for local OpenRouter chat title generation", () => {
 		expect(DEFAULT_OPENROUTER_TITLE_MODEL).toBe("z-ai/glm-5");
+	});
+});
+
+describe("premium endpoint model mapping", () => {
+	it("maps Nano Banana hybrid models to OpenRouter variants", () => {
+		const premiumAccess: ChatModelAccess = {
+			hasGeminiAccess: true,
+			hasOpenRouterAccess: true,
+			isPremiumEndpointPreferred: true
+		};
+
+		expect(getPremiumEndpointChatModel("gemini-2.5-flash-image")).toBe("google/gemini-2.5-flash-image");
+		expect(getValidChatModel("gemini-2.5-flash-image", premiumAccess)).toBe("google/gemini-2.5-flash-image");
+		expect(getValidChatModel("gemini-3-pro-image-preview", premiumAccess)).toBe(
+			"google/gemini-3-pro-image-preview"
+		);
+		expect(getValidChatModel("gemini-3.1-flash-image-preview", premiumAccess)).toBe(
+			"google/gemini-3.1-flash-image-preview"
+		);
+	});
+
+	it("keeps OpenRouter Nano Banana variants as image-output chat models", () => {
+		const models = [
+			"google/gemini-2.5-flash-image",
+			"google/gemini-3-pro-image-preview",
+			"google/gemini-3.1-flash-image-preview"
+		];
+
+		for (const model of models) {
+			expect(getChatModelDefinition(model)?.provider).toBe("openrouter");
+			expect(getChatModelDefinition(model)?.supportsImageOutput).toBe(true);
+		}
 	});
 });
 

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -18,6 +18,14 @@ describe("default model roles", () => {
 });
 
 describe("premium endpoint model mapping", () => {
+	it("keeps local Nano Banana as a local-only Gemini SDK model", () => {
+		const localNanoBanana = getChatModelDefinition("gemini-2.5-flash-image");
+
+		expect(localNanoBanana?.provider).toBe("gemini");
+		expect(localNanoBanana?.localOnly).toBe(true);
+		expect(localNanoBanana?.supportsImageOutput).toBe(true);
+	});
+
 	it("maps Nano Banana hybrid models to OpenRouter variants", () => {
 		const premiumAccess: ChatModelAccess = {
 			hasGeminiAccess: true,

--- a/tests/unit/openrouter-history.test.ts
+++ b/tests/unit/openrouter-history.test.ts
@@ -131,7 +131,7 @@ describe("OpenRouter history conversion", () => {
 		expect(messages).toEqual([]);
 	});
 
-	it("preserves OpenRouter response reasoning details as model response parts", async () => {
+	it("omits OpenRouter encrypted reasoning from saved model response signatures", async () => {
 		vi.stubGlobal(
 			"fetch",
 			vi.fn().mockResolvedValue(
@@ -176,7 +176,7 @@ describe("OpenRouter history conversion", () => {
 
 		expect(result.text).toBe("visible answer");
 		expect(result.thinking).toBe("hidden reasoning");
-		expect(result.textSignature).toBe("answer-signature");
+		expect(result.textSignature).toBeUndefined();
 		expect(result.responseParts).toEqual([
 			{
 				text: "hidden reasoning",
@@ -189,14 +189,7 @@ describe("OpenRouter history conversion", () => {
 				}
 			},
 			{
-				text: "visible answer",
-				thoughtSignature: "answer-signature",
-				reasoningDetail: {
-					type: "reasoning.encrypted",
-					format: "google-gemini-v1",
-					index: 1,
-					provider_extra: "encrypted-kept"
-				}
+				text: "visible answer"
 			}
 		]);
 

--- a/tests/unit/openrouter-history.test.ts
+++ b/tests/unit/openrouter-history.test.ts
@@ -1,11 +1,18 @@
 import type { Content } from "@google/genai";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/utils/helpers", () => ({
 	fileToBase64: vi.fn()
 }));
 
-import { convertGeminiHistoryToOpenRouterMessages } from "../../src/services/OpenRouter.service";
+import {
+	convertGeminiHistoryToOpenRouterMessages,
+	requestOpenRouterCompletion
+} from "../../src/services/OpenRouter.service";
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
 
 describe("OpenRouter history conversion", () => {
 	it("preserves assistant generated-image thought signatures as encrypted reasoning details", async () => {
@@ -83,6 +90,130 @@ describe("OpenRouter history conversion", () => {
 					format: "provider-returned-format-v1",
 					index: 7,
 					provider_extra: "kept"
+				}
+			]
+		});
+	});
+
+	it("converts native Gemini thought parts into OpenRouter reasoning details and deduplicates identical encrypted signatures", async () => {
+		const history = [
+			{
+				role: "model",
+				parts: [
+					{ text: "hidden reasoning", thought: true },
+					{ text: "visible answer", thoughtSignature: "answer-signature" },
+					{
+						inlineData: { data: "image-base64", mimeType: "image/png" },
+						thoughtSignature: "answer-signature"
+					}
+				]
+			}
+		] as unknown as Content[];
+
+		const messages = await convertGeminiHistoryToOpenRouterMessages(history);
+
+		expect(messages[0]).toEqual({
+			role: "assistant",
+			content: [
+				{ type: "text", text: "visible answer" },
+				{ type: "image_url", image_url: { url: "data:image/png;base64,image-base64" } }
+			],
+			reasoning_details: [
+				{ type: "reasoning.text", text: "hidden reasoning", format: "google-gemini-v1" },
+				{ type: "reasoning.encrypted", data: "answer-signature", format: "google-gemini-v1" }
+			]
+		});
+	});
+
+	it("preserves OpenRouter response reasoning details as model response parts", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						choices: [
+							{
+								finish_reason: "stop",
+								message: {
+									role: "assistant",
+									content: "visible answer",
+									reasoning: "hidden reasoning",
+									reasoning_details: [
+										{
+											type: "reasoning.text",
+											text: "hidden reasoning",
+											format: "google-gemini-v1",
+											index: 0,
+											provider_extra: "text-kept"
+										},
+										{
+											type: "reasoning.encrypted",
+											data: "answer-signature",
+											format: "google-gemini-v1",
+											index: 1,
+											provider_extra: "encrypted-kept"
+										}
+									]
+								}
+							}
+						]
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } }
+				)
+			)
+		);
+
+		const result = await requestOpenRouterCompletion({
+			apiKey: "test-key",
+			request: { stream: false, messages: [{ role: "user", content: "hi" }] }
+		});
+
+		expect(result.text).toBe("visible answer");
+		expect(result.thinking).toBe("hidden reasoning");
+		expect(result.textSignature).toBe("answer-signature");
+		expect(result.responseParts).toEqual([
+			{
+				text: "hidden reasoning",
+				thought: true,
+				reasoningDetail: {
+					type: "reasoning.text",
+					format: "google-gemini-v1",
+					index: 0,
+					provider_extra: "text-kept"
+				}
+			},
+			{
+				text: "visible answer",
+				thoughtSignature: "answer-signature",
+				reasoningDetail: {
+					type: "reasoning.encrypted",
+					format: "google-gemini-v1",
+					index: 1,
+					provider_extra: "encrypted-kept"
+				}
+			}
+		]);
+
+		const nextMessages = await convertGeminiHistoryToOpenRouterMessages([
+			{ role: "model", parts: result.responseParts }
+		] as unknown as Content[]);
+		expect(nextMessages[0]).toEqual({
+			role: "assistant",
+			content: "visible answer",
+			reasoning_details: [
+				{
+					type: "reasoning.text",
+					text: "hidden reasoning",
+					format: "google-gemini-v1",
+					index: 0,
+					provider_extra: "text-kept"
+				},
+				{
+					type: "reasoning.encrypted",
+					data: "answer-signature",
+					format: "google-gemini-v1",
+					index: 1,
+					provider_extra: "encrypted-kept"
 				}
 			]
 		});

--- a/tests/unit/openrouter-history.test.ts
+++ b/tests/unit/openrouter-history.test.ts
@@ -15,7 +15,7 @@ afterEach(() => {
 });
 
 describe("OpenRouter history conversion", () => {
-	it("preserves assistant generated-image thought signatures as encrypted reasoning details", async () => {
+	it("sends assistant generated-image history as user messages without reasoning details", async () => {
 		const history = [
 			{
 				role: "user",
@@ -43,21 +43,19 @@ describe("OpenRouter history conversion", () => {
 
 		expect(messages[0]).not.toHaveProperty("reasoning_details");
 		expect(messages[1]).toEqual({
-			role: "assistant",
+			role: "user",
 			content: [
 				{ type: "text", text: "Here is the generated image." },
 				{
 					type: "image_url",
 					image_url: { url: "data:image/png;base64,assistant-image-base64" }
 				}
-			],
-			reasoning_details: [
-				{ type: "reasoning.encrypted", data: "assistant-signature", format: "google-gemini-v1" }
 			]
 		});
+		expect(messages[1]).not.toHaveProperty("reasoning_details");
 	});
 
-	it("keeps the encrypted reasoning metadata provided by the previous OpenRouter response", async () => {
+	it("sends OpenRouter assistant image history as user messages without reasoning metadata", async () => {
 		const history = [
 			{
 				role: "model",
@@ -80,22 +78,20 @@ describe("OpenRouter history conversion", () => {
 
 		const messages = await convertGeminiHistoryToOpenRouterMessages(history);
 
-		expect(messages[0]).toMatchObject({
-			role: "assistant",
-			reasoning_details: [
+		expect(messages[0]).toEqual({
+			role: "user",
+			content: [
+				{ type: "text", text: "Generated from OpenRouter." },
 				{
-					type: "reasoning.encrypted",
-					data: "assistant-signature",
-					id: "reasoning-encrypted-previous",
-					format: "provider-returned-format-v1",
-					index: 7,
-					provider_extra: "kept"
+					type: "image_url",
+					image_url: { url: "data:image/png;base64,assistant-image-base64" }
 				}
 			]
 		});
+		expect(messages[0]).not.toHaveProperty("reasoning_details");
 	});
 
-	it("converts native Gemini thought parts into OpenRouter reasoning details and deduplicates identical encrypted signatures", async () => {
+	it("omits native Gemini thought parts and encrypted signatures from OpenRouter requests", async () => {
 		const history = [
 			{
 				role: "model",
@@ -113,16 +109,26 @@ describe("OpenRouter history conversion", () => {
 		const messages = await convertGeminiHistoryToOpenRouterMessages(history);
 
 		expect(messages[0]).toEqual({
-			role: "assistant",
+			role: "user",
 			content: [
 				{ type: "text", text: "visible answer" },
 				{ type: "image_url", image_url: { url: "data:image/png;base64,image-base64" } }
-			],
-			reasoning_details: [
-				{ type: "reasoning.text", text: "hidden reasoning", format: "google-gemini-v1" },
-				{ type: "reasoning.encrypted", data: "answer-signature", format: "google-gemini-v1" }
 			]
 		});
+		expect(messages[0]).not.toHaveProperty("reasoning_details");
+	});
+
+	it("drops history messages that contain only prior reasoning", async () => {
+		const history = [
+			{
+				role: "model",
+				parts: [{ text: "hidden reasoning only", thought: true }]
+			}
+		] as unknown as Content[];
+
+		const messages = await convertGeminiHistoryToOpenRouterMessages(history);
+
+		expect(messages).toEqual([]);
 	});
 
 	it("preserves OpenRouter response reasoning details as model response parts", async () => {
@@ -199,23 +205,8 @@ describe("OpenRouter history conversion", () => {
 		] as unknown as Content[]);
 		expect(nextMessages[0]).toEqual({
 			role: "assistant",
-			content: "visible answer",
-			reasoning_details: [
-				{
-					type: "reasoning.text",
-					text: "hidden reasoning",
-					format: "google-gemini-v1",
-					index: 0,
-					provider_extra: "text-kept"
-				},
-				{
-					type: "reasoning.encrypted",
-					data: "answer-signature",
-					format: "google-gemini-v1",
-					index: 1,
-					provider_extra: "encrypted-kept"
-				}
-			]
+			content: "visible answer"
 		});
+		expect(nextMessages[0]).not.toHaveProperty("reasoning_details");
 	});
 });

--- a/tests/unit/openrouter-history.test.ts
+++ b/tests/unit/openrouter-history.test.ts
@@ -1,0 +1,90 @@
+import type { Content } from "@google/genai";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/utils/helpers", () => ({
+	fileToBase64: vi.fn()
+}));
+
+import { convertGeminiHistoryToOpenRouterMessages } from "../../src/services/OpenRouter.service";
+
+describe("OpenRouter history conversion", () => {
+	it("preserves assistant generated-image thought signatures as encrypted reasoning details", async () => {
+		const history = [
+			{
+				role: "user",
+				parts: [
+					{ text: "Can you still see this?" },
+					{
+						inlineData: { data: "user-image-base64", mimeType: "image/png" },
+						thoughtSignature: "user-signature"
+					}
+				]
+			},
+			{
+				role: "model",
+				parts: [
+					{ text: "Here is the generated image." },
+					{
+						inlineData: { data: "assistant-image-base64", mimeType: "image/png" },
+						thoughtSignature: "assistant-signature"
+					}
+				]
+			}
+		] as unknown as Content[];
+
+		const messages = await convertGeminiHistoryToOpenRouterMessages(history);
+
+		expect(messages[0]).not.toHaveProperty("reasoning_details");
+		expect(messages[1]).toEqual({
+			role: "assistant",
+			content: [
+				{ type: "text", text: "Here is the generated image." },
+				{
+					type: "image_url",
+					image_url: { url: "data:image/png;base64,assistant-image-base64" }
+				}
+			],
+			reasoning_details: [
+				{ type: "reasoning.encrypted", data: "assistant-signature", format: "google-gemini-v1" }
+			]
+		});
+	});
+
+	it("keeps the encrypted reasoning metadata provided by the previous OpenRouter response", async () => {
+		const history = [
+			{
+				role: "model",
+				parts: [
+					{ text: "Generated from OpenRouter." },
+					{
+						inlineData: { data: "assistant-image-base64", mimeType: "image/png" },
+						thoughtSignature: "assistant-signature",
+						thoughtSignatureReasoningDetail: {
+							type: "reasoning.encrypted",
+							id: "reasoning-encrypted-previous",
+							format: "provider-returned-format-v1",
+							index: 7,
+							provider_extra: "kept"
+						}
+					}
+				]
+			}
+		] as unknown as Content[];
+
+		const messages = await convertGeminiHistoryToOpenRouterMessages(history);
+
+		expect(messages[0]).toMatchObject({
+			role: "assistant",
+			reasoning_details: [
+				{
+					type: "reasoning.encrypted",
+					data: "assistant-signature",
+					id: "reasoning-encrypted-previous",
+					format: "provider-returned-format-v1",
+					index: 7,
+					provider_extra: "kept"
+				}
+			]
+		});
+	});
+});

--- a/tests/unit/premium-endpoint-response-processor.test.ts
+++ b/tests/unit/premium-endpoint-response-processor.test.ts
@@ -19,7 +19,7 @@ function sseResponse(blocks: string[]): Response {
 }
 
 describe("premium endpoint response processing", () => {
-	it("preserves fallback encrypted reasoning as the final text signature", async () => {
+	it("does not save OpenRouter fallback encrypted reasoning as a Gemini text signature", async () => {
 		const response = sseResponse([
 			`event: fallback\ndata: ${JSON.stringify({ mode: "restart", reason: "direct_openrouter" })}\n\n`,
 			`data: ${JSON.stringify({
@@ -58,6 +58,6 @@ describe("premium endpoint response processing", () => {
 
 		expect(result.wasFallbackMode).toBe(true);
 		expect(result.text).toBe("visible answer");
-		expect(result.textSignature).toBe("fallback-signature");
+		expect(result.textSignature).toBeUndefined();
 	});
 });

--- a/tests/unit/premium-endpoint-response-processor.test.ts
+++ b/tests/unit/premium-endpoint-response-processor.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/utils/helpers", () => ({
+	fileToBase64: vi.fn()
+}));
+
+import { processPremiumEndpointSse } from "../../src/services/PremiumEndpointResponseProcessor.service";
+
+function sseResponse(blocks: string[]): Response {
+	const stream = new ReadableStream({
+		start(controller) {
+			const encoder = new TextEncoder();
+			controller.enqueue(encoder.encode(blocks.join("")));
+			controller.close();
+		}
+	});
+
+	return new Response(stream);
+}
+
+describe("premium endpoint response processing", () => {
+	it("preserves fallback encrypted reasoning as the final text signature", async () => {
+		const response = sseResponse([
+			`event: fallback\ndata: ${JSON.stringify({ mode: "restart", reason: "direct_openrouter" })}\n\n`,
+			`data: ${JSON.stringify({
+				choices: [
+					{
+						delta: {
+							content: "visible answer",
+							reasoning_details: [
+								{
+									type: "reasoning.encrypted",
+									data: "fallback-signature",
+									format: "google-gemini-v1",
+									index: 0
+								}
+							]
+						}
+					}
+				]
+			})}\n\n`,
+			"event: done\ndata: {}\n\n"
+		]);
+
+		const result = await processPremiumEndpointSse({
+			res: response,
+			process: {
+				includeThoughts: false,
+				useSkipThoughtSignature: false,
+				skipThoughtSignatureValidator: "skip_thought_signature_validator",
+				abortMode: "return",
+				throwOnBlocked: () => false,
+				onBlocked: () => {
+					throw new Error("blocked");
+				}
+			}
+		});
+
+		expect(result.wasFallbackMode).toBe(true);
+		expect(result.text).toBe("visible answer");
+		expect(result.textSignature).toBe("fallback-signature");
+	});
+});

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,13 +1,110 @@
 import basicSsl from "@vitejs/plugin-basic-ssl";
 import tailwindcss from "@tailwindcss/vite";
+import { Buffer } from "node:buffer";
+import type { IncomingMessage } from "node:http";
 import { fileURLToPath } from "node:url";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 
 const fromRoot = (path: string) => fileURLToPath(new URL(path, import.meta.url));
 
+const DEBUG_REPLAY_MAX_BODY_BYTES = 80 * 1024 * 1024;
+const DEBUG_REPLAY_ALLOWED_HOSTS = [
+	"generativelanguage.googleapis.com",
+	"aiplatform.googleapis.com",
+	"openrouter.ai"
+];
+
+function isAllowedDebugReplayHost(hostname: string): boolean {
+	return (
+		DEBUG_REPLAY_ALLOWED_HOSTS.includes(hostname) ||
+		hostname.endsWith(".supabase.co") ||
+		hostname.endsWith(".googleapis.com")
+	);
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<any> {
+	const chunks: Buffer[] = [];
+	let totalBytes = 0;
+
+	for await (const chunk of req) {
+		const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+		totalBytes += buffer.byteLength;
+		if (totalBytes > DEBUG_REPLAY_MAX_BODY_BYTES) {
+			throw new Error("Replay payload is too large.");
+		}
+		chunks.push(buffer);
+	}
+
+	return JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+}
+
+function normalizeReplayBody(body: unknown): BodyInit | undefined {
+	if (body === undefined || body === null) return undefined;
+	return typeof body === "string" ? body : JSON.stringify(body);
+}
+
+function debugReplayProxy(): Plugin {
+	return {
+		name: "zodiac-debug-replay-proxy",
+		apply: "serve",
+		configureServer(server) {
+			server.middlewares.use("/__debug/replay", (req, res) => {
+				void (async () => {
+				if (req.method !== "POST") {
+					res.statusCode = 405;
+					res.setHeader("Content-Type", "application/json");
+					res.end(JSON.stringify({ error: "Use POST" }));
+					return;
+				}
+
+				try {
+					const replay = await readJsonBody(req);
+					const url = new URL(String(replay.url || ""));
+					if (url.protocol !== "https:" || !isAllowedDebugReplayHost(url.hostname)) {
+						res.statusCode = 400;
+						res.setHeader("Content-Type", "application/json");
+						res.end(JSON.stringify({ error: `Replay host is not allowed: ${url.hostname}` }));
+						return;
+					}
+
+					const headers = new Headers(replay.headers || {});
+					headers.delete("origin");
+					headers.delete("referer");
+					headers.delete("user-agent");
+					headers.delete("content-length");
+
+					const upstream = await fetch(url, {
+						method: replay.method || "POST",
+						headers,
+						body: normalizeReplayBody(replay.body),
+						redirect: "manual"
+					});
+					const text = await upstream.text();
+
+					res.statusCode = 200;
+					res.setHeader("Content-Type", "application/json");
+					res.end(
+						JSON.stringify({
+							status: upstream.status,
+							statusText: upstream.statusText,
+							headers: Object.fromEntries(upstream.headers.entries()),
+							body: text
+						})
+					);
+				} catch (error) {
+					res.statusCode = 500;
+					res.setHeader("Content-Type", "application/json");
+					res.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }));
+				}
+				})();
+			});
+		}
+	};
+}
+
 export default defineConfig({
 	root: "src",
-	plugins: [basicSsl(), tailwindcss()],
+	plugins: [basicSsl(), tailwindcss(), debugReplayProxy()],
 	build: {
 		target: "esnext",
 		outDir: "../dist",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,110 +1,13 @@
 import basicSsl from "@vitejs/plugin-basic-ssl";
 import tailwindcss from "@tailwindcss/vite";
-import { Buffer } from "node:buffer";
-import type { IncomingMessage } from "node:http";
 import { fileURLToPath } from "node:url";
-import { defineConfig, type Plugin } from "vite";
+import { defineConfig } from "vite";
 
 const fromRoot = (path: string) => fileURLToPath(new URL(path, import.meta.url));
 
-const DEBUG_REPLAY_MAX_BODY_BYTES = 80 * 1024 * 1024;
-const DEBUG_REPLAY_ALLOWED_HOSTS = [
-	"generativelanguage.googleapis.com",
-	"aiplatform.googleapis.com",
-	"openrouter.ai"
-];
-
-function isAllowedDebugReplayHost(hostname: string): boolean {
-	return (
-		DEBUG_REPLAY_ALLOWED_HOSTS.includes(hostname) ||
-		hostname.endsWith(".supabase.co") ||
-		hostname.endsWith(".googleapis.com")
-	);
-}
-
-async function readJsonBody(req: IncomingMessage): Promise<any> {
-	const chunks: Buffer[] = [];
-	let totalBytes = 0;
-
-	for await (const chunk of req) {
-		const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-		totalBytes += buffer.byteLength;
-		if (totalBytes > DEBUG_REPLAY_MAX_BODY_BYTES) {
-			throw new Error("Replay payload is too large.");
-		}
-		chunks.push(buffer);
-	}
-
-	return JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
-}
-
-function normalizeReplayBody(body: unknown): BodyInit | undefined {
-	if (body === undefined || body === null) return undefined;
-	return typeof body === "string" ? body : JSON.stringify(body);
-}
-
-function debugReplayProxy(): Plugin {
-	return {
-		name: "zodiac-debug-replay-proxy",
-		apply: "serve",
-		configureServer(server) {
-			server.middlewares.use("/__debug/replay", (req, res) => {
-				void (async () => {
-				if (req.method !== "POST") {
-					res.statusCode = 405;
-					res.setHeader("Content-Type", "application/json");
-					res.end(JSON.stringify({ error: "Use POST" }));
-					return;
-				}
-
-				try {
-					const replay = await readJsonBody(req);
-					const url = new URL(String(replay.url || ""));
-					if (url.protocol !== "https:" || !isAllowedDebugReplayHost(url.hostname)) {
-						res.statusCode = 400;
-						res.setHeader("Content-Type", "application/json");
-						res.end(JSON.stringify({ error: `Replay host is not allowed: ${url.hostname}` }));
-						return;
-					}
-
-					const headers = new Headers(replay.headers || {});
-					headers.delete("origin");
-					headers.delete("referer");
-					headers.delete("user-agent");
-					headers.delete("content-length");
-
-					const upstream = await fetch(url, {
-						method: replay.method || "POST",
-						headers,
-						body: normalizeReplayBody(replay.body),
-						redirect: "manual"
-					});
-					const text = await upstream.text();
-
-					res.statusCode = 200;
-					res.setHeader("Content-Type", "application/json");
-					res.end(
-						JSON.stringify({
-							status: upstream.status,
-							statusText: upstream.statusText,
-							headers: Object.fromEntries(upstream.headers.entries()),
-							body: text
-						})
-					);
-				} catch (error) {
-					res.statusCode = 500;
-					res.setHeader("Content-Type", "application/json");
-					res.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }));
-				}
-				})();
-			});
-		}
-	};
-}
-
 export default defineConfig({
 	root: "src",
-	plugins: [basicSsl(), tailwindcss(), debugReplayProxy()],
+	plugins: [basicSsl(), tailwindcss()],
 	build: {
 		target: "esnext",
 		outDir: "../dist",


### PR DESCRIPTION
## Summary
- add OpenRouter-served Gemini text model variants while keeping Gemini SDK/local models
- hide local-only Gemini text models and use premium labels in unified premium endpoint selectors
- map stale local Gemini selections to matching OpenRouter variants for premium endpoint fallback
- update roleplay model expectations and fallback coverage

## Validation
- npm run build
- npx vitest run --config vitest.config.mts tests/unit/models.test.ts tests/integration/messages/roleplay-composer-model-dropdown.test.ts
- pre-push hook: npm run lint, npm run type-check, npm run test:vitest