### PR TITLE
Prepare release 1.8.5

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1601,13 +1601,16 @@
 					<h1 id="header-version">What's New in</h1>
 					<ul id="changelog">
 						<li>
-							<b>New Openrouter models:</b> Users that use their Openrouter API instead of Gemini API key
-							will be able to use the Gemini models
+							<b>Richer model picker:</b> Browse models by provider family, search faster, and pin
+							favorites for quicker access
 						</li>
-						<li><b>Better image support:</b> More models accept image input</li>
 						<li>
-							<b>Chat History Stability Fixes:</b> Attachment data, thought parts, and reasoning
-							signatures now stay intact when editing, regenerating, or restoring messages
+							<b>More model choices:</b> New OpenRouter options are available, including expanded Gemini,
+							Grok, Qwen, DeepSeek, and Inception models
+						</li>
+						<li>
+							<b>Safer large sends:</b> Zodiac now warns when attachments or messages are too large,
+							helping prevent failed requests before they start
 						</li>
 					</ul>
 				</div>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -57,7 +57,7 @@ export function lightenCard(element: HTMLElement) {
 }
 
 export function getVersion() {
-	return "1.8.4";
+	return "1.8.5";
 }
 
 export function getSanitized(string: string) {


### PR DESCRIPTION
## Summary
- Bump the in-app version to 1.8.5
- Refresh the What's New changelog for the model picker, expanded model choices, and large-send warnings
- Address review comments by removing the Gemini 3.1 mega-mode notice and the Zhipu mention

## Validation
- npm run type-check
- push hook: npm run lint
- push hook: npm run test