### PR TITLE
Add payload limits for attachments and message sends

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1014,12 +1014,6 @@
 			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-			"integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/@protobufjs/path": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
@@ -2683,9 +2677,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
-			"integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+			"version": "3.4.11",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+			"integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -4287,9 +4281,9 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
-			"integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -4299,7 +4293,6 @@
 				"@protobufjs/eventemitter": "^1.1.1",
 				"@protobufjs/fetch": "^1.1.1",
 				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.2",
 				"@protobufjs/path": "^1.1.2",
 				"@protobufjs/pool": "^1.1.0",
 				"@protobufjs/utf8": "^1.1.1",
@@ -4852,9 +4845,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-			"integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+			"version": "6.4.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+			"integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.25.0",

--- a/src/components/static/AttachButton.component.ts
+++ b/src/components/static/AttachButton.component.ts
@@ -1,3 +1,5 @@
+import { SUPPORTED_ACCEPT_ATTRIBUTE } from "../../utils/attachments";
+
 const attachButton = document.querySelector<HTMLButtonElement>("#btn-attach");
 
 if (!attachButton) {
@@ -11,7 +13,7 @@ attachButton.addEventListener("click", () => {
 		return;
 	}
 	input.value = ""; // Clear the input value to allow re-selection of the same file
-	input.accept = "image/*,application/pdf,text/plain"; // Accept images, PDFs, and text files
+	input.accept = SUPPORTED_ACCEPT_ATTRIBUTE;
 	input.multiple = true; // Allow multiple files to be selected
 	input.click();
 });

--- a/src/components/static/AttachmentPreview.component.ts
+++ b/src/components/static/AttachmentPreview.component.ts
@@ -50,8 +50,13 @@ export const attachmentPreviewElement = (file: File) => {
 		};
 		reader.readAsDataURL(file);
 	}
