### PR TITLE
Add new OpenRouter models

### DIFF
--- a/src/components/static/ImageCreditsLabel.component.ts
+++ b/src/components/static/ImageCreditsLabel.component.ts
@@ -14,6 +14,7 @@ import { ChatModel, getChatModelDefinition, getPremiumEndpointChatModel, ImageMo
 import * as overlayService from "../../services/Overlay.service";
 import * as helpers from "../../utils/helpers";
 import { dispatchAppEvent } from "../../events";
+import { shouldPreferPremiumEndpoint } from "./ApiKeyInput.component";
 
 const imageCreditsLabel = document.querySelector<HTMLDivElement>("#image-credits-label");
 const imageCreditsPopover = document.querySelector<HTMLDivElement>("#image-credits-popover");
@@ -120,6 +121,11 @@ window.addEventListener("chat-model-changed", () => {
 	renderLabel();
 });
 
+window.addEventListener("premium-endpoint-preference-changed", () => {
+	updateImageCreditsLabelVisibility();
+	renderLabel();
+});
+
 window.addEventListener(
 	"subscription-updated",
 	() =>
@@ -151,6 +157,14 @@ function getSelectedChatModel(): string | null {
 	return modelSelector?.value || null;
 }
 
+function selectedChatModelConsumesImageCredits(): boolean {
+	if (subscriptionTier === "free" || !shouldPreferPremiumEndpoint()) {
+		return false;
+	}
+
+	return getChatModelDefinition(getSelectedChatModel())?.consumesImageCredits === true;
+}
+
 function getAllowanceMode(): AllowanceMode {
 	if (isImageEditingActive() || isImageModeActive()) {
 		return "image";
@@ -158,6 +172,10 @@ function getAllowanceMode(): AllowanceMode {
 
 	const selectedModel = getSelectedChatModel();
 	const modelDefinition = getChatModelDefinition(selectedModel);
+
+	if (selectedChatModelConsumesImageCredits()) {
+		return "image";
+	}
 
 	if (modelDefinition?.mega && (subscriptionTier === "pro" || subscriptionTier === "pro_plus")) {
 		return "mega";
@@ -233,6 +251,10 @@ function isImagenModel(): boolean {
 function calculateCreditsNeeded(): number {
 	const isEditing = isImageEditingActive();
 	const isGenerating = isImageModeActive();
+
+	if (selectedChatModelConsumesImageCredits() && !isEditing && !isGenerating) {
+		return 1;
+	}
 
 	if (!isEditing && !isGenerating) {
 		return 0;

--- a/src/index.html
+++ b/src/index.html
@@ -2176,9 +2176,10 @@
 									<details class="subscription-faq-item" open>
 										<summary>What are Mega models?</summary>
 										<p>
-											Mega models are Zodiac's most expensive premium models. Right now, that
-											means Claude Opus. Pro and Pro Plus include a monthly Mega Credit allowance,
-											and each Mega request costs 1 credit. Max includes unlimited access.
+											Mega models are Zodiac's highest-cost premium models, including Claude Opus,
+											GPT-5.5, and DeepSeek V4 Pro. Pro and Pro Plus include a monthly Mega Credit
+											allowance, and each Mega request costs 1 credit. Max includes unlimited
+											access.
 										</p>
 									</details>
 

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -23,6 +23,7 @@ import type { DbPersonality } from "../types/Personality";
 import {
 	ChatModel,
 	DEFAULT_OPENROUTER_TITLE_MODEL,
+	getChatModelDefinition,
 	getValidChatModel,
 	isGeminiModel,
 	isOpenRouterModel,
@@ -1988,6 +1989,13 @@ async function finalizeTextChatSuccess(
 	hljs.highlightAll();
 	helpers.messageContainerScrollToBottom();
 	endGeneration(ctx.chatId);
+	if (
+		ctx.isPremiumEndpointPreferred &&
+		state.generatedImages.length > 0 &&
+		getChatModelDefinition(ctx.settings.model)?.consumesImageCredits
+	) {
+		void supabaseService.refreshImageGenerationRecord();
+	}
 
 	return ctx.userMessageElement;
 }

--- a/src/services/OpenRouter.service.ts
+++ b/src/services/OpenRouter.service.ts
@@ -490,7 +490,7 @@ export function buildOpenRouterRequest(args: {
 		plugins: buildOpenRouterPlugins({ isInternetSearchEnabled: args.isInternetSearchEnabled }),
 		response_format: args.responseFormat,
 		provider: definition?.provider === "openrouter" ? { require_parameters: false } : undefined,
-		modalities: definition?.supportsImageOutput ? ["text", "image"] : undefined
+		modalities: definition?.supportsImageOutput ? (definition.outputModalities ?? ["text", "image"]) : undefined
 	};
 }
 

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -64,6 +64,7 @@ export interface ChatModelDefinition {
 	supportsFileInput: boolean;
 	supportsImageOutput: boolean;
 	outputModalities?: ("text" | "image")[];
+	consumesImageCredits?: boolean;
 	roleplayModeSuggester?: boolean;
 	roleplaySuggestionThinkingCap?: number;
 }
@@ -402,7 +403,8 @@ export const OPENROUTER_CHAT_MODELS: ChatModelDefinition[] = [
 		supportsImageInput: true,
 		supportsFileInput: false,
 		supportsImageOutput: true,
-		outputModalities: ["image"]
+		outputModalities: ["image"],
+		consumesImageCredits: true
 	},
 	{
 		id: "google/gemma-4-31b-it",

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -63,6 +63,7 @@ export interface ChatModelDefinition {
 	supportsImageInput: boolean;
 	supportsFileInput: boolean;
 	supportsImageOutput: boolean;
+	outputModalities?: ("text" | "image")[];
 	roleplayModeSuggester?: boolean;
 	roleplaySuggestionThinkingCap?: number;
 }
@@ -252,6 +253,17 @@ export const OPENROUTER_CHAT_MODELS: ChatModelDefinition[] = [
 		supportsImageOutput: false
 	},
 	{
+		id: "openai/gpt-5.5",
+		label: "GPT-5.5",
+		provider: "openrouter",
+		mega: true,
+		supportsThinking: true,
+		supportsTemperature: true,
+		supportsImageInput: true,
+		supportsFileInput: true,
+		supportsImageOutput: false
+	},
+	{
 		id: "openai/gpt-5.4-pro",
 		label: "GPT-5.4 Pro",
 		provider: "openrouter",
@@ -313,6 +325,18 @@ export const OPENROUTER_CHAT_MODELS: ChatModelDefinition[] = [
 		supportsImageOutput: false
 	},
 	{
+		id: "anthropic/claude-haiku-4.5",
+		label: "Claude Haiku 4.5",
+		provider: "openrouter",
+		mega: false,
+		roleplayModeSuggester: true,
+		supportsThinking: true,
+		supportsTemperature: true,
+		supportsImageInput: true,
+		supportsFileInput: false,
+		supportsImageOutput: false
+	},
+	{
 		id: "anthropic/claude-opus-4.6",
 		label: "Claude Opus 4.6",
 		provider: "openrouter",
@@ -324,8 +348,89 @@ export const OPENROUTER_CHAT_MODELS: ChatModelDefinition[] = [
 		supportsImageOutput: false
 	},
 	{
+		id: "anthropic/claude-opus-4.7",
+		label: "Claude Opus 4.7",
+		provider: "openrouter",
+		mega: true,
+		supportsThinking: true,
+		supportsTemperature: true,
+		supportsImageInput: true,
+		supportsFileInput: false,
+		supportsImageOutput: false
+	},
+	{
+		id: "anthropic/claude-opus-4.8",
+		label: "Claude Opus 4.8",
+		provider: "openrouter",
+		mega: true,
+		supportsThinking: true,
+		supportsTemperature: true,
+		supportsImageInput: true,
+		supportsFileInput: false,
+		supportsImageOutput: false
+	},
+	{
+		id: "deepseek/deepseek-v4-pro",
+		label: "DeepSeek V4 Pro",
+		provider: "openrouter",
+		mega: true,
+		supportsThinking: true,
+		supportsTemperature: true,
+		supportsImageInput: false,
+		supportsFileInput: false,
+		supportsImageOutput: false
+	},
+	{
+		id: "deepseek/deepseek-v4-flash",
+		label: "DeepSeek V4 Flash",
+		provider: "openrouter",
+		mega: false,
+		roleplayModeSuggester: true,
+		supportsThinking: true,
+		supportsTemperature: true,
+		supportsImageInput: false,
+		supportsFileInput: false,
+		supportsImageOutput: false
+	},
+	{
+		id: "x-ai/grok-imagine-image-quality",
+		label: "Grok Imagine Image Quality",
+		provider: "openrouter",
+		mega: false,
+		supportsThinking: false,
+		supportsTemperature: true,
+		supportsImageInput: true,
+		supportsFileInput: false,
+		supportsImageOutput: true,
+		outputModalities: ["image"]
+	},
+	{
+		id: "google/gemma-4-31b-it",
+		label: "Gemma 4 31B",
+		provider: "openrouter",
+		mega: false,
+		roleplayModeSuggester: true,
+		supportsThinking: true,
+		supportsTemperature: true,
+		supportsImageInput: true,
+		supportsFileInput: false,
+		supportsImageOutput: false
+	},
+	{
 		id: "z-ai/glm-5",
 		label: "GLM 5",
+		provider: "openrouter",
+		mega: false,
+		roleplayModeSuggester: true,
+		supportsThinking: true,
+		supportsTemperature: true,
+		supportsImageInput: false,
+		supportsFileInput: false,
+		supportsImageOutput: false
+	},
+	{
+		id: "z-ai/glm-5.1",
+		label: "GLM 5.1",
 		provider: "openrouter",
 		mega: false,
 		roleplayModeSuggester: true,

--- a/tests/integration/messages/roleplay-composer-model-dropdown.test.ts
+++ b/tests/integration/messages/roleplay-composer-model-dropdown.test.ts
@@ -144,7 +144,11 @@ describe("roleplay suggestion model dropdown", () => {
 			"Gemini 3.1 Pro Preview via OpenRouter",
 			"GPT-OSS 120B",
 			"Claude Sonnet 4.6",
+			"Claude Haiku 4.5",
+			"DeepSeek V4 Flash",
 			"GLM 5",
+			"GLM 5.1",
+			"Gemma 4 31B",
 			"Qwen3.5 397B",
 			"Qwen3.5 Plus"
 		];

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -43,11 +43,12 @@ describe("premium endpoint model mapping", () => {
 		);
 	});
 
-	it("keeps OpenRouter Nano Banana variants as image-output chat models", () => {
+	it("keeps OpenRouter image-output variants as image-output chat models", () => {
 		const models = [
 			"google/gemini-2.5-flash-image",
 			"google/gemini-3-pro-image-preview",
-			"google/gemini-3.1-flash-image-preview"
+			"google/gemini-3.1-flash-image-preview",
+			"x-ai/grok-imagine-image-quality"
 		];
 
 		for (const model of models) {
@@ -82,7 +83,11 @@ describe("roleplay suggestion models", () => {
 			"Gemini 3.1 Pro Preview via OpenRouter",
 			"GPT-OSS 120B",
 			"Claude Sonnet 4.6",
+			"Claude Haiku 4.5",
+			"DeepSeek V4 Flash",
 			"GLM 5",
+			"GLM 5.1",
+			"Gemma 4 31B",
 			"Qwen3.5 397B",
 			"Qwen3.5 Plus"
 		];


### PR DESCRIPTION
## Summary
- Adds the requested OpenRouter chat models to the frontend picker: Opus 4.7, Opus 4.8, GPT-5.5, DeepSeek V4 Pro, Haiku 4.5, DeepSeek V4 Flash, Gemma 4 31B, and GLM 5.1.
- Adds Grok Imagine Image Quality as an image-output-only OpenRouter model.
- Marks the requested Mega models for UI labeling/access behavior and keeps roleplay model expectations covered by the model-list tests.
- Treats premium-endpoint Grok image generation as Image Credit consuming, including Image Credit gating and allowance refresh after successful generated-image responses.

## Notes
- The Windows create-worktree script was split out of this PR and moved to #187 so this PR stays scoped to model and image-credit behavior.
- BYOK OpenRouter usage remains separate from premium endpoint billing; the Image Credit behavior applies to premium endpoint usage.
- Image Credits remain metered for all paid tiers, including Max. This matches the existing dedicated image generation/editing model, where Max receives a monthly Image Credit allowance rather than unlimited Image Credits.

## Validation
- `npm.cmd run type-check`
- `npm.cmd run test:vitest` (18 files, 76 tests)