### PR TITLE
feat: add rich model picker with grid + filtering

### DIFF
--- a/src/components/static/RichPicker.component.ts
+++ b/src/components/static/RichPicker.component.ts
@@ -1,0 +1,371 @@
+import * as surfaceService from "../../services/Surface.service";
+import { onDocumentEvent } from "../../events";
+import { getChatModelDefinition, type ChatModelDefinition } from "../../types/Models";
+
+const SHEET_ID = "model-picker-sheet";
+
+const modelSelect = document.querySelector<HTMLSelectElement>("#selectedModel");
+const trigger = document.querySelector<HTMLButtonElement>("#model-picker-trigger");
+const triggerLabel = trigger?.querySelector<HTMLElement>(".model-picker-trigger__label") ?? null;
+const sheet = document.querySelector<HTMLElement>("#model-picker-sheet");
+const searchInput = document.querySelector<HTMLInputElement>("#model-picker-search");
+const filtersContainer = document.querySelector<HTMLElement>("#model-picker-filters");
+const grid = document.querySelector<HTMLElement>("#model-picker-grid");
+const emptyState = document.querySelector<HTMLElement>("#model-picker-empty");
+
+if (!modelSelect || !trigger || !triggerLabel || !sheet || !searchInput || !filtersContainer || !grid || !emptyState) {
+	console.error("Rich model picker initialization failed");
+	throw new Error("Missing DOM element for the rich model picker");
+}
+
+const ensuredSelect = modelSelect;
+const ensuredTrigger = trigger;
+const ensuredTriggerLabel = triggerLabel;
+const ensuredSearch = searchInput;
+const ensuredFilters = filtersContainer;
+const ensuredGrid = grid;
+const ensuredEmpty = emptyState;
+
+type ProviderFilter = "all" | "gemini" | "openrouter";
+
+type CapabilityKey = "vision" | "imageOut" | "thinking" | "files";
+
+interface CapabilityDescriptor {
+	key: CapabilityKey;
+	label: string;
+	icon: string;
+	test: (definition: ChatModelDefinition) => boolean;
+}
+
+interface ModelEntry {
+	id: string;
+	label: string;
+	definition: ChatModelDefinition | undefined;
+}
+
+const PROVIDER_FILTERS: { key: ProviderFilter; label: string }[] = [
+	{ key: "all", label: "All" },
+	{ key: "gemini", label: "Gemini" },
+	{ key: "openrouter", label: "OpenRouter" }
+];
+
+const CAPABILITIES: CapabilityDescriptor[] = [
+	{ key: "vision", label: "Vision", icon: "visibility", test: (model) => model.supportsImageInput },
+	{ key: "imageOut", label: "Image gen", icon: "image", test: (model) => model.supportsImageOutput },
+	{ key: "thinking", label: "Thinking", icon: "neurology", test: (model) => model.supportsThinking },
+	{ key: "files", label: "Files", icon: "description", test: (model) => model.supportsFileInput }
+];
+
+const filterState = {
+	search: "",
+	provider: "all" as ProviderFilter,
+	capabilities: new Set<CapabilityKey>(),
+	megaOnly: false
+};
+
+function readEntries(): ModelEntry[] {
+	const entries: ModelEntry[] = [];
+	for (const option of Array.from(ensuredSelect.options)) {
+		if (option.disabled || option.value === "") continue;
+		entries.push({
+			id: option.value,
+			label: (option.textContent ?? option.value).trim(),
+			definition: getChatModelDefinition(option.value)
+		});
+	}
+	return entries;
+}
+
+function matchesFilters(entry: ModelEntry): boolean {
+	const { definition } = entry;
+
+	if (filterState.search) {
+		const haystack = `${entry.label} ${entry.id}`.toLowerCase();
+		if (!haystack.includes(filterState.search)) return false;
+	}
+
+	if (filterState.provider !== "all" && definition?.provider !== filterState.provider) return false;
+
+	if (filterState.megaOnly && !definition?.mega) return false;
+
+	if (filterState.capabilities.size > 0) {
+		if (!definition) return false;
+		for (const key of filterState.capabilities) {
+			const capability = CAPABILITIES.find((candidate) => candidate.key === key);
+			if (capability && !capability.test(definition)) return false;
+		}
+	}
+
+	return true;
+}
+
+function createCapabilityBadge(capability: CapabilityDescriptor): HTMLElement {
+	const badge = document.createElement("span");
+	badge.className = "model-card__cap";
+	badge.title = capability.label;
+
+	const icon = document.createElement("span");
+	icon.className = "material-symbols-outlined";
+	icon.textContent = capability.icon;
+	badge.append(icon);
+
+	return badge;
+}
+
+function createCard(entry: ModelEntry): HTMLButtonElement {
+	const card = document.createElement("button");
+	card.type = "button";
+	card.className = "model-card";
+	card.dataset.modelId = entry.id;
+	card.setAttribute("role", "option");
+
+	const isSelected = entry.id === ensuredSelect.value;
+	card.classList.toggle("selected", isSelected);
+	card.setAttribute("aria-selected", isSelected ? "true" : "false");
+
+	const header = document.createElement("span");
+	header.className = "model-card__header";
+
+	const name = document.createElement("span");
+	name.className = "model-card__name";
+	name.textContent = entry.label;
+	header.append(name);
+
+	if (entry.definition?.mega) {
+		const mega = document.createElement("span");
+		mega.className = "model-card__mega";
+		mega.textContent = "MEGA";
+		header.append(mega);
+	}
+
+	card.append(header);
+
+	if (entry.definition) {
+		const provider = document.createElement("span");
+		provider.className = "model-card__provider";
+		provider.textContent = entry.definition.provider === "gemini" ? "Gemini" : "OpenRouter";
+		card.append(provider);
+
+		const supported = CAPABILITIES.filter((capability) => capability.test(entry.definition!));
+		if (supported.length > 0) {
+			const caps = document.createElement("span");
+			caps.className = "model-card__caps";
+			for (const capability of supported) caps.append(createCapabilityBadge(capability));
+			card.append(caps);
+		}
+	}
+
+	card.addEventListener("click", () => selectModel(entry.id));
+
+	return card;
+}
+
+function renderGrid(): void {
+	const entries = readEntries();
+	const visible = entries.filter(matchesFilters);
+
+	ensuredGrid.replaceChildren();
+	for (const entry of visible) ensuredGrid.append(createCard(entry));
+
+	ensuredEmpty.classList.toggle("hidden", visible.length > 0);
+}
+
+function selectModel(id: string): void {
+	ensuredSelect.value = id;
+	if (ensuredSelect.value !== id) return; // option not selectable (e.g. lost access)
+
+	ensuredSelect.dispatchEvent(new Event("change", { bubbles: true }));
+	updateTrigger();
+	surfaceService.close(SHEET_ID);
+}
+
+function updateTrigger(): void {
+	const selected = ensuredSelect.selectedOptions[0];
+	ensuredTriggerLabel.textContent = selected?.textContent?.trim() || "Select a model";
+	ensuredTrigger.disabled = ensuredSelect.disabled;
+}
+
+function buildFilters(): void {
+	const row = document.createElement("div");
+	row.className = "model-picker-filter-row";
+
+	row.append(buildProviderSelect(), buildCapabilitiesDropdown());
+
+	ensuredFilters.replaceChildren(row);
+}
+
+function buildProviderSelect(): HTMLSelectElement {
+	const select = document.createElement("select");
+	select.className = "input-field model-picker-provider";
+	select.setAttribute("aria-label", "Filter by provider");
+
+	for (const provider of PROVIDER_FILTERS) {
+		const option = document.createElement("option");
+		option.value = provider.key;
+		option.textContent = provider.key === "all" ? "All providers" : provider.label;
+		select.append(option);
+	}
+
+	select.value = filterState.provider;
+	select.addEventListener("change", () => {
+		filterState.provider = select.value as ProviderFilter;
+		renderGrid();
+	});
+
+	return select;
+}
+
+function buildCapabilitiesDropdown(): HTMLElement {
+	const wrap = document.createElement("div");
+	wrap.className = "model-picker-dropdown";
+
+	const button = document.createElement("button");
+	button.type = "button";
+	button.className = "input-field model-picker-dropdown__button";
+	button.setAttribute("aria-haspopup", "true");
+	button.setAttribute("aria-expanded", "false");
+
+	const label = document.createElement("span");
+	label.className = "model-picker-dropdown__label";
+	label.textContent = "Capabilities";
+
+	const badge = document.createElement("span");
+	badge.className = "model-picker-dropdown__badge hidden";
+
+	const chevron = document.createElement("span");
+	chevron.className = "material-symbols-outlined model-picker-dropdown__chevron";
+	chevron.textContent = "expand_more";
+
+	button.append(label, badge, chevron);
+
+	const panel = document.createElement("div");
+	panel.className = "model-picker-dropdown__panel hidden";
+	panel.setAttribute("role", "group");
+	panel.setAttribute("aria-label", "Filter by capability");
+
+	const updateBadge = () => {
+		const count = filterState.capabilities.size + (filterState.megaOnly ? 1 : 0);
+		badge.textContent = String(count);
+		badge.classList.toggle("hidden", count === 0);
+	};
+
+	for (const capability of CAPABILITIES) {
+		panel.append(
+			buildCapabilityOption(
+				capability.label,
+				capability.icon,
+				() => filterState.capabilities.has(capability.key),
+				(checked) => {
+					if (checked) filterState.capabilities.add(capability.key);
+					else filterState.capabilities.delete(capability.key);
+					updateBadge();
+					renderGrid();
+				}
+			)
+		);
+	}
+
+	const divider = document.createElement("span");
+	divider.className = "model-picker-dropdown__divider";
+	divider.setAttribute("aria-hidden", "true");
+	panel.append(divider);
+
+	panel.append(
+		buildCapabilityOption(
+			"MEGA tier only",
+			"bolt",
+			() => filterState.megaOnly,
+			(checked) => {
+				filterState.megaOnly = checked;
+				updateBadge();
+				renderGrid();
+			}
+		)
+	);
+
+	const setOpen = (open: boolean) => {
+		panel.classList.toggle("hidden", !open);
+		wrap.classList.toggle("open", open);
+		button.setAttribute("aria-expanded", open ? "true" : "false");
+	};
+
+	button.addEventListener("click", (event) => {
+		event.stopPropagation();
+		setOpen(panel.classList.contains("hidden"));
+	});
+
+	// Keep the panel open while toggling checkboxes; close on outside click or Escape.
+	panel.addEventListener("click", (event) => event.stopPropagation());
+	document.addEventListener("click", () => setOpen(false));
+	wrap.addEventListener("keydown", (event) => {
+		if (event.key === "Escape" && !panel.classList.contains("hidden")) {
+			event.stopPropagation();
+			setOpen(false);
+			button.focus();
+		}
+	});
+
+	wrap.append(button, panel);
+	return wrap;
+}
+
+function buildCapabilityOption(
+	text: string,
+	icon: string,
+	isChecked: () => boolean,
+	onToggle: (checked: boolean) => void
+): HTMLLabelElement {
+	const option = document.createElement("label");
+	option.className = "model-picker-dropdown__option";
+
+	const checkbox = document.createElement("input");
+	checkbox.type = "checkbox";
+	checkbox.checked = isChecked();
+	checkbox.addEventListener("change", () => onToggle(checkbox.checked));
+
+	const iconEl = document.createElement("span");
+	iconEl.className = "material-symbols-outlined";
+	iconEl.textContent = icon;
+
+	const textEl = document.createElement("span");
+	textEl.textContent = text;
+
+	option.append(checkbox, iconEl, textEl);
+	return option;
+}
+
+function openSheet(): void {
+	renderGrid();
+	surfaceService.show(SHEET_ID);
+	ensuredTrigger.setAttribute("aria-expanded", "true");
+	requestAnimationFrame(() => ensuredSearch.focus());
+}
+
+ensuredTrigger.addEventListener("click", openSheet);
+
+ensuredSearch.addEventListener("input", () => {
+	filterState.search = ensuredSearch.value.trim().toLowerCase();
+	renderGrid();
+});
+
+sheet.addEventListener("surface-closed", () => {
+	ensuredTrigger.setAttribute("aria-expanded", "false");
+});
+
+ensuredSelect.addEventListener("change", updateTrigger);
+onDocumentEvent("chat-model-changed", updateTrigger);
+
+// The native select is rebuilt when access changes (API keys, auth, premium endpoint).
+// Mirror those updates: keep the trigger label correct and refresh the grid if it's open.
+const selectObserver = new MutationObserver(() => {
+	updateTrigger();
+	if (!sheet.classList.contains("hidden")) renderGrid();
+});
+selectObserver.observe(ensuredSelect, { childList: true, attributes: true, attributeFilter: ["disabled"] });
+
+// Reveal the button-based picker and retire the native select as the visible control.
+ensuredSelect.classList.add("model-picker-native-hidden");
+ensuredTrigger.classList.remove("hidden");
+
+buildFilters();
+updateTrigger();

