### PR TITLE
chore: prepare v1.8.4 release

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1588,8 +1588,13 @@
 					<h1 id="header-version">What's New in</h1>
 					<ul id="changelog">
 						<li>
-							<b>Stability fixes:</b> This release includes reliability improvements and polish across
-							Zodiac
+							<b>New Openrouter models:</b> Users that use their Openrouter API instead of Gemini API key
+							will be able to use the Gemini models
+						</li>
+						<li><b>Better image support:</b> More models accept image input</li>
+						<li>
+							<b>Chat History Stability Fixes:</b> Attachment data, thought parts, and reasoning
+							signatures now stay intact when editing, regenerating, or restoring messages
 						</li>
 					</ul>
 				</div>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -57,7 +57,7 @@ export function lightenCard(element: HTMLElement) {
 }
 
 export function getVersion() {
-	return "1.8.3";
+	return "1.8.4";
 }
 
 export function getSanitized(string: string) {


### PR DESCRIPTION
## v1.8.4 Release

- Bump version to 1.8.4
- Update changelog with new models, image support, and chat history reliability improvements