-	//text and pdf files
-	else if (file.type === "application/pdf" || file.type === "text/plain") {
+	//text-like and pdf files
+	else if (
+		file.type === "application/pdf" ||
+		file.type === "text/plain" ||
+		file.type === "text/markdown" ||
+		file.type === "application/json"
+	) {
 		container.classList.add("attachment-preview-container");
 		const removeButton = document.createElement("button");
 		removeButton.classList.add("btn-textual", "material-symbols-outlined", "btn-remove-attachment");

--- a/src/components/static/AttachmentPreview.component.ts
+++ b/src/components/static/AttachmentPreview.component.ts
@@ -1,4 +1,4 @@
-import { getFileSignature } from "../../utils/attachments";
+import { getFileSignature, validateAttachmentFile } from "../../utils/attachments";
 import { dispatchAppEvent, dispatchElementEvent } from "../../events";
 
 const input = document.querySelector<HTMLInputElement>("#attachments");
@@ -17,8 +17,12 @@ export const attachmentPreviewElement = (file: File) => {
 
 	// Check if this file is from chat history
 	const isFromChatHistory = (file as any)._fromChatHistory === true;
+	const validation = validateAttachmentFile(file);
+	const policy = validation.ok ? validation.policy : null;
+	const isImageAttachment = !!policy?.mimeTypes.some((mimeType) => mimeType.startsWith("image/"));
+	const isPreviewableFile = !!policy;
 
-	if (file.type.startsWith("image/")) {
+	if (isImageAttachment) {
 		const reader = new FileReader();
 		reader.onload = (e) => {
 			const removeButton = document.createElement("button");
@@ -51,12 +55,7 @@ export const attachmentPreviewElement = (file: File) => {
 		reader.readAsDataURL(file);
 	}
 	//text-like and pdf files
-	else if (
-		file.type === "application/pdf" ||
-		file.type === "text/plain" ||
-		file.type === "text/markdown" ||
-		file.type === "application/json"
-	) {
+	else if (isPreviewableFile) {
 		container.classList.add("attachment-preview-container");
 		const removeButton = document.createElement("button");
 		removeButton.classList.add("btn-textual", "material-symbols-outlined", "btn-remove-attachment");
@@ -71,7 +70,7 @@ export const attachmentPreviewElement = (file: File) => {
 		const fileName = document.createElement("span");
 		const fileType = document.createElement("span");
 		fileName.textContent = file.name;
-		fileType.textContent = file.type;
+		fileType.textContent = file.type || policy.label;
 		fileName.classList.add("attachment-name");
 		fileType.classList.add("attachment-type");
 		fileIcon.classList.add("material-symbols-outlined", "attachment-icon");
@@ -152,5 +151,8 @@ export function getAttachmentCount(): number {
 	if (!input || !input.files) {
 		return 0;
 	}
-	return Array.from(input.files).filter((f) => f.type.startsWith("image/")).length;
+	return Array.from(input.files).filter((file) => {
+		const validation = validateAttachmentFile(file);
+		return validation.ok && validation.policy.mimeTypes.some((mimeType) => mimeType.startsWith("image/"));
+	}).length;
 }

--- a/src/components/static/ChatInput.component.ts
+++ b/src/components/static/ChatInput.component.ts
@@ -6,8 +6,7 @@ import * as toastService from "../../services/Toast.service";
 import {
 	formatFileListForToast,
 	getFileSignature,
-	isSupportedFileType,
-	MAX_ATTACHMENT_BYTES,
+	validateAttachmentFile,
 	MAX_ATTACHMENTS,
 	SUPPORTED_ACCEPT_ATTRIBUTE,
 	SUPPORTED_TYPES_LABEL
@@ -17,6 +16,14 @@ import * as chatsService from "../../services/Chats.service";
 import { getSelectedEditingModel } from "./ImageEditModelSelector.component";
 import { updateImageCreditsLabelVisibility } from "./ImageCreditsLabel.component";
 import { MODEL_IMAGE_LIMITS } from "../../constants/ImageModels";
+import { SETTINGS_STORAGE_KEYS } from "../../constants/SettingsStorageKeys";
+import type { SubscriptionTier } from "../../types/Supabase";
+import {
+	countMessageCharacters,
+	getMessagePayloadLimitState,
+	getPremiumMessageCharacterLimit,
+	truncateToCharacterLimit
+} from "../../utils/payloadLimits";
 
 interface AttachmentRemovedDetail {
 	signature: string;
@@ -30,6 +37,7 @@ const attachmentPreview = document.querySelector<HTMLDivElement>("#attachment-pr
 const sendMessageButton = document.querySelector<HTMLButtonElement>("#btn-send");
 const internetSearchToggle = document.querySelector<HTMLButtonElement>("#btn-internet");
 const roleplayActionsMenu = document.querySelector<HTMLButtonElement>("#btn-roleplay");
+const messageBoxRight = document.querySelector<HTMLDivElement>(".message-box-right");
 
 //turn control elements (optional - for group chats)
 const turnControlPanel = document.querySelector<HTMLDivElement>("#turn-control-panel");
@@ -74,12 +82,23 @@ let isImageEditingActive = false;
 let isComposerAllowanceBlocked = false;
 let composerAllowanceBlockTitle = "Request unavailable";
 let composerAllowanceBlockText = "This request is currently unavailable.";
+let isMessagePayloadOverLimit = false;
+let activeSubscriptionTier: SubscriptionTier = "free";
+let isPremiumEndpointPreferred = getStoredPremiumEndpointPreference();
 
 let isUserTurnInRpg = true;
 let isGroupChatContext = false;
 let isRpgGroupChatContext = false;
 let isDynamicGroupChatContext = false;
 let allowDynamicPings = false;
+
+const messageLimitIndicator = document.createElement("button");
+messageLimitIndicator.type = "button";
+messageLimitIndicator.id = "message-limit-indicator";
+messageLimitIndicator.className = "message-limit-indicator hidden";
+messageLimitIndicator.setAttribute("aria-live", "polite");
+messageLimitIndicator.setAttribute("aria-disabled", "true");
+messageBoxRight?.prepend(messageLimitIndicator);
 
 function copyRuntimeFileMetadata(source: File, target: File): void {
 	const sourceMetadata = source as any;
@@ -126,12 +145,117 @@ const bottomUiResizeObserver = new ResizeObserver(() => {
 
 bottomUiResizeObserver.observe(bottomUiContainer);
 
+function getStoredPremiumEndpointPreference(): boolean {
+	const savedPreference = localStorage.getItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT);
+	return savedPreference === null ? true : savedPreference === "true";
+}
+
+function getActiveMessageCharacterLimit(): number | null {
+	return getPremiumMessageCharacterLimit(activeSubscriptionTier, isPremiumEndpointPreferred);
+}
+
+function getCurrentMessageCharacterCount(): number {
+	return countMessageCharacters(serializeMessageInput());
+}
+
+function getSelectedInputCharacterCount(): number {
+	const input = messageInput as HTMLDivElement;
+	const selection = window.getSelection();
+	if (!selection || selection.rangeCount === 0) return 0;
+	const range = selection.getRangeAt(0);
+	if (!input.contains(range.commonAncestorContainer)) return 0;
+
+	const fragment = range.cloneContents();
+	fragment.querySelectorAll(".mention-chip-input").forEach((node) => node.remove());
+	return countMessageCharacters(fragment.textContent ?? "");
+}
+
+function getRemainingCharacterBudgetForInsertion(): number | null {
+	const limit = getActiveMessageCharacterLimit();
+	if (limit === null) return null;
+
+	const selectedCount = getSelectedInputCharacterCount();
+	const currentCount = getCurrentMessageCharacterCount();
+	return Math.max(0, limit - Math.max(0, currentCount - selectedCount));
+}
+
+function showMessageLimitToast(): void {
+	const limit = getActiveMessageCharacterLimit();
+	if (limit === null) return;
+
+	toastService.warn({
+		title: "Message limit reached",
+		text: `Premium endpoint messages are limited to ${limit.toLocaleString()} characters on your current plan.`
+	});
+}
+
+function insertTextRespectingMessageLimit(text: string): void {
+	const normalizedText = text.replace(/\r/g, "");
+	const remaining = getRemainingCharacterBudgetForInsertion();
+	if (remaining === null) {
+		document.execCommand("insertText", false, normalizedText);
+		updateMessageLimitIndicator();
+		return;
+	}
+
+	if (remaining <= 0) {
+		showMessageLimitToast();
+		updateMessageLimitIndicator();
+		return;
+	}
+
+	const truncatedText = truncateToCharacterLimit(normalizedText, remaining);
+	if (countMessageCharacters(truncatedText) < countMessageCharacters(normalizedText)) {
+		showMessageLimitToast();
+	}
+
+	if (truncatedText) {
+		document.execCommand("insertText", false, truncatedText);
+	}
+	updateMessageLimitIndicator();
+}
+
+function updateMessageLimitIndicator(): void {
+	const indicator = messageLimitIndicator;
+	const limit = getActiveMessageCharacterLimit();
+	const state = getMessagePayloadLimitState(serializeMessageInput(), limit);
+	isMessagePayloadOverLimit = state.isOverLimit;
+
+	if (limit === null) {
+		indicator.classList.add("hidden");
+		indicator.textContent = "";
+		indicator.title = "";
+		indicator.setAttribute("aria-disabled", "true");
+		indicator.classList.remove("message-limit-indicator-near", "message-limit-indicator-over", "message-limit-indicator-upsell");
+		syncComposerInteractivity();
+		return;
+	}
+
+	indicator.classList.remove("hidden");
+	indicator.textContent = `${state.characterCount.toLocaleString()} / ${limit.toLocaleString()}`;
+	indicator.classList.toggle("message-limit-indicator-near", state.isNearLimit);
+	indicator.classList.toggle("message-limit-indicator-over", state.isOverLimit);
+
+	const shouldUpsell = activeSubscriptionTier === "pro" && state.isNearLimit;
+	indicator.classList.toggle("message-limit-indicator-upsell", shouldUpsell);
+	indicator.title = shouldUpsell
+		? "Need more? Switch to Pro+ messaging."
+		: `${(state.remaining ?? 0).toLocaleString()} characters remaining`;
+	indicator.setAttribute("aria-disabled", shouldUpsell ? "false" : "true");
+	syncComposerInteractivity();
+}
+
+function refreshMessageLimitFromPreference(): void {
+	isPremiumEndpointPreferred = getStoredPremiumEndpointPreference();
+	updateMessageLimitIndicator();
+}
+
 function syncComposerInteractivity(): void {
 	const canEdit = !isRpgGroupChatContext || (!isCurrentlyGenerating && isUserTurnInRpg);
 	messageInput!.contentEditable = String(canEdit);
 	messageInput!.classList.toggle("disabled", !canEdit);
 
-	const isSendActionBlocked = isComposerAllowanceBlocked && !isCurrentlyGenerating;
+	const isSendActionBlocked = (isComposerAllowanceBlocked || isMessagePayloadOverLimit) && !isCurrentlyGenerating;
 	const isSendUiDisabled =
 		isSendActionBlocked || (isRpgGroupChatContext && !isUserTurnInRpg && !isCurrentlyGenerating);
 
@@ -139,7 +263,9 @@ function syncComposerInteractivity(): void {
 	sendMessageButton!.classList.toggle("disabled", isSendUiDisabled);
 	sendMessageButton!.setAttribute("aria-disabled", isSendActionBlocked ? "true" : "false");
 
-	if (isSendActionBlocked) {
+	if (isMessagePayloadOverLimit) {
+		sendMessageButton!.title = "Message is over the character limit.";
+	} else if (isSendActionBlocked) {
 		sendMessageButton!.title = composerAllowanceBlockTitle;
 	} else if (!isCurrentlyGenerating) {
 		sendMessageButton!.title = "";
@@ -524,23 +650,53 @@ messageInput.addEventListener("focus", () => {
 	});
 });
 
+messageInput.addEventListener("beforeinput", (event: InputEvent) => {
+	if (event.isComposing || !event.inputType.startsWith("insert")) {
+		return;
+	}
+
+	const remaining = getRemainingCharacterBudgetForInsertion();
+	if (remaining === null) {
+		return;
+	}
+
+	const incomingText =
+		event.inputType === "insertParagraph" || event.inputType === "insertLineBreak" ? "\n" : event.data;
+	if (incomingText === null) {
+		if (remaining <= 0) {
+			event.preventDefault();
+			showMessageLimitToast();
+			updateMessageLimitIndicator();
+		}
+		return;
+	}
+
+	const normalizedText = incomingText.replace(/\r/g, "");
+	if (countMessageCharacters(normalizedText) <= remaining) {
+		return;
+	}
+
+	event.preventDefault();
+	insertTextRespectingMessageLimit(normalizedText);
+});
+
 messageInput.addEventListener("paste", (event: ClipboardEvent) => {
 	const files = collectFilesFromClipboard(event);
 	const text = event.clipboardData?.getData("text/plain") ?? "";
 	const hasFiles = files.length > 0;
-	const hasText = text.trim().length > 0;
+	const hasText = text.length > 0;
 
 	if (!hasFiles) {
 		if (hasText) {
 			event.preventDefault();
-			document.execCommand("insertText", false, text.replace(/\r/g, ""));
+			insertTextRespectingMessageLimit(text);
 		}
 		return;
 	}
 
 	event.preventDefault();
 	if (hasText) {
-		document.execCommand("insertText", false, text.replace(/\r/g, ""));
+		insertTextRespectingMessageLimit(text);
 	}
 	addAttachments(files);
 });
@@ -549,6 +705,7 @@ messageInput.addEventListener("input", () => {
 	if (messageInput.innerHTML.trim() === "<br>" || messageInput.innerHTML.trim() === "<p><br></p>") {
 		messageInput.innerHTML = "";
 	}
+	updateMessageLimitIndicator();
 	updateMentionMenu();
 });
 
@@ -664,6 +821,11 @@ sendMessageButton.addEventListener(
 					title: composerAllowanceBlockTitle,
 					text: composerAllowanceBlockText
 				});
+				return;
+			}
+
+			if (isMessagePayloadOverLimit) {
+				showMessageLimitToast();
 				return;
 			}
 
@@ -1002,6 +1164,7 @@ document.querySelector<HTMLDivElement>("#personalitiesDiv")!.addEventListener(
 		})()
 );
 
+updateMessageLimitIndicator();
 await setupBottomBar();
 
 // Listen for image editing toggle events
@@ -1046,6 +1209,35 @@ window.addEventListener("history-image-removed", () => {
 	currentHistoryImagePreview = null;
 });
 
+messageLimitIndicator.addEventListener("click", () => {
+	if (!messageLimitIndicator.classList.contains("message-limit-indicator-upsell")) {
+		return;
+	}
+
+	document.querySelector<HTMLButtonElement>("#btn-show-subscription-options")?.click();
+});
+
+window.addEventListener("auth-state-changed", (event: any) => {
+	const subscription = event.detail?.subscription ?? null;
+	if (!event.detail?.loggedIn || !subscription) {
+		activeSubscriptionTier = "free";
+		updateMessageLimitIndicator();
+		return;
+	}
+
+	// subscription-updated follows this event after Supabase UI refresh; keep this as a quick fallback.
+	activeSubscriptionTier = event.detail?.tier ?? activeSubscriptionTier;
+	updateMessageLimitIndicator();
+});
+
+window.addEventListener("subscription-updated", (event: any) => {
+	activeSubscriptionTier = event.detail?.tier ?? "free";
+	updateMessageLimitIndicator();
+});
+
+window.addEventListener("premium-endpoint-preference-changed", refreshMessageLimitFromPreference);
+window.addEventListener("settings-loaded-from-storage", refreshMessageLimitFromPreference);
+
 // Listen for attach-image-from-chat event (from Edit/Attach buttons in messages)
 window.addEventListener("attach-image-from-chat", (event: any) => {
 	const { file, toggleEditing } = event.detail;
@@ -1088,8 +1280,10 @@ function addAttachments(rawFiles: File[]): void {
 
 	const files = dedupeFiles(rawFiles);
 	const duplicateNames: string[] = [];
-	const oversizedNames: string[] = [];
-	const unsupportedNames: string[] = [];
+	const oversizedMessages: string[] = [];
+	const absoluteOversizedMessages: string[] = [];
+	const unsupportedMessages: string[] = [];
+	const mimeMismatchMessages: string[] = [];
 	let limitReached = false;
 	const added: File[] = [];
 	const existingSignatures = new Set(attachmentState.map(getFileSignature));
@@ -1101,14 +1295,18 @@ function addAttachments(rawFiles: File[]): void {
 		}
 
 		const displayName = getDisplayName(file);
+		const validation = validateAttachmentFile(file);
 
-		if (!isSupportedFileType(file)) {
-			unsupportedNames.push(displayName);
-			continue;
-		}
-
-		if (file.size > MAX_ATTACHMENT_BYTES) {
-			oversizedNames.push(displayName);
+		if (!validation.ok) {
+			if (validation.reason === "too-large") {
+				oversizedMessages.push(validation.message);
+			} else if (validation.reason === "absolute-too-large") {
+				absoluteOversizedMessages.push(validation.message);
+			} else if (validation.reason === "mime-mismatch") {
+				mimeMismatchMessages.push(validation.message);
+			} else {
+				unsupportedMessages.push(validation.message);
+			}
 			continue;
 		}
 
@@ -1164,17 +1362,34 @@ function addAttachments(rawFiles: File[]): void {
 		});
 	}
 
-	if (oversizedNames.length) {
+	if (oversizedMessages.length) {
 		toastService.warn({
-			title: oversizedNames.length === 1 ? "File exceeds 5 MB limit" : "Files exceed 5 MB limit",
-			text: formatFileListForToast(oversizedNames)
+			title: oversizedMessages.length === 1 ? "File exceeds type limit" : "Files exceed type limits",
+			text: formatFileListForToast(oversizedMessages)
 		});
 	}
 
-	if (unsupportedNames.length) {
+	if (absoluteOversizedMessages.length) {
+		toastService.warn({
+			title:
+				absoluteOversizedMessages.length === 1
+					? "File exceeds 10 MB attachment cap"
+					: "Files exceed 10 MB attachment cap",
+			text: formatFileListForToast(absoluteOversizedMessages)
+		});
+	}
+
+	if (mimeMismatchMessages.length) {
 		toastService.danger({
-			title: unsupportedNames.length === 1 ? "Unsupported file type" : "Unsupported file types",
-			text: `${formatFileListForToast(unsupportedNames)}\nSupported types: ${SUPPORTED_TYPES_LABEL}.`
+			title: mimeMismatchMessages.length === 1 ? "File type mismatch" : "File type mismatches",
+			text: formatFileListForToast(mimeMismatchMessages)
+		});
+	}
+
+	if (unsupportedMessages.length) {
+		toastService.danger({
+			title: unsupportedMessages.length === 1 ? "Unsupported file type" : "Unsupported file types",
+			text: `${formatFileListForToast(unsupportedMessages)}\nSupported types: ${SUPPORTED_TYPES_LABEL}.`
 		});
 	}
 

--- a/src/components/static/ChatInput.component.ts
+++ b/src/components/static/ChatInput.component.ts
@@ -17,6 +17,7 @@ import { getSelectedEditingModel } from "./ImageEditModelSelector.component";
 import { updateImageCreditsLabelVisibility } from "./ImageCreditsLabel.component";
 import { MODEL_IMAGE_LIMITS } from "../../constants/ImageModels";
 import { SETTINGS_STORAGE_KEYS } from "../../constants/SettingsStorageKeys";
+import { openCustomerPortal } from "../../services/Supabase.service";
 import type { SubscriptionTier } from "../../types/Supabase";
 import {
 	countMessageCharacters,
@@ -92,12 +93,11 @@ let isRpgGroupChatContext = false;
 let isDynamicGroupChatContext = false;
 let allowDynamicPings = false;
 
-const messageLimitIndicator = document.createElement("button");
-messageLimitIndicator.type = "button";
+const messageLimitIndicator = document.createElement("span");
 messageLimitIndicator.id = "message-limit-indicator";
 messageLimitIndicator.className = "message-limit-indicator hidden";
 messageLimitIndicator.setAttribute("aria-live", "polite");
-messageLimitIndicator.setAttribute("aria-disabled", "true");
+messageLimitIndicator.setAttribute("role", "status");
 messageBoxRight?.prepend(messageLimitIndicator);
 
 function copyRuntimeFileMetadata(source: File, target: File): void {
@@ -179,13 +179,39 @@ function getRemainingCharacterBudgetForInsertion(): number | null {
 	return Math.max(0, limit - Math.max(0, currentCount - selectedCount));
 }
 
+function formatCompactCharacterLimit(limit: number): string {
+	return limit >= 1000 && limit % 1000 === 0 ? `${limit / 1000}K` : limit.toLocaleString();
+}
+
 function showMessageLimitToast(): void {
 	const limit = getActiveMessageCharacterLimit();
 	if (limit === null) return;
 
+	const actions =
+		activeSubscriptionTier === "pro"
+			? [
+					{
+						label: "Upgrade to Pro+",
+						onClick: async (dismiss: () => void) => {
+							dismiss();
+							try {
+								await openCustomerPortal();
+							} catch (error) {
+								console.error(error);
+								toastService.danger({
+									title: "Portal unavailable",
+									text: "Unable to open your customer portal right now. Please try again in a moment."
+								});
+							}
+						}
+					}
+				]
+			: [];
+
 	toastService.warn({
 		title: "Message limit reached",
-		text: `Premium endpoint messages are limited to ${limit.toLocaleString()} characters on your current plan.`
+		text: `Premium endpoint messages are limited to ${limit.toLocaleString()} characters on your current plan.`,
+		actions
 	});
 }
 
@@ -215,39 +241,66 @@ function insertTextRespectingMessageLimit(text: string): void {
 	updateMessageLimitIndicator();
 }
 
-function updateMessageLimitIndicator(): void {
+function enforceCurrentMessageLimit(options: { showToast?: boolean } = {}): void {
+	const limit = getActiveMessageCharacterLimit();
+	if (limit === null) return;
+
+	const serializedMessage = serializeMessageInput();
+	const state = getMessagePayloadLimitState(serializedMessage, limit);
+	if (!state.isOverLimit) return;
+
+	(messageInput as HTMLDivElement).innerText = truncateToCharacterLimit(serializedMessage, limit);
+	closeMentionMenu();
+	if (options.showToast) {
+		showMessageLimitToast();
+	}
+}
+
+function updateMessageLimitIndicator(
+	options: { enforceCurrentContent?: boolean; showLimitToast?: boolean } = {}
+): void {
+	if (options.enforceCurrentContent) {
+		enforceCurrentMessageLimit({ showToast: options.showLimitToast });
+	}
+
 	const indicator = messageLimitIndicator;
 	const limit = getActiveMessageCharacterLimit();
 	const state = getMessagePayloadLimitState(serializeMessageInput(), limit);
 	isMessagePayloadOverLimit = state.isOverLimit;
 
-	if (limit === null) {
+	if (limit === null || !state.isNearLimit) {
 		indicator.classList.add("hidden");
 		indicator.textContent = "";
 		indicator.title = "";
-		indicator.setAttribute("aria-disabled", "true");
-		indicator.classList.remove("message-limit-indicator-near", "message-limit-indicator-over", "message-limit-indicator-upsell");
+		indicator.classList.remove(
+			"message-limit-indicator-near",
+			"message-limit-indicator-over",
+			"message-limit-indicator-upsell"
+		);
 		syncComposerInteractivity();
 		return;
 	}
 
 	indicator.classList.remove("hidden");
-	indicator.textContent = `${state.characterCount.toLocaleString()} / ${limit.toLocaleString()}`;
+	const remaining = state.remaining ?? 0;
+	indicator.textContent =
+		remaining === 0
+			? `${formatCompactCharacterLimit(limit)} character limit`
+			: `${state.characterCount.toLocaleString()} / ${limit.toLocaleString()}`;
 	indicator.classList.toggle("message-limit-indicator-near", state.isNearLimit);
 	indicator.classList.toggle("message-limit-indicator-over", state.isOverLimit);
 
 	const shouldUpsell = activeSubscriptionTier === "pro" && state.isNearLimit;
 	indicator.classList.toggle("message-limit-indicator-upsell", shouldUpsell);
 	indicator.title = shouldUpsell
-		? "Need more? Switch to Pro+ messaging."
+		? "Pro+ allows longer premium endpoint messages."
 		: `${(state.remaining ?? 0).toLocaleString()} characters remaining`;
-	indicator.setAttribute("aria-disabled", shouldUpsell ? "false" : "true");
 	syncComposerInteractivity();
 }
 
 function refreshMessageLimitFromPreference(): void {
 	isPremiumEndpointPreferred = getStoredPremiumEndpointPreference();
-	updateMessageLimitIndicator();
+	updateMessageLimitIndicator({ enforceCurrentContent: true, showLimitToast: true });
 }
 
 function syncComposerInteractivity(): void {
@@ -1209,14 +1262,6 @@ window.addEventListener("history-image-removed", () => {
 	currentHistoryImagePreview = null;
 });
 
-messageLimitIndicator.addEventListener("click", () => {
-	if (!messageLimitIndicator.classList.contains("message-limit-indicator-upsell")) {
-		return;
-	}
-
-	document.querySelector<HTMLButtonElement>("#btn-show-subscription-options")?.click();
-});
-
 window.addEventListener("auth-state-changed", (event: any) => {
 	const subscription = event.detail?.subscription ?? null;
 	if (!event.detail?.loggedIn || !subscription) {
@@ -1227,12 +1272,12 @@ window.addEventListener("auth-state-changed", (event: any) => {
 
 	// subscription-updated follows this event after Supabase UI refresh; keep this as a quick fallback.
 	activeSubscriptionTier = event.detail?.tier ?? activeSubscriptionTier;
-	updateMessageLimitIndicator();
+	updateMessageLimitIndicator({ enforceCurrentContent: true, showLimitToast: true });
 });
 
 window.addEventListener("subscription-updated", (event: any) => {
 	activeSubscriptionTier = event.detail?.tier ?? "free";
-	updateMessageLimitIndicator();
+	updateMessageLimitIndicator({ enforceCurrentContent: true, showLimitToast: true });
 });
 
 window.addEventListener("premium-endpoint-preference-changed", refreshMessageLimitFromPreference);

--- a/src/components/static/ChatInput.component.ts
+++ b/src/components/static/ChatInput.component.ts
@@ -241,6 +241,105 @@ function insertTextRespectingMessageLimit(text: string): void {
 	updateMessageLimitIndicator();
 }
 
+function getMentionMarkerLength(element: HTMLElement): number | null {
+	if (!element.classList.contains("mention-chip-input")) return null;
+	const personaId = element.dataset.personaId;
+	return personaId ? countMessageCharacters(`@<${personaId}>`) : 0;
+}
+
+function getAtomicNodeCharacterLength(node: Node): number | null {
+	if (node.nodeType === Node.TEXT_NODE) {
+		return countMessageCharacters(node.textContent ?? "");
+	}
+
+	if (!(node instanceof HTMLElement)) {
+		return null;
+	}
+
+	const mentionLength = getMentionMarkerLength(node);
+	if (mentionLength !== null) {
+		return mentionLength;
+	}
+
+	if (node.tagName === "BR") {
+		return 1;
+	}
+
+	return null;
+}
+
+function trimLiveComposerNodeFromEnd(node: Node, charactersToRemove: { value: number }): boolean {
+	if (charactersToRemove.value <= 0) return false;
+
+	const atomicLength = getAtomicNodeCharacterLength(node);
+	if (atomicLength !== null) {
+		if (atomicLength <= 0) {
+			node.parentNode?.removeChild(node);
+			return true;
+		}
+
+		if (node.nodeType === Node.TEXT_NODE) {
+			const text = node.textContent ?? "";
+			if (atomicLength <= charactersToRemove.value) {
+				node.parentNode?.removeChild(node);
+				charactersToRemove.value -= atomicLength;
+			} else {
+				node.textContent = truncateToCharacterLimit(text, atomicLength - charactersToRemove.value);
+				charactersToRemove.value = 0;
+			}
+			return true;
+		}
+
+		node.parentNode?.removeChild(node);
+		charactersToRemove.value = Math.max(0, charactersToRemove.value - atomicLength);
+		return true;
+	}
+
+	const children = Array.from(node.childNodes);
+	let didTrim = false;
+	for (let index = children.length - 1; index >= 0 && charactersToRemove.value > 0; index--) {
+		didTrim = trimLiveComposerNodeFromEnd(children[index], charactersToRemove) || didTrim;
+	}
+
+	if (node !== messageInput && node instanceof HTMLElement && node.childNodes.length === 0) {
+		node.remove();
+	}
+
+	return didTrim;
+}
+
+function moveCaretToComposerEnd(): void {
+	const input = messageInput as HTMLDivElement;
+	const selection = window.getSelection();
+	if (!selection) return;
+
+	const range = document.createRange();
+	range.selectNodeContents(input);
+	range.collapse(false);
+	selection.removeAllRanges();
+	selection.addRange(range);
+}
+
+function trimLiveComposerToSerializedLimit(limit: number): boolean {
+	let didTrim = false;
+
+	for (let attempts = 0; attempts < 20; attempts++) {
+		const serializedMessage = serializeMessageInput();
+		const overage = countMessageCharacters(serializedMessage) - limit;
+		if (overage <= 0) {
+			return didTrim;
+		}
+
+		const removed = trimLiveComposerNodeFromEnd(messageInput as HTMLDivElement, { value: overage });
+		if (!removed) {
+			return didTrim;
+		}
+		didTrim = true;
+	}
+
+	return didTrim;
+}
+
 function enforceCurrentMessageLimit(options: { showToast?: boolean } = {}): void {
 	const limit = getActiveMessageCharacterLimit();
 	if (limit === null) return;
@@ -249,7 +348,8 @@ function enforceCurrentMessageLimit(options: { showToast?: boolean } = {}): void
 	const state = getMessagePayloadLimitState(serializedMessage, limit);
 	if (!state.isOverLimit) return;
 
-	(messageInput as HTMLDivElement).innerText = truncateToCharacterLimit(serializedMessage, limit);
+	if (!trimLiveComposerToSerializedLimit(limit)) return;
+	moveCaretToComposerEnd();
 	closeMentionMenu();
 	if (options.showToast) {
 		showMessageLimitToast();

--- a/src/index.html
+++ b/src/index.html
@@ -2073,6 +2073,12 @@
 											<span class="feature-icon">✓</span
 											><span class="feature-text">Better memory recall in long chats</span>
 										</li>
+										<li class="feature-item">
+											<span class="feature-icon">✓</span
+											><span class="feature-text"
+												>Higher character limit for longer messages</span
+											>
+										</li>
 									</ul>
 								</div>
 								<button
@@ -2151,7 +2157,7 @@
 										<li class="feature-item">
 											<span class="feature-icon">✓</span
 											><span class="feature-text"
-												>Unlimited access to GPT-5.4 Pro and Claude Opus 4.6</span
+												>Unlimited access to Claude Opus 4.8 and GPT-5.5</span
 											>
 										</li>
 									</ul>

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -82,6 +82,13 @@ import {
 	UNRESTRICTED_SAFETY_SETTINGS
 } from "../utils/chatHistoryBuilder";
 import { resolveAttachmentFile, resolveThoughtSignature } from "../utils/blobResolver";
+import {
+	formatFileListForToast,
+	getAttachmentValidationSummary,
+	MAX_ATTACHMENTS,
+	SUPPORTED_TYPES_LABEL
+} from "../utils/attachments";
+import { getPremiumMessageCharacterLimit, validateMessagePayloadLimit } from "../utils/payloadLimits";
 
 import { sendGroupChatRpg, type RpgInputArgs } from "./RpgGroupChat";
 import { sendGroupChatDynamic, type DynamicInputArgs } from "./DynamicGroupChat";
@@ -1579,6 +1586,35 @@ function isViewingChat(chatId: string): boolean {
 	return chatsService.getCurrentChatId() === chatId;
 }
 
+function showAttachmentValidationFailures(errors: ReturnType<typeof getAttachmentValidationSummary>["errors"]): void {
+	const unsupportedMessages = errors.filter((error) => error.reason === "unsupported").map((error) => error.message);
+	const mismatchMessages = errors.filter((error) => error.reason === "mime-mismatch").map((error) => error.message);
+	const sizeMessages = errors
+		.filter((error) => error.reason === "too-large" || error.reason === "absolute-too-large")
+		.map((error) => error.message);
+
+	if (sizeMessages.length) {
+		warn({
+			title: sizeMessages.length === 1 ? "Attachment too large" : "Attachments too large",
+			text: formatFileListForToast(sizeMessages)
+		});
+	}
+
+	if (mismatchMessages.length) {
+		danger({
+			title: mismatchMessages.length === 1 ? "File type mismatch" : "File type mismatches",
+			text: formatFileListForToast(mismatchMessages)
+		});
+	}
+
+	if (unsupportedMessages.length) {
+		danger({
+			title: unsupportedMessages.length === 1 ? "Unsupported file type" : "Unsupported file types",
+			text: `${formatFileListForToast(unsupportedMessages)}\nSupported types: ${SUPPORTED_TYPES_LABEL}.`
+		});
+	}
+}
+
 async function performEarlyValidation(msg: string, options: SendOptions = {}): Promise<EarlyValidationResult> {
 	await ensureChatFullyHydratedForWrite(options.targetChatId);
 	const settings = settingsService.getSettings();
@@ -1597,12 +1633,6 @@ async function performEarlyValidation(msg: string, options: SendOptions = {}): P
 
 	const attachmentFiles: FileList = options.attachmentFiles ?? cloneFilesToFileList(attachmentsInput.files);
 
-	if (!options.attachmentFiles) {
-		attachmentsInput.value = "";
-		attachmentsInput.files = new DataTransfer().files;
-		clearAttachmentPreviews();
-	}
-
 	if (!selectedPersonality) {
 		return { canProceed: false };
 	}
@@ -1611,6 +1641,29 @@ async function performEarlyValidation(msg: string, options: SendOptions = {}): P
 	const tier = await supabaseService.getSubscriptionTier(subscription);
 	const hasSubscription = tier === "pro" || tier === "pro_plus" || tier === "max";
 	const isPremiumEndpointPreferred = hasSubscription && shouldPreferPremiumEndpoint();
+	const messageLimit = getPremiumMessageCharacterLimit(tier, isPremiumEndpointPreferred);
+	const messageLimitState = validateMessagePayloadLimit(msg, messageLimit);
+	if (messageLimitState.isOverLimit && messageLimit !== null) {
+		warn({
+			title: "Message too long",
+			text: `Premium endpoint messages are limited to ${messageLimit.toLocaleString()} characters on your current plan.`
+		});
+		return { canProceed: false };
+	}
+
+	const attachmentValidation = getAttachmentValidationSummary(attachmentFiles);
+	if (attachmentValidation.tooMany) {
+		warn({
+			title: "Attachment limit reached",
+			text: `You can attach up to ${MAX_ATTACHMENTS} files per message.`
+		});
+		return { canProceed: false };
+	}
+	if (attachmentValidation.errors.length) {
+		showAttachmentValidationFailures(attachmentValidation.errors);
+		return { canProceed: false };
+	}
+
 	if (isPremiumEndpointPreferred) {
 		settings.model = getValidChatModel(settings.model, {
 			hasGeminiAccess: true,
@@ -1655,6 +1708,12 @@ async function performEarlyValidation(msg: string, options: SendOptions = {}): P
 
 	if (!msg && !allowsEmptyMessage && (attachmentFiles?.length ?? 0) === 0) {
 		return { canProceed: false };
+	}
+
+	if (!options.attachmentFiles) {
+		attachmentsInput.value = "";
+		attachmentsInput.files = new DataTransfer().files;
+		clearAttachmentPreviews();
 	}
 
 	return {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4495,8 +4495,12 @@ body.full-width-chat #message-box {
 	margin-left: auto;
 }
 
-.image-credits-label {
+.image-credits-label,
+.message-limit-indicator {
+	box-sizing: border-box;
 	font-size: 0.8rem;
+	font-family: inherit;
+	font-weight: inherit;
 	line-height: 1.2;
 	padding: 0.25rem 0.6rem;
 	border-radius: 999px;
@@ -4506,6 +4510,7 @@ body.full-width-chat #message-box {
 	display: inline-flex;
 	align-items: center;
 	gap: 0.35rem;
+	min-height: 0;
 	cursor: pointer;
 	user-select: none;
 	transition:
@@ -4519,17 +4524,6 @@ body.full-width-chat #message-box {
 }
 
 .message-limit-indicator {
-	display: inline-flex;
-	align-items: center;
-	gap: 0.25rem;
-	padding: 0.25rem 0.55rem;
-	border: 1px solid var(--badge-border);
-	border-radius: 999px;
-	background: var(--badge-bg);
-	color: var(--badge-fg);
-	font-size: 0.78rem;
-	line-height: 1.2;
-	white-space: nowrap;
 	cursor: default;
 }
 
@@ -4541,15 +4535,6 @@ body.full-width-chat #message-box {
 .message-limit-indicator-over {
 	border-color: var(--danger);
 	color: var(--danger);
-}
-
-.message-limit-indicator-upsell {
-	cursor: pointer;
-}
-
-.message-limit-indicator-upsell:hover {
-	background: var(--badge-bg-hover);
-	border-color: var(--badge-border-hover);
 }
 
 .image-credits-label:active {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4518,6 +4518,40 @@ body.full-width-chat #message-box {
 	border-color: var(--badge-border-hover);
 }
 
+.message-limit-indicator {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	padding: 0.25rem 0.55rem;
+	border: 1px solid var(--badge-border);
+	border-radius: 999px;
+	background: var(--badge-bg);
+	color: var(--badge-fg);
+	font-size: 0.78rem;
+	line-height: 1.2;
+	white-space: nowrap;
+	cursor: default;
+}
+
+.message-limit-indicator-near {
+	border-color: var(--warning-border);
+	color: var(--warning-fg);
+}
+
+.message-limit-indicator-over {
+	border-color: var(--danger);
+	color: var(--danger);
+}
+
+.message-limit-indicator-upsell {
+	cursor: pointer;
+}
+
+.message-limit-indicator-upsell:hover {
+	background: var(--badge-bg-hover);
+	border-color: var(--badge-border-hover);
+}
+
 .image-credits-label:active {
 	transform: scale(0.98);
 }

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1,8 +1,4 @@
-export type AttachmentValidationFailureReason =
-	| "unsupported"
-	| "mime-mismatch"
-	| "too-large"
-	| "absolute-too-large";
+export type AttachmentValidationFailureReason = "unsupported" | "mime-mismatch" | "too-large" | "absolute-too-large";
 
 export interface AttachmentPolicy {
 	extensions: string[];
@@ -83,7 +79,7 @@ export function validateAttachmentFile(file: File): AttachmentValidationResult {
 	}
 
 	const mimeType = file.type.trim().toLowerCase();
-	if (!policy.mimeTypes.includes(mimeType)) {
+	if (!isUnknownMimeType(mimeType) && !policy.mimeTypes.includes(mimeType)) {
 		return {
 			ok: false,
 			reason: "mime-mismatch",
@@ -122,7 +118,9 @@ export function getAttachmentValidationSummary(files: ArrayLike<File> | Iterable
 	tooMany: boolean;
 } {
 	const fileList = Array.from(files);
-	const errors = fileList.map(validateAttachmentFile).filter((result): result is AttachmentValidationFailure => !result.ok);
+	const errors = fileList
+		.map(validateAttachmentFile)
+		.filter((result): result is AttachmentValidationFailure => !result.ok);
 	return {
 		ok: fileList.length <= MAX_ATTACHMENTS && errors.length === 0,
 		errors,
@@ -168,4 +166,8 @@ function formatMimeTypes(mimeTypes: string[]): string {
 		return mimeTypes[0];
 	}
 	return mimeTypes.slice(0, -1).join(", ") + " or " + mimeTypes[mimeTypes.length - 1];
+}
+
+function isUnknownMimeType(mimeType: string): boolean {
+	return mimeType === "" || mimeType === "application/octet-stream";
 }

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1,33 +1,133 @@
-const SUPPORTED_MIME_PATTERNS: RegExp[] = [/^image\//i, /^application\/pdf$/i, /^text\/plain$/i];
+export type AttachmentValidationFailureReason =
+	| "unsupported"
+	| "mime-mismatch"
+	| "too-large"
+	| "absolute-too-large";
 
-const IMAGE_EXTENSIONS = ["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg", "avif", "heic", "heif"];
-const VIDEO_EXTENSIONS = ["mp4", "mov", "mkv", "webm", "avi", "m4v", "mpg", "mpeg"];
-const AUDIO_EXTENSIONS = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "opus", "oga"];
-const TEXT_EXTENSIONS = ["txt", "text"];
-const PDF_EXTENSIONS = ["pdf"];
+export interface AttachmentPolicy {
+	extensions: string[];
+	mimeTypes: string[];
+	maxBytes: number;
+	label: string;
+}
 
-const EXTENSION_CATALOG = new Map<string, string>();
-IMAGE_EXTENSIONS.forEach((ext) => EXTENSION_CATALOG.set(ext, "image"));
-VIDEO_EXTENSIONS.forEach((ext) => EXTENSION_CATALOG.set(ext, "video"));
-AUDIO_EXTENSIONS.forEach((ext) => EXTENSION_CATALOG.set(ext, "audio"));
-TEXT_EXTENSIONS.forEach((ext) => EXTENSION_CATALOG.set(ext, "text"));
-PDF_EXTENSIONS.forEach((ext) => EXTENSION_CATALOG.set(ext, "pdf"));
+export interface AttachmentValidationSuccess {
+	ok: true;
+	policy: AttachmentPolicy;
+	extension: string;
+}
 
-export const SUPPORTED_ACCEPT_ATTRIBUTE = "image/*,application/pdf,text/plain";
-export const SUPPORTED_TYPES_LABEL = "images, PDF, plain text";
-export const MAX_ATTACHMENTS = 6;
-export const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024; //10MB
+export interface AttachmentValidationFailure {
+	ok: false;
+	reason: AttachmentValidationFailureReason;
+	extension?: string;
+	expectedMimeTypes?: string[];
+	maxBytes?: number;
+	message: string;
+}
+
+export type AttachmentValidationResult = AttachmentValidationSuccess | AttachmentValidationFailure;
+
+const KIB = 1024;
+const MIB = 1024 * 1024;
+
+const TEXT_FILE_BYTES = 512 * KIB;
+const PDF_FILE_BYTES = 1 * MIB;
+const IMAGE_FILE_BYTES = 5 * MIB;
+
+const ATTACHMENT_POLICIES: AttachmentPolicy[] = [
+	{ extensions: ["txt"], mimeTypes: ["text/plain"], maxBytes: TEXT_FILE_BYTES, label: "TXT" },
+	{ extensions: ["md"], mimeTypes: ["text/markdown", "text/plain"], maxBytes: TEXT_FILE_BYTES, label: "Markdown" },
+	{ extensions: ["json"], mimeTypes: ["application/json"], maxBytes: TEXT_FILE_BYTES, label: "JSON" },
+	{ extensions: ["pdf"], mimeTypes: ["application/pdf"], maxBytes: PDF_FILE_BYTES, label: "PDF" },
+	{ extensions: ["jpg", "jpeg"], mimeTypes: ["image/jpeg"], maxBytes: IMAGE_FILE_BYTES, label: "JPEG" },
+	{ extensions: ["png"], mimeTypes: ["image/png"], maxBytes: IMAGE_FILE_BYTES, label: "PNG" }
+];
+
+const POLICY_BY_EXTENSION = new Map<string, AttachmentPolicy>();
+for (const policy of ATTACHMENT_POLICIES) {
+	for (const extension of policy.extensions) {
+		POLICY_BY_EXTENSION.set(extension, policy);
+	}
+}
+
+export const SUPPORTED_ACCEPT_ATTRIBUTE =
+	".txt,.md,.json,.pdf,.jpg,.jpeg,.png,text/plain,text/markdown,application/json,application/pdf,image/jpeg,image/png";
+export const SUPPORTED_TYPES_LABEL = "TXT, Markdown, JSON, PDF, JPEG, and PNG files";
+export const MAX_ATTACHMENTS = 5;
+export const MAX_ATTACHMENT_BYTES = 10 * MIB; // 10MB absolute backstop
 
 export function isSupportedFileType(file: File): boolean {
-	if (SUPPORTED_MIME_PATTERNS.some((pattern) => pattern.test(file.type))) {
-		return true;
-	}
+	return validateAttachmentFile(file).ok;
+}
 
+export function validateAttachmentFile(file: File): AttachmentValidationResult {
+	const displayName = getDisplayName(file);
 	const extension = getExtension(file.name);
 	if (!extension) {
-		return false;
+		return {
+			ok: false,
+			reason: "unsupported",
+			message: `${displayName} has no supported file extension. Supported types: ${SUPPORTED_TYPES_LABEL}.`
+		};
 	}
-	return EXTENSION_CATALOG.has(extension);
+
+	const policy = POLICY_BY_EXTENSION.get(extension);
+	if (!policy) {
+		return {
+			ok: false,
+			reason: "unsupported",
+			extension,
+			message: `${displayName} uses .${extension}, which is not supported. Supported types: ${SUPPORTED_TYPES_LABEL}.`
+		};
+	}
+
+	const mimeType = file.type.trim().toLowerCase();
+	if (!policy.mimeTypes.includes(mimeType)) {
+		return {
+			ok: false,
+			reason: "mime-mismatch",
+			extension,
+			expectedMimeTypes: policy.mimeTypes,
+			message: `${displayName} must be a .${extension} file with ${formatMimeTypes(policy.mimeTypes)}.`
+		};
+	}
+
+	if (file.size > MAX_ATTACHMENT_BYTES) {
+		return {
+			ok: false,
+			reason: "absolute-too-large",
+			extension,
+			maxBytes: MAX_ATTACHMENT_BYTES,
+			message: `${displayName} exceeds the 10 MB attachment cap.`
+		};
+	}
+
+	if (file.size > policy.maxBytes) {
+		return {
+			ok: false,
+			reason: "too-large",
+			extension,
+			maxBytes: policy.maxBytes,
+			message: `${displayName} exceeds the ${formatBytes(policy.maxBytes)} limit for ${policy.label} files.`
+		};
+	}
+
+	return { ok: true, policy, extension };
+}
+
+export function getAttachmentValidationSummary(files: ArrayLike<File> | Iterable<File>): {
+	ok: boolean;
+	errors: AttachmentValidationFailure[];
+	tooMany: boolean;
+} {
+	const fileList = Array.from(files);
+	const errors = fileList.map(validateAttachmentFile).filter((result): result is AttachmentValidationFailure => !result.ok);
+	return {
+		ok: fileList.length <= MAX_ATTACHMENTS && errors.length === 0,
+		errors,
+		tooMany: fileList.length > MAX_ATTACHMENTS
+	};
 }
 
 export function getFileSignature(file: File): string {
@@ -42,9 +142,30 @@ export function formatFileListForToast(fileNames: string[]): string {
 	return fileNames.map((name) => `• ${name}`).join("\n");
 }
 
+export function formatBytes(bytes: number): string {
+	if (bytes % MIB === 0) {
+		return `${bytes / MIB} MB`;
+	}
+	if (bytes % KIB === 0) {
+		return `${bytes / KIB} KB`;
+	}
+	return `${bytes} bytes`;
+}
+
+function getDisplayName(file: File): string {
+	return file.name?.trim() ? file.name : "Unnamed file";
+}
+
 function getExtension(name: string): string | undefined {
 	if (!name.includes(".")) {
 		return undefined;
 	}
 	return name.split(".").pop()?.toLowerCase();
+}
+
+function formatMimeTypes(mimeTypes: string[]): string {
+	if (mimeTypes.length === 1) {
+		return mimeTypes[0];
+	}
+	return mimeTypes.slice(0, -1).join(", ") + " or " + mimeTypes[mimeTypes.length - 1];
 }

--- a/src/utils/payloadLimits.ts
+++ b/src/utils/payloadLimits.ts
@@ -1,0 +1,69 @@
+import type { SubscriptionTier } from "../types/Supabase";
+
+export const PRO_MESSAGE_CHARACTER_LIMIT = 5000;
+export const PRO_PLUS_MESSAGE_CHARACTER_LIMIT = 15000;
+export const MESSAGE_LIMIT_UPSELL_THRESHOLD = 0.8;
+
+export interface MessagePayloadLimitState {
+	limit: number | null;
+	characterCount: number;
+	remaining: number | null;
+	isNearLimit: boolean;
+	isOverLimit: boolean;
+}
+
+export function getPremiumMessageCharacterLimit(
+	tier: SubscriptionTier | null | undefined,
+	isPremiumEndpointPreferred: boolean
+): number | null {
+	if (!isPremiumEndpointPreferred) {
+		return null;
+	}
+
+	if (tier === "pro") {
+		return PRO_MESSAGE_CHARACTER_LIMIT;
+	}
+
+	if (tier === "pro_plus" || tier === "max") {
+		return PRO_PLUS_MESSAGE_CHARACTER_LIMIT;
+	}
+
+	return null;
+}
+
+export function countMessageCharacters(message: string): number {
+	return Array.from(message).length;
+}
+
+export function truncateToCharacterLimit(message: string, limit: number): string {
+	if (limit <= 0) {
+		return "";
+	}
+	return Array.from(message).slice(0, limit).join("");
+}
+
+export function getMessagePayloadLimitState(message: string, limit: number | null): MessagePayloadLimitState {
+	const characterCount = countMessageCharacters(message);
+
+	if (limit === null) {
+		return {
+			limit,
+			characterCount,
+			remaining: null,
+			isNearLimit: false,
+			isOverLimit: false
+		};
+	}
+
+	return {
+		limit,
+		characterCount,
+		remaining: Math.max(0, limit - characterCount),
+		isNearLimit: characterCount >= Math.floor(limit * MESSAGE_LIMIT_UPSELL_THRESHOLD),
+		isOverLimit: characterCount > limit
+	};
+}
+
+export function validateMessagePayloadLimit(message: string, limit: number | null): MessagePayloadLimitState {
+	return getMessagePayloadLimitState(message, limit);
+}

--- a/src/utils/payloadLimits.ts
+++ b/src/utils/payloadLimits.ts
@@ -2,7 +2,7 @@ import type { SubscriptionTier } from "../types/Supabase";
 
 export const PRO_MESSAGE_CHARACTER_LIMIT = 5000;
 export const PRO_PLUS_MESSAGE_CHARACTER_LIMIT = 15000;
-export const MESSAGE_LIMIT_UPSELL_THRESHOLD = 0.8;
+export const MESSAGE_LIMIT_INDICATOR_REMAINING_THRESHOLD = 1000;
 
 export interface MessagePayloadLimitState {
 	limit: number | null;
@@ -59,7 +59,7 @@ export function getMessagePayloadLimitState(message: string, limit: number | nul
 		limit,
 		characterCount,
 		remaining: Math.max(0, limit - characterCount),
-		isNearLimit: characterCount >= Math.floor(limit * MESSAGE_LIMIT_UPSELL_THRESHOLD),
+		isNearLimit: limit - characterCount <= MESSAGE_LIMIT_INDICATOR_REMAINING_THRESHOLD,
 		isOverLimit: characterCount > limit
 	};
 }

--- a/tests/integration/attachments/chat-input-attachments.test.ts
+++ b/tests/integration/attachments/chat-input-attachments.test.ts
@@ -216,6 +216,17 @@ describe("ChatInput attachment drop workflow", () => {
 		expect(getInputFiles().map((file) => file.name)).toEqual(["image.png", "photo.jpeg"]);
 	});
 
+	it("drop accepts supported extensions when the browser reports an unknown MIME type", async () => {
+		const markdownFile = createFile("notes.md", "", "# hello");
+		const jsonFile = createFile("data.json", "application/octet-stream", '{"ok":true}');
+		const textFile = createFile("notes.txt", "", "hello world");
+
+		dispatchDrop([markdownFile, jsonFile, textFile]);
+
+		expect(getInputFiles().map((file) => file.name)).toEqual(["notes.md", "data.json", "notes.txt"]);
+		expect(getPreviewNames()).toEqual(["notes.md", "data.json", "notes.txt"]);
+	});
+
 	it("drop enforces the five file attachment limit", async () => {
 		const toastService = await import("../../../src/services/Toast.service");
 		const files = Array.from({ length: MAX_ATTACHMENTS + 1 }, (_, index) =>

--- a/tests/integration/attachments/chat-input-attachments.test.ts
+++ b/tests/integration/attachments/chat-input-attachments.test.ts
@@ -14,6 +14,7 @@ vi.mock("../../../src/services/Message.service", () => ({
 
 vi.mock("../../../src/utils/helpers", () => ({
 	getClientScrollbarWidth: vi.fn(() => 0),
+	getEncoded: vi.fn((html: string) => html),
 	showElement: vi.fn(),
 	messageContainerScrollToBottom: vi.fn()
 }));

--- a/tests/integration/attachments/chat-input-attachments.test.ts
+++ b/tests/integration/attachments/chat-input-attachments.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { MAX_ATTACHMENT_BYTES } from "../../../src/utils/attachments";
+import { MAX_ATTACHMENTS } from "../../../src/utils/attachments";
 import { bootstrapDom } from "../../helpers/dom";
 import { MockDataTransfer, makeEmptyFileList } from "../../helpers/files";
 
@@ -97,8 +97,8 @@ function createFile(name: string, type: string, contents: string): File {
 	return new File([contents], name, { type, lastModified: 1 });
 }
 
-function createOversizedTextFile(name = "too-large.txt"): File {
-	return createFile(name, "text/plain", "x".repeat(MAX_ATTACHMENT_BYTES + 1));
+function createSizedFile(name: string, type: string, size: number): File {
+	return new File([new Uint8Array(size)], name, { type, lastModified: 1 });
 }
 
 function getAttachmentsInput(): HTMLInputElement {
@@ -187,14 +187,54 @@ describe("ChatInput attachment drop workflow", () => {
 		vi.clearAllMocks();
 	});
 
-	it("drop attaches files to the backing input", async () => {
+	it("drop attaches supported files to the backing input", async () => {
 		const notesFile = createFile("notes.txt", "text/plain", "hello world");
+		const markdownFile = createFile("notes.md", "text/markdown", "# hello");
+		const jsonFile = createFile("data.json", "application/json", '{"ok":true}');
 		const pdfFile = createFile("guide.pdf", "application/pdf", "pdf-content");
+		const jpegFile = createFile("photo.jpg", "image/jpeg", "jpeg-content");
 
-		dispatchDrop([notesFile, pdfFile]);
+		dispatchDrop([notesFile, markdownFile, jsonFile, pdfFile, jpegFile]);
 
-		expect(getInputFiles().map((file) => file.name)).toEqual(["notes.txt", "guide.pdf"]);
-		expect(getPreviewNames()).toEqual(["notes.txt", "guide.pdf"]);
+		expect(getInputFiles().map((file) => file.name)).toEqual([
+			"notes.txt",
+			"notes.md",
+			"data.json",
+			"guide.pdf",
+			"photo.jpg"
+		]);
+		expect(getPreviewNames()).toEqual(["notes.txt", "notes.md", "data.json", "guide.pdf"]);
+	});
+
+	it("drop accepts png and jpeg extensions with matching MIME types", async () => {
+		const pngFile = createFile("image.png", "image/png", "png-content");
+		const jpegFile = createFile("photo.jpeg", "image/jpeg", "jpeg-content");
+
+		dispatchDrop([pngFile, jpegFile]);
+
+		expect(getInputFiles().map((file) => file.name)).toEqual(["image.png", "photo.jpeg"]);
+	});
+
+	it("drop enforces the five file attachment limit", async () => {
+		const toastService = await import("../../../src/services/Toast.service");
+		const files = Array.from({ length: MAX_ATTACHMENTS + 1 }, (_, index) =>
+			createFile(`notes-${index + 1}.txt`, "text/plain", "hello")
+		);
+
+		dispatchDrop(files);
+
+		expect(getInputFiles().map((file) => file.name)).toEqual([
+			"notes-1.txt",
+			"notes-2.txt",
+			"notes-3.txt",
+			"notes-4.txt",
+			"notes-5.txt"
+		]);
+		expect(vi.mocked(toastService.warn)).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: "Attachment limit reached"
+			})
+		);
 	});
 
 	it("drop dedupes duplicate files", async () => {
@@ -215,7 +255,7 @@ describe("ChatInput attachment drop workflow", () => {
 
 	it("drop rejects unsupported files", async () => {
 		const toastService = await import("../../../src/services/Toast.service");
-		const unsupportedFile = createFile("data.json", "application/json", '{"ok":true}');
+		const unsupportedFile = createFile("data.csv", "text/csv", "ok,true");
 
 		dispatchDrop([unsupportedFile]);
 
@@ -228,17 +268,44 @@ describe("ChatInput attachment drop workflow", () => {
 		);
 	});
 
-	it("drop rejects oversized files", async () => {
+	it("drop rejects files with mismatched extension and MIME type", async () => {
 		const toastService = await import("../../../src/services/Toast.service");
-		const oversizedFile = createOversizedTextFile();
+		const mismatchedFile = createFile("notes.txt", "application/json", '{"ok":true}');
 
-		dispatchDrop([oversizedFile]);
+		dispatchDrop([mismatchedFile]);
+
+		expect(getInputFiles()).toHaveLength(0);
+		expect(getPreviewNames()).toEqual([]);
+		expect(vi.mocked(toastService.danger)).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: "File type mismatch"
+			})
+		);
+	});
+
+	it("drop rejects files over their per-type size caps", async () => {
+		const toastService = await import("../../../src/services/Toast.service");
+		const oversizedTextFile = createSizedFile("too-large.txt", "text/plain", 512 * 1024 + 1);
+		const oversizedMarkdownFile = createSizedFile("too-large.md", "text/markdown", 512 * 1024 + 1);
+		const oversizedJsonFile = createSizedFile("too-large.json", "application/json", 512 * 1024 + 1);
+		const oversizedPdfFile = createSizedFile("too-large.pdf", "application/pdf", 1024 * 1024 + 1);
+		const oversizedPngFile = createSizedFile("too-large.png", "image/png", 5 * 1024 * 1024 + 1);
+		const oversizedJpegFile = createSizedFile("too-large.jpg", "image/jpeg", 5 * 1024 * 1024 + 1);
+
+		dispatchDrop([
+			oversizedTextFile,
+			oversizedMarkdownFile,
+			oversizedJsonFile,
+			oversizedPdfFile,
+			oversizedPngFile,
+			oversizedJpegFile
+		]);
 
 		expect(getInputFiles()).toHaveLength(0);
 		expect(getPreviewNames()).toEqual([]);
 		expect(vi.mocked(toastService.warn)).toHaveBeenCalledWith(
 			expect.objectContaining({
-				title: "File exceeds 5 MB limit"
+				title: "Files exceed type limits"
 			})
 		);
 	});

--- a/tests/integration/messages/message-send.test.ts
+++ b/tests/integration/messages/message-send.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Db } from "../../../src/services/Db.service";
 import type { Chat, GroupChatConfig } from "../../../src/types/Chat";
 import type { Personality } from "../../../src/types/Personality";
+import { PRO_MESSAGE_CHARACTER_LIMIT } from "../../../src/utils/payloadLimits";
 import { makeChat } from "../../fixtures/chats";
 import { makeModelMessage, makeUserMessage } from "../../fixtures/messages";
 import { waitForCondition } from "../../helpers/async";
@@ -476,6 +477,67 @@ describe("Message send lifecycle", () => {
 		expect(visibleDomMessages).toHaveLength(2);
 		expect(getVisibleMessageTexts()).toEqual(["Hello normal chat", "Mocked assistant reply"]);
 		expect(document.querySelector("#chat-title")?.textContent).toBe("Normal Chat");
+	});
+
+	it("blocks over-limit Pro premium endpoint messages before persistence or fetch", async () => {
+		seedMockPersonas([
+			{
+				id: "persona-premium-limit",
+				persona: {
+					name: "Premium Limit Persona",
+					description: "Used for payload limit tests."
+				}
+			}
+		]);
+
+		const { db: testDb, chatsService, messageService } = await loadServices();
+		db = testDb;
+		const supabaseService = await import("../../../src/services/Supabase.service");
+		const apiKeyInput = await import("../../../src/components/static/ApiKeyInput.component");
+		const toastService = await import("../../../src/services/Toast.service");
+
+		vi.mocked(supabaseService.getUserSubscription).mockResolvedValue({
+			id: "sub-pro",
+			user_id: "user-pro",
+			status: "active",
+			price_id: "price-pro"
+		} as any);
+		vi.mocked(supabaseService.getSubscriptionTier).mockReturnValue("pro");
+		vi.mocked(apiKeyInput.shouldPreferPremiumEndpoint).mockReturnValue(true);
+
+		const chatId = await createAndLoadChat({
+			chatsService,
+			chat: makeChat({
+				id: "chat-premium-limit",
+				title: "Premium Limit Chat",
+				content: []
+			})
+		});
+
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		try {
+			await messageService.send("x".repeat(PRO_MESSAGE_CHARACTER_LIMIT + 1), {
+				targetChatId: chatId,
+				selectedPersonalityId: "persona-premium-limit",
+				attachmentFiles: makeEmptyFileList()
+			});
+		} finally {
+			vi.unstubAllGlobals();
+		}
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(toastService.warn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: "Message too long"
+			})
+		);
+
+		const persistedChat = await testDb.chats.get(chatId);
+		expect(persistedChat?.content ?? []).toHaveLength(0);
+		expect(getVisibleMessageElements()).toHaveLength(0);
+		expect(messageService.getIsGenerating(chatId)).toBe(false);
 	});
 
 	it("allows image generation with credits without a Gemini API key", async () => {

--- a/tests/unit/payload-limits.test.ts
+++ b/tests/unit/payload-limits.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	countMessageCharacters,
+	getMessagePayloadLimitState,
+	getPremiumMessageCharacterLimit,
+	PRO_MESSAGE_CHARACTER_LIMIT,
+	PRO_PLUS_MESSAGE_CHARACTER_LIMIT,
+	truncateToCharacterLimit
+} from "../../src/utils/payloadLimits";
+
+describe("payload limits", () => {
+	it("does not limit logged-out, free, or BYOK premium-pref-disabled users", () => {
+		expect(getPremiumMessageCharacterLimit("free", true)).toBeNull();
+		expect(getPremiumMessageCharacterLimit(null, true)).toBeNull();
+		expect(getPremiumMessageCharacterLimit("pro", false)).toBeNull();
+		expect(getPremiumMessageCharacterLimit("pro_plus", false)).toBeNull();
+		expect(getPremiumMessageCharacterLimit("max", false)).toBeNull();
+	});
+
+	it("returns premium endpoint character limits by paid tier", () => {
+		expect(getPremiumMessageCharacterLimit("pro", true)).toBe(PRO_MESSAGE_CHARACTER_LIMIT);
+		expect(getPremiumMessageCharacterLimit("pro_plus", true)).toBe(PRO_PLUS_MESSAGE_CHARACTER_LIMIT);
+		expect(getPremiumMessageCharacterLimit("max", true)).toBe(PRO_PLUS_MESSAGE_CHARACTER_LIMIT);
+	});
+
+	it("counts unicode code points instead of UTF-16 code units", () => {
+		expect(countMessageCharacters("a😀b")).toBe(3);
+		expect(truncateToCharacterLimit("a😀b", 2)).toBe("a😀");
+	});
+
+	it("marks messages near and over the active limit", () => {
+		expect(getMessagePayloadLimitState("x".repeat(3999), PRO_MESSAGE_CHARACTER_LIMIT)).toMatchObject({
+			isNearLimit: false,
+			isOverLimit: false,
+			remaining: 1001
+		});
+		expect(getMessagePayloadLimitState("x".repeat(4000), PRO_MESSAGE_CHARACTER_LIMIT)).toMatchObject({
+			isNearLimit: true,
+			isOverLimit: false,
+			remaining: 1000
+		});
+		expect(getMessagePayloadLimitState("x".repeat(5001), PRO_MESSAGE_CHARACTER_LIMIT)).toMatchObject({
+			isNearLimit: true,
+			isOverLimit: true,
+			remaining: 0
+		});
+	});
+});

--- a/tests/unit/payload-limits.test.ts
+++ b/tests/unit/payload-limits.test.ts
@@ -45,5 +45,15 @@ describe("payload limits", () => {
 			isOverLimit: true,
 			remaining: 0
 		});
+		expect(getMessagePayloadLimitState("x".repeat(13999), PRO_PLUS_MESSAGE_CHARACTER_LIMIT)).toMatchObject({
+			isNearLimit: false,
+			isOverLimit: false,
+			remaining: 1001
+		});
+		expect(getMessagePayloadLimitState("x".repeat(14000), PRO_PLUS_MESSAGE_CHARACTER_LIMIT)).toMatchObject({
+			isNearLimit: true,
+			isOverLimit: false,
+			remaining: 1000
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- Enforce attachment and message payload size limits before sending
- Surface attachment validation in chat input, preview, and send flow
- Add shared payload-limit utilities and supporting styles
- Cover the new limits with unit and integration tests

## Testing
- Added unit coverage for payload limit calculations
- Added integration coverage for attachment handling and message sending
- Not run (not requested)