--- a/src/components/static/RichPicker.component.ts
+++ b/src/components/static/RichPicker.component.ts
@@ -8,12 +8,25 @@ const modelSelect = document.querySelector<HTMLSelectElement>("#selectedModel");
 const trigger = document.querySelector<HTMLButtonElement>("#model-picker-trigger");
 const triggerLabel = trigger?.querySelector<HTMLElement>(".model-picker-trigger__label") ?? null;
 const sheet = document.querySelector<HTMLElement>("#model-picker-sheet");
-const searchInput = document.querySelector<HTMLInputElement>("#model-picker-search");
-const filtersContainer = document.querySelector<HTMLElement>("#model-picker-filters");
-const grid = document.querySelector<HTMLElement>("#model-picker-grid");
-const emptyState = document.querySelector<HTMLElement>("#model-picker-empty");
+const familiesView = document.querySelector<HTMLElement>("#model-picker-families");
+const familyList = document.querySelector<HTMLElement>("#model-picker-family-list");
+const detailView = document.querySelector<HTMLElement>("#model-picker-family-detail");
+const backButton = document.querySelector<HTMLButtonElement>("#model-picker-back");
+const familyTitle = document.querySelector<HTMLElement>("#model-picker-family-title");
+const modelList = document.querySelector<HTMLElement>("#model-picker-model-list");
 
-if (!modelSelect || !trigger || !triggerLabel || !sheet || !searchInput || !filtersContainer || !grid || !emptyState) {
+if (
+	!modelSelect ||
+	!trigger ||
+	!triggerLabel ||
+	!sheet ||
+	!familiesView ||
+	!familyList ||
+	!detailView ||
+	!backButton ||
+	!familyTitle ||
+	!modelList
+) {
 	console.error("Rich model picker initialization failed");
 	throw new Error("Missing DOM element for the rich model picker");
 }
@@ -21,20 +34,26 @@ if (!modelSelect || !trigger || !triggerLabel || !sheet || !searchInput || !filt
 const ensuredSelect = modelSelect;
 const ensuredTrigger = trigger;
 const ensuredTriggerLabel = triggerLabel;
-const ensuredSearch = searchInput;
-const ensuredFilters = filtersContainer;
-const ensuredGrid = grid;
-const ensuredEmpty = emptyState;
-
-type ProviderFilter = "all" | "gemini" | "openrouter";
-
-type CapabilityKey = "vision" | "imageOut" | "thinking" | "files";
+const ensuredSheet = sheet;
+const ensuredFamiliesView = familiesView;
+const ensuredFamilyList = familyList;
+const ensuredDetailView = detailView;
+const ensuredBack = backButton;
+const ensuredFamilyTitle = familyTitle;
+const ensuredModelList = modelList;
 
 interface CapabilityDescriptor {
-	key: CapabilityKey;
 	label: string;
 	icon: string;
 	test: (definition: ChatModelDefinition) => boolean;
+}
+
+interface ModelFamily {
+	key: string;
+	label: string;
+	icon: string;
+	/** Matched against the lowercased model id. */
+	test: (id: string) => boolean;
 }
 
 interface ModelEntry {
@@ -43,25 +62,43 @@ interface ModelEntry {
 	definition: ChatModelDefinition | undefined;
 }
 
-const PROVIDER_FILTERS: { key: ProviderFilter; label: string }[] = [
-	{ key: "all", label: "All" },
-	{ key: "gemini", label: "Gemini" },
-	{ key: "openrouter", label: "OpenRouter" }
-];
+interface FamilyGroup {
+	family: ModelFamily;
+	models: ModelEntry[];
+}
 
 const CAPABILITIES: CapabilityDescriptor[] = [
-	{ key: "vision", label: "Vision", icon: "visibility", test: (model) => model.supportsImageInput },
-	{ key: "imageOut", label: "Image gen", icon: "image", test: (model) => model.supportsImageOutput },
-	{ key: "thinking", label: "Thinking", icon: "neurology", test: (model) => model.supportsThinking },
-	{ key: "files", label: "Files", icon: "description", test: (model) => model.supportsFileInput }
+	{ label: "Vision", icon: "visibility", test: (model) => model.supportsImageInput },
+	{ label: "Image gen", icon: "image", test: (model) => model.supportsImageOutput },
+	{ label: "Thinking", icon: "neurology", test: (model) => model.supportsThinking },
+	{ label: "Files", icon: "description", test: (model) => model.supportsFileInput }
 ];
 
-const filterState = {
-	search: "",
-	provider: "all" as ProviderFilter,
-	capabilities: new Set<CapabilityKey>(),
-	megaOnly: false
-};
+// Families are matched in order; the first hit wins. Anything unmatched lands in OTHER_FAMILY.
+const FAMILIES: ModelFamily[] = [
+	{ key: "gemini", label: "Gemini", icon: "auto_awesome", test: (id) => id.includes("gemini") },
+	{ key: "gpt", label: "GPT", icon: "blur_on", test: (id) => id.includes("gpt") || id.startsWith("openai/") },
+	{
+		key: "claude",
+		label: "Claude",
+		icon: "psychology",
+		test: (id) => id.includes("claude") || id.startsWith("anthropic/")
+	},
+	{ key: "qwen", label: "Qwen", icon: "language", test: (id) => id.includes("qwen") },
+	{ key: "glm", label: "GLM", icon: "hub", test: (id) => id.includes("glm") || id.startsWith("z-ai/") },
+	{
+		key: "mercury",
+		label: "Mercury",
+		icon: "bolt",
+		test: (id) => id.includes("mercury") || id.startsWith("inception/")
+	}
+];
+
+const OTHER_FAMILY: ModelFamily = { key: "other", label: "Other", icon: "category", test: () => true };
+
+// Which family page is currently shown, and whether we skipped the family list because only one exists.
+let activeFamily: string | null = null;
+let singleFamilyMode = false;
 
 function readEntries(): ModelEntry[] {
 	const entries: ModelEntry[] = [];
@@ -76,98 +113,157 @@ function readEntries(): ModelEntry[] {
 	return entries;
 }
 
-function matchesFilters(entry: ModelEntry): boolean {
-	const { definition } = entry;
+function familyKeyOf(entry: ModelEntry): string {
+	const id = entry.id.toLowerCase();
+	for (const family of FAMILIES) {
+		if (family.test(id)) return family.key;
+	}
+	return OTHER_FAMILY.key;
+}
 
-	if (filterState.search) {
-		const haystack = `${entry.label} ${entry.id}`.toLowerCase();
-		if (!haystack.includes(filterState.search)) return false;
+function groupByFamily(entries: ModelEntry[]): FamilyGroup[] {
+	const groups: FamilyGroup[] = [];
+	for (const family of [...FAMILIES, OTHER_FAMILY]) {
+		const models = entries.filter((entry) => familyKeyOf(entry) === family.key);
+		if (models.length > 0) groups.push({ family, models });
+	}
+	return groups;
+}
+
+function createFamilyRow(group: FamilyGroup): HTMLButtonElement {
+	const { family, models } = group;
+	const row = document.createElement("button");
+	row.type = "button";
+	row.className = "settings-list-item model-picker-family";
+	row.dataset.familyKey = family.key;
+
+	const selectedModel = models.find((entry) => entry.id === ensuredSelect.value);
+	row.classList.toggle("selected", Boolean(selectedModel));
+
+	const icon = document.createElement("span");
+	icon.className = "settings-list-item-icon material-symbols-outlined";
+	icon.textContent = family.icon;
+	row.append(icon);
+
+	const text = document.createElement("span");
+	text.className = "settings-list-item-text";
+
+	const title = document.createElement("span");
+	title.className = "settings-list-item-title";
+	title.textContent = family.label;
+	text.append(title);
+
+	const subtitle = document.createElement("span");
+	subtitle.className = "settings-list-item-subtitle";
+	subtitle.textContent = selectedModel
+		? selectedModel.label
+		: `${models.length} ${models.length === 1 ? "model" : "models"}`;
+	text.append(subtitle);
+
+	row.append(text);
+
+	const chevron = document.createElement("span");
+	chevron.className = "settings-list-item-chevron material-symbols-outlined";
+	chevron.textContent = "chevron_right";
+	row.append(chevron);
+
+	row.addEventListener("click", () => navigateToFamily(family.key));
+
+	return row;
+}
+
+function createModelRow(entry: ModelEntry): HTMLButtonElement {
+	const row = document.createElement("button");
+	row.type = "button";
+	row.className = "settings-list-item model-picker-row";
+	row.dataset.modelId = entry.id;
+	row.setAttribute("role", "option");
+
+	const isSelected = entry.id === ensuredSelect.value;
+	row.classList.toggle("selected", isSelected);
+	row.setAttribute("aria-selected", isSelected ? "true" : "false");
+
+	const icon = document.createElement("span");
+	icon.className = "settings-list-item-icon material-symbols-outlined";
+	icon.textContent = isSelected ? "check_circle" : "radio_button_unchecked";
+	row.append(icon);
+
+	const text = document.createElement("span");
+	text.className = "settings-list-item-text";
+
+	const title = document.createElement("span");
+	title.className = "settings-list-item-title model-picker-row__title";
+
+	const name = document.createElement("span");
+	name.textContent = entry.label;
+	title.append(name);
+
+	if (entry.definition?.mega) {
+		const mega = document.createElement("span");
+		mega.className = "model-picker-mega";
+		mega.textContent = "MEGA";
+		title.append(mega);
 	}
 
-	if (filterState.provider !== "all" && definition?.provider !== filterState.provider) return false;
+	text.append(title);
 
-	if (filterState.megaOnly && !definition?.mega) return false;
-
-	if (filterState.capabilities.size > 0) {
-		if (!definition) return false;
-		for (const key of filterState.capabilities) {
-			const capability = CAPABILITIES.find((candidate) => candidate.key === key);
-			if (capability && !capability.test(definition)) return false;
+	if (entry.definition) {
+		const supported = CAPABILITIES.filter((capability) => capability.test(entry.definition!));
+		if (supported.length > 0) {
+			const caps = document.createElement("span");
+			caps.className = "settings-list-item-subtitle model-picker-caps";
+			for (const capability of supported) {
+				const capIcon = document.createElement("span");
+				capIcon.className = "material-symbols-outlined";
+				capIcon.textContent = capability.icon;
+				capIcon.title = capability.label;
+				caps.append(capIcon);
+			}
+			text.append(caps);
 		}
 	}
+
+	row.append(text);
+	row.addEventListener("click", () => selectModel(entry.id));
+
+	return row;
+}
+
+function showView(view: "families" | "detail"): void {
+	ensuredFamiliesView.classList.toggle("hidden", view !== "families");
+	ensuredDetailView.classList.toggle("hidden", view !== "detail");
+}
+
+function renderFamilyList(): void {
+	const groups = groupByFamily(readEntries());
+	ensuredFamilyList.replaceChildren();
+	for (const group of groups) ensuredFamilyList.append(createFamilyRow(group));
+}
+
+function renderFamilyDetail(): boolean {
+	const groups = groupByFamily(readEntries());
+	const group = groups.find((candidate) => candidate.family.key === activeFamily);
+	if (!group) return false;
+
+	activeFamily = group.family.key;
+	ensuredFamilyTitle.textContent = group.family.label;
+	ensuredBack.classList.toggle("hidden", singleFamilyMode);
+
+	ensuredModelList.replaceChildren();
+	for (const entry of group.models) ensuredModelList.append(createModelRow(entry));
 
 	return true;
 }
 
-function createCapabilityBadge(capability: CapabilityDescriptor): HTMLElement {
-	const badge = document.createElement("span");
-	badge.className = "model-card__cap";
-	badge.title = capability.label;
-
-	const icon = document.createElement("span");
-	icon.className = "material-symbols-outlined";
-	icon.textContent = capability.icon;
-	badge.append(icon);
-
-	return badge;
+function navigateToFamily(key: string): void {
+	activeFamily = key;
+	if (renderFamilyDetail()) showView("detail");
 }
 
-function createCard(entry: ModelEntry): HTMLButtonElement {
-	const card = document.createElement("button");
-	card.type = "button";
-	card.className = "model-card";
-	card.dataset.modelId = entry.id;
-	card.setAttribute("role", "option");
-
-	const isSelected = entry.id === ensuredSelect.value;
-	card.classList.toggle("selected", isSelected);
-	card.setAttribute("aria-selected", isSelected ? "true" : "false");
-
-	const header = document.createElement("span");
-	header.className = "model-card__header";
-
-	const name = document.createElement("span");
-	name.className = "model-card__name";
-	name.textContent = entry.label;
-	header.append(name);
-
-	if (entry.definition?.mega) {
-		const mega = document.createElement("span");
-		mega.className = "model-card__mega";
-		mega.textContent = "MEGA";
-		header.append(mega);
-	}
-
-	card.append(header);
-
-	if (entry.definition) {
-		const provider = document.createElement("span");
-		provider.className = "model-card__provider";
-		provider.textContent = entry.definition.provider === "gemini" ? "Gemini" : "OpenRouter";
-		card.append(provider);
-
-		const supported = CAPABILITIES.filter((capability) => capability.test(entry.definition!));
-		if (supported.length > 0) {
-			const caps = document.createElement("span");
-			caps.className = "model-card__caps";
-			for (const capability of supported) caps.append(createCapabilityBadge(capability));
-			card.append(caps);
-		}
-	}
-
-	card.addEventListener("click", () => selectModel(entry.id));
-
-	return card;
-}
-
-function renderGrid(): void {
-	const entries = readEntries();
-	const visible = entries.filter(matchesFilters);
-
-	ensuredGrid.replaceChildren();
-	for (const entry of visible) ensuredGrid.append(createCard(entry));
-
-	ensuredEmpty.classList.toggle("hidden", visible.length > 0);
+function navigateToFamilyList(): void {
+	activeFamily = null;
+	renderFamilyList();
+	showView("families");
 }
 
 function selectModel(id: string): void {
@@ -185,181 +281,63 @@ function updateTrigger(): void {
 	ensuredTrigger.disabled = ensuredSelect.disabled;
 }
 
-function buildFilters(): void {
-	const row = document.createElement("div");
-	row.className = "model-picker-filter-row";
-
-	row.append(buildProviderSelect(), buildCapabilitiesDropdown());
-
-	ensuredFilters.replaceChildren(row);
-}
-
-function buildProviderSelect(): HTMLSelectElement {
-	const select = document.createElement("select");
-	select.className = "input-field model-picker-provider";
-	select.setAttribute("aria-label", "Filter by provider");
-
-	for (const provider of PROVIDER_FILTERS) {
-		const option = document.createElement("option");
-		option.value = provider.key;
-		option.textContent = provider.key === "all" ? "All providers" : provider.label;
-		select.append(option);
-	}
-
-	select.value = filterState.provider;
-	select.addEventListener("change", () => {
-		filterState.provider = select.value as ProviderFilter;
-		renderGrid();
-	});
-
-	return select;
-}
-
-function buildCapabilitiesDropdown(): HTMLElement {
-	const wrap = document.createElement("div");
-	wrap.className = "model-picker-dropdown";
-
-	const button = document.createElement("button");
-	button.type = "button";
-	button.className = "input-field model-picker-dropdown__button";
-	button.setAttribute("aria-haspopup", "true");
-	button.setAttribute("aria-expanded", "false");
-
-	const label = document.createElement("span");
-	label.className = "model-picker-dropdown__label";
-	label.textContent = "Capabilities";
-
-	const badge = document.createElement("span");
-	badge.className = "model-picker-dropdown__badge hidden";
-
-	const chevron = document.createElement("span");
-	chevron.className = "material-symbols-outlined model-picker-dropdown__chevron";
-	chevron.textContent = "expand_more";
-
-	button.append(label, badge, chevron);
-
-	const panel = document.createElement("div");
-	panel.className = "model-picker-dropdown__panel hidden";
-	panel.setAttribute("role", "group");
-	panel.setAttribute("aria-label", "Filter by capability");
-
-	const updateBadge = () => {
-		const count = filterState.capabilities.size + (filterState.megaOnly ? 1 : 0);
-		badge.textContent = String(count);
-		badge.classList.toggle("hidden", count === 0);
-	};
-
-	for (const capability of CAPABILITIES) {
-		panel.append(
-			buildCapabilityOption(
-				capability.label,
-				capability.icon,
-				() => filterState.capabilities.has(capability.key),
-				(checked) => {
-					if (checked) filterState.capabilities.add(capability.key);
-					else filterState.capabilities.delete(capability.key);
-					updateBadge();
-					renderGrid();
-				}
-			)
-		);
-	}
-
-	const divider = document.createElement("span");
-	divider.className = "model-picker-dropdown__divider";
-	divider.setAttribute("aria-hidden", "true");
-	panel.append(divider);
-
-	panel.append(
-		buildCapabilityOption(
-			"MEGA tier only",
-			"bolt",
-			() => filterState.megaOnly,
-			(checked) => {
-				filterState.megaOnly = checked;
-				updateBadge();
-				renderGrid();
-			}
-		)
-	);
-
-	const setOpen = (open: boolean) => {
-		panel.classList.toggle("hidden", !open);
-		wrap.classList.toggle("open", open);
-		button.setAttribute("aria-expanded", open ? "true" : "false");
-	};
-
-	button.addEventListener("click", (event) => {
-		event.stopPropagation();
-		setOpen(panel.classList.contains("hidden"));
-	});
-
-	// Keep the panel open while toggling checkboxes; close on outside click or Escape.
-	panel.addEventListener("click", (event) => event.stopPropagation());
-	document.addEventListener("click", () => setOpen(false));
-	wrap.addEventListener("keydown", (event) => {
-		if (event.key === "Escape" && !panel.classList.contains("hidden")) {
-			event.stopPropagation();
-			setOpen(false);
-			button.focus();
-		}
-	});
-
-	wrap.append(button, panel);
-	return wrap;
-}
-
-function buildCapabilityOption(
-	text: string,
-	icon: string,
-	isChecked: () => boolean,
-	onToggle: (checked: boolean) => void
-): HTMLLabelElement {
-	const option = document.createElement("label");
-	option.className = "model-picker-dropdown__option";
-
-	const checkbox = document.createElement("input");
-	checkbox.type = "checkbox";
-	checkbox.checked = isChecked();
-	checkbox.addEventListener("change", () => onToggle(checkbox.checked));
-
-	const iconEl = document.createElement("span");
-	iconEl.className = "material-symbols-outlined";
-	iconEl.textContent = icon;
-
-	const textEl = document.createElement("span");
-	textEl.textContent = text;
-
-	option.append(checkbox, iconEl, textEl);
-	return option;
-}
-
 function openSheet(): void {
-	renderGrid();
+	const groups = groupByFamily(readEntries());
+	singleFamilyMode = groups.length === 1;
+
+	if (singleFamilyMode) {
+		// Skip the family list when there is nothing to choose between; drill straight in.
+		activeFamily = groups[0].family.key;
+		renderFamilyDetail();
+		showView("detail");
+	} else {
+		navigateToFamilyList();
+	}
+
 	surfaceService.show(SHEET_ID);
 	ensuredTrigger.setAttribute("aria-expanded", "true");
-	requestAnimationFrame(() => ensuredSearch.focus());
+}
+
+// Keep an open sheet in sync when the underlying option list changes (access gating, premium endpoint, etc.).
+function refreshOpenSheet(): void {
+	if (ensuredSheet.classList.contains("hidden")) return;
+
+	const groups = groupByFamily(readEntries());
+	singleFamilyMode = groups.length === 1;
+
+	if (singleFamilyMode) {
+		activeFamily = groups[0].family.key;
+		renderFamilyDetail();
+		showView("detail");
+		return;
+	}
+
+	renderFamilyList();
+	if (activeFamily && renderFamilyDetail()) showView("detail");
+	else navigateToFamilyList();
 }
 
 ensuredTrigger.addEventListener("click", openSheet);
+ensuredBack.addEventListener("click", navigateToFamilyList);
 
-ensuredSearch.addEventListener("input", () => {
-	filterState.search = ensuredSearch.value.trim().toLowerCase();
-	renderGrid();
-});
-
-sheet.addEventListener("surface-closed", () => {
+ensuredSheet.addEventListener("surface-closed", () => {
 	ensuredTrigger.setAttribute("aria-expanded", "false");
 });
 
-ensuredSelect.addEventListener("change", updateTrigger);
-onDocumentEvent("chat-model-changed", updateTrigger);
+ensuredSelect.addEventListener("change", () => {
+	updateTrigger();
+	refreshOpenSheet();
+});
+onDocumentEvent("chat-model-changed", () => {
+	updateTrigger();
+	refreshOpenSheet();
+});
 
 // The native select is rebuilt when access changes (API keys, auth, premium endpoint).
-// Mirror those updates: keep the trigger label correct and refresh the grid if it's open.
+// Mirror those updates: keep the trigger label correct and refresh the picker if it's open.
 const selectObserver = new MutationObserver(() => {
 	updateTrigger();
-	if (!sheet.classList.contains("hidden")) renderGrid();
+	refreshOpenSheet();
 });
 selectObserver.observe(ensuredSelect, { childList: true, attributes: true, attributeFilter: ["disabled"] });
 
@@ -367,5 +345,4 @@ selectObserver.observe(ensuredSelect, { childList: true, attributes: true, attri
 ensuredSelect.classList.add("model-picker-native-hidden");
 ensuredTrigger.classList.remove("hidden");
 
-buildFilters();
 updateTrigger();

--- a/src/index.html
+++ b/src/index.html
@@ -3209,18 +3209,24 @@
 			role="dialog"
 			aria-labelledby="model-picker-title"
 		>
-			<h1 id="model-picker-title">Select a model</h1>
-			<input
-				id="model-picker-search"
-				class="input-field model-picker-search"
-				type="search"
-				placeholder="Search models…"
-				autocomplete="off"
-				aria-label="Search models"
-			/>
-			<div id="model-picker-filters" class="model-picker-filters"></div>
-			<div id="model-picker-grid" class="model-picker-grid" role="listbox" aria-label="Models"></div>
-			<p id="model-picker-empty" class="model-picker-empty hidden">No models match your filters.</p>
+			<div id="model-picker-families" class="model-picker-view">
+				<h1 id="model-picker-title">Select a model</h1>
+				<div id="model-picker-family-list" class="settings-list" aria-label="Model families"></div>
+			</div>
+			<div id="model-picker-family-detail" class="model-picker-view hidden">
+				<div class="settings-page-header">
+					<button
+						id="model-picker-back"
+						class="settings-page-back btn-textual"
+						type="button"
+						aria-label="Back to model families"
+					>
+						<span class="material-symbols-outlined">arrow_back</span>
+					</button>
+					<h3 id="model-picker-family-title" class="settings-page-title">Models</h3>
+				</div>
+				<div id="model-picker-model-list" class="settings-list" role="listbox" aria-label="Models"></div>
+			</div>
 		</div>
 
 		<script type="module" src="main.ts" defer></script>

--- a/src/index.html
+++ b/src/index.html
@@ -441,6 +441,19 @@
 												</span>
 											</label>
 											<select id="selectedModel" class="input-field"></select>
+											<button
+												id="model-picker-trigger"
+												class="input-field model-picker-trigger hidden"
+												type="button"
+												aria-haspopup="dialog"
+												aria-expanded="false"
+												aria-controls="model-picker-sheet"
+											>
+												<span class="model-picker-trigger__label">Select a model</span>
+												<span class="material-symbols-outlined model-picker-trigger__icon"
+													>expand_more</span
+												>
+											</button>
 										</div>
 										<div>
 											<label class="setting-label" for="maxTokens"
@@ -3188,6 +3201,26 @@
 					<button id="btn-roleplay-add-modal-cancel" class="btn btn-secondary" type="button">Cancel</button>
 				</div>
 			</div>
+		</div>
+
+		<div
+			id="model-picker-sheet"
+			class="adaptive-sheet model-picker-sheet hidden"
+			role="dialog"
+			aria-labelledby="model-picker-title"
+		>
+			<h1 id="model-picker-title">Select a model</h1>
+			<input
+				id="model-picker-search"
+				class="input-field model-picker-search"
+				type="search"
+				placeholder="Search models…"
+				autocomplete="off"
+				aria-label="Search models"
+			/>
+			<div id="model-picker-filters" class="model-picker-filters"></div>
+			<div id="model-picker-grid" class="model-picker-grid" role="listbox" aria-label="Models"></div>
+			<p id="model-picker-empty" class="model-picker-empty hidden">No models match your filters.</p>
 		</div>
 
 		<script type="module" src="main.ts" defer></script>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2587,6 +2587,244 @@ form {
 	display: none;
 }
 
+/* Rich model picker */
+.model-picker-native-hidden {
+	display: none !important;
+}
+
+/* Buttons that should look like a native select (the .input-field class carries no box styling on its own) */
+.model-picker-trigger,
+.model-picker-dropdown__button {
+	border: 1px solid var(--input-text-border);
+	border-radius: 0.5rem;
+	background-color: var(--input-bg);
+	color: var(--input-fg);
+	padding: 0.5rem;
+	font-size: 1rem;
+	cursor: pointer;
+}
+
+.model-picker-trigger:focus-visible,
+.model-picker-dropdown__button:focus-visible {
+	border-color: var(--input-text-border-focus);
+	outline: none;
+}
+
+.model-picker-trigger {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5rem;
+	width: 100%;
+	text-align: left;
+	font-weight: normal;
+}
+
+.model-picker-trigger__label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.model-picker-trigger__icon {
+	flex-shrink: 0;
+	font-size: 1.25rem;
+	opacity: 0.7;
+}
+
+.model-picker-trigger:disabled {
+	cursor: not-allowed;
+	opacity: 0.6;
+}
+
+.model-picker-sheet {
+	gap: 1rem;
+}
+
+.model-picker-filter-row {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.model-picker-provider {
+	width: auto;
+	flex: 0 1 auto;
+}
+
+.model-picker-dropdown {
+	position: relative;
+	flex: 0 1 auto;
+}
+
+.model-picker-dropdown__button {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	width: auto;
+	cursor: pointer;
+	font-weight: normal;
+}
+
+.model-picker-dropdown__badge {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 1.1rem;
+	height: 1.1rem;
+	padding: 0 0.3rem;
+	border-radius: 999px;
+	background: var(--primary);
+	color: #fff;
+	font-size: 0.7rem;
+	font-weight: 700;
+}
+
+.model-picker-dropdown__chevron {
+	font-size: 1.25rem;
+	opacity: 0.7;
+	transition: transform 0.15s ease;
+}
+
+.model-picker-dropdown.open .model-picker-dropdown__chevron {
+	transform: rotate(180deg);
+}
+
+.model-picker-dropdown__panel {
+	position: absolute;
+	z-index: 5;
+	top: calc(100% + 0.35rem);
+	left: 0;
+	display: flex;
+	min-width: 12rem;
+	flex-direction: column;
+	gap: 0.1rem;
+	padding: 0.35rem;
+	border: var(--elevated-ui-outline);
+	border-radius: 0.6rem;
+	background: var(--modal-bg, var(--body-bg));
+	box-shadow: var(--elevated-ui-shadow);
+}
+
+.model-picker-dropdown__option {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.4rem 0.5rem;
+	border-radius: 0.4rem;
+	cursor: pointer;
+	font-size: 0.9rem;
+}
+
+.model-picker-dropdown__option:hover {
+	background: color-mix(in srgb, var(--input-bg) 70%, var(--primary) 30%);
+}
+
+.model-picker-dropdown__option input {
+	margin: 0;
+	cursor: pointer;
+}
+
+.model-picker-dropdown__option .material-symbols-outlined {
+	font-size: 1.15rem;
+	opacity: 0.75;
+}
+
+.model-picker-dropdown__divider {
+	height: 1px;
+	margin: 0.2rem 0.3rem;
+	background: var(--input-text-border);
+}
+
+.model-picker-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+	gap: 0.6rem;
+}
+
+.model-card {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 0.4rem;
+	padding: 0.75rem;
+	border: 1px solid var(--input-text-border);
+	border-radius: 0.75rem;
+	background: var(--input-bg);
+	color: var(--input-fg);
+	cursor: pointer;
+	text-align: left;
+	transition:
+		background-color 0.15s ease,
+		border-color 0.15s ease,
+		transform 0.1s ease;
+}
+
+.model-card:hover {
+	border-color: var(--input-text-border-focus);
+	transform: translateY(-1px);
+}
+
+.model-card.selected {
+	border-color: var(--primary);
+	background: color-mix(in srgb, var(--input-bg) 82%, var(--primary) 18%);
+}
+
+.model-card__header {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	width: 100%;
+}
+
+.model-card__name {
+	font-size: 0.95rem;
+	font-weight: 600;
+	line-height: 1.2;
+}
+
+.model-card__mega {
+	margin-left: auto;
+	flex-shrink: 0;
+	padding: 0.1rem 0.4rem;
+	border-radius: 0.4rem;
+	background: var(--primary);
+	color: #fff;
+	font-size: 0.65rem;
+	font-weight: 700;
+	letter-spacing: 0.04em;
+}
+
+.model-card__provider {
+	font-size: 0.75rem;
+	opacity: 0.7;
+}
+
+.model-card__caps {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.3rem;
+	margin-top: 0.1rem;
+}
+
+.model-card__cap {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	opacity: 0.75;
+}
+
+.model-card__cap .material-symbols-outlined {
+	font-size: 1.05rem;
+}
+
+.model-picker-empty {
+	margin: 1rem 0;
+	text-align: center;
+	opacity: 0.7;
+}
+
 .message-debug-modal {
 	width: min(42rem, 100%);
 	display: flex;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2592,9 +2592,8 @@ form {
 	display: none !important;
 }
 
-/* Buttons that should look like a native select (the .input-field class carries no box styling on its own) */
-.model-picker-trigger,
-.model-picker-dropdown__button {
+/* The trigger should look like a native select (the .input-field class carries no box styling on its own) */
+.model-picker-trigger {
 	border: 1px solid var(--input-text-border);
 	border-radius: 0.5rem;
 	background-color: var(--input-bg);
@@ -2604,8 +2603,7 @@ form {
 	cursor: pointer;
 }
 
-.model-picker-trigger:focus-visible,
-.model-picker-dropdown__button:focus-visible {
+.model-picker-trigger:focus-visible {
 	border-color: var(--input-text-border-focus);
 	outline: none;
 }
@@ -2641,187 +2639,54 @@ form {
 	gap: 1rem;
 }
 
-.model-picker-filter-row {
+/* Drill-down views: family list and the per-family model list, reusing the settings menu mechanics. */
+.model-picker-view {
 	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
-	gap: 0.5rem;
-}
-
-.model-picker-provider {
-	width: auto;
-	flex: 0 1 auto;
-}
-
-.model-picker-dropdown {
-	position: relative;
-	flex: 0 1 auto;
-}
-
-.model-picker-dropdown__button {
-	display: inline-flex;
-	align-items: center;
-	gap: 0.4rem;
-	width: auto;
-	cursor: pointer;
-	font-weight: normal;
-}
-
-.model-picker-dropdown__badge {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	min-width: 1.1rem;
-	height: 1.1rem;
-	padding: 0 0.3rem;
-	border-radius: 999px;
-	background: var(--primary);
-	color: #fff;
-	font-size: 0.7rem;
-	font-weight: 700;
-}
-
-.model-picker-dropdown__chevron {
-	font-size: 1.25rem;
-	opacity: 0.7;
-	transition: transform 0.15s ease;
-}
-
-.model-picker-dropdown.open .model-picker-dropdown__chevron {
-	transform: rotate(180deg);
-}
-
-.model-picker-dropdown__panel {
-	position: absolute;
-	z-index: 5;
-	top: calc(100% + 0.35rem);
-	left: 0;
-	display: flex;
-	min-width: 12rem;
 	flex-direction: column;
-	gap: 0.1rem;
-	padding: 0.35rem;
-	border: var(--elevated-ui-outline);
-	border-radius: 0.6rem;
-	background: var(--modal-bg, var(--body-bg));
-	box-shadow: var(--elevated-ui-shadow);
+	gap: 0.75rem;
 }
 
-.model-picker-dropdown__option {
-	display: flex;
-	align-items: center;
-	gap: 0.5rem;
-	padding: 0.4rem 0.5rem;
-	border-radius: 0.4rem;
-	cursor: pointer;
-	font-size: 0.9rem;
-}
-
-.model-picker-dropdown__option:hover {
-	background: color-mix(in srgb, var(--input-bg) 70%, var(--primary) 30%);
-}
-
-.model-picker-dropdown__option input {
+.model-picker-sheet h1 {
 	margin: 0;
-	cursor: pointer;
 }
 
-.model-picker-dropdown__option .material-symbols-outlined {
-	font-size: 1.15rem;
-	opacity: 0.75;
-}
-
-.model-picker-dropdown__divider {
-	height: 1px;
-	margin: 0.2rem 0.3rem;
-	background: var(--input-text-border);
-}
-
-.model-picker-grid {
-	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
-	gap: 0.6rem;
-}
-
-.model-card {
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	gap: 0.4rem;
-	padding: 0.75rem;
-	border: 1px solid var(--input-text-border);
-	border-radius: 0.75rem;
-	background: var(--input-bg);
-	color: var(--input-fg);
-	cursor: pointer;
-	text-align: left;
-	transition:
-		background-color 0.15s ease,
-		border-color 0.15s ease,
-		transform 0.1s ease;
-}
-
-.model-card:hover {
-	border-color: var(--input-text-border-focus);
-	transform: translateY(-1px);
-}
-
-.model-card.selected {
+/* Highlight the family that holds the current selection, and the selected model row. */
+.model-picker-family.selected,
+.model-picker-row.selected {
 	border-color: var(--primary);
-	background: color-mix(in srgb, var(--input-bg) 82%, var(--primary) 18%);
 }
 
-.model-card__header {
+.model-picker-row.selected .settings-list-item-icon {
+	color: var(--primary);
+	opacity: 1;
+}
+
+.model-picker-row__title {
 	display: flex;
 	align-items: center;
 	gap: 0.4rem;
-	width: 100%;
 }
 
-.model-card__name {
-	font-size: 0.95rem;
-	font-weight: 600;
-	line-height: 1.2;
-}
-
-.model-card__mega {
-	margin-left: auto;
+.model-picker-mega {
 	flex-shrink: 0;
-	padding: 0.1rem 0.4rem;
+	padding: 0.05rem 0.35rem;
 	border-radius: 0.4rem;
 	background: var(--primary);
 	color: #fff;
-	font-size: 0.65rem;
+	font-size: 0.6rem;
 	font-weight: 700;
 	letter-spacing: 0.04em;
 }
 
-.model-card__provider {
-	font-size: 0.75rem;
-	opacity: 0.7;
-}
-
-.model-card__caps {
+.model-picker-caps {
 	display: flex;
-	flex-wrap: wrap;
-	gap: 0.3rem;
-	margin-top: 0.1rem;
-}
-
-.model-card__cap {
-	display: inline-flex;
 	align-items: center;
-	justify-content: center;
-	opacity: 0.75;
+	gap: 0.3rem;
+	margin-top: 0.15rem;
 }
 
-.model-card__cap .material-symbols-outlined {
-	font-size: 1.05rem;
-}
-
-.model-picker-empty {
-	margin: 1rem 0;
-	text-align: center;
+.model-picker-caps .material-symbols-outlined {
+	font-size: 1rem;
 	opacity: 0.7;
 }
 


### PR DESCRIPTION
Replace the native model `<select>` with a button-triggered adaptive
sheet: a centered dialog on desktop, a drag-dismissable bottom sheet on
mobile. The sheet shows models as a searchable, filterable card grid so
the growing model list stays browsable.

The native `#selectedModel` stays in the DOM as the hidden source of
truth, so all existing access gating, premium-endpoint mapping, settings
persistence, and the `chat-model-changed` event keep working unchanged.
The picker mirrors the select's current options and writes selections
back via a dispatched `change` event; a MutationObserver keeps the
trigger label and grid in sync when access changes.

Filtering: a provider <select> plus a Capabilities dropdown (vision,
image gen, thinking, files, MEGA) with an active-count badge. Cards show
the model name, provider, a MEGA badge, and capability icons.

Also style the trigger and dropdown buttons explicitly to match a native
select, since the `.input-field` class carries no standalone box styling
in this codebase.