### PR TITLE
Fix surface plane backdrop blur

### DIFF
--- a/src/services/Surface.service.ts
+++ b/src/services/Surface.service.ts
@@ -42,13 +42,13 @@ function prepareSurface(element: HTMLElement): void {
 }
 
 function refreshSurfacePlaneState(): void {
-	const visibleSurfaces = Array.from(surfacePlane.querySelectorAll<HTMLElement>(".surface-plane__item")).filter(
-		(element) => !element.classList.contains("hidden")
+	const openSurfaces = Array.from(surfacePlane.querySelectorAll<HTMLElement>(".surface-plane__item")).filter(
+		(element) => !element.classList.contains("hidden") && !element.classList.contains("surface-closing")
 	);
-	const hasVisibleAdaptiveSheet = visibleSurfaces.some((element) => element.classList.contains("adaptive-sheet"));
+	const hasOpenAdaptiveSheet = openSurfaces.some((element) => element.classList.contains("adaptive-sheet"));
 
-	surfacePlane.classList.toggle(surfaceActiveClass, visibleSurfaces.length > 0);
-	surfacePlane.classList.toggle(surfaceBlurredClass, hasVisibleAdaptiveSheet);
+	surfacePlane.classList.toggle(surfaceActiveClass, openSurfaces.length > 0);
+	surfacePlane.classList.toggle(surfaceBlurredClass, hasOpenAdaptiveSheet);
 }
 
 function finishClose(element: HTMLElement): void {

--- a/src/services/Surface.service.ts
+++ b/src/services/Surface.service.ts
@@ -8,6 +8,8 @@ const closeTimers = new WeakMap<HTMLElement, number>();
 const focusRestoreTargets = new WeakMap<HTMLElement, HTMLElement>();
 let activeSurface: HTMLElement | null = null;
 let outsideDismissPointerStart: { surface: HTMLElement; startedOutside: boolean } | null = null;
+const surfaceActiveClass = "surface-plane--active";
+const surfaceBlurredClass = "surface-plane--blurred";
 
 const FOCUSABLE_SELECTOR = [
 	"[data-surface-initial-focus]",
@@ -39,12 +41,23 @@ function prepareSurface(element: HTMLElement): void {
 	if (!element.hasAttribute("tabindex")) element.tabIndex = -1;
 }
 
+function refreshSurfacePlaneState(): void {
+	const visibleSurfaces = Array.from(surfacePlane.querySelectorAll<HTMLElement>(".surface-plane__item")).filter(
+		(element) => !element.classList.contains("hidden")
+	);
+	const hasVisibleAdaptiveSheet = visibleSurfaces.some((element) => element.classList.contains("adaptive-sheet"));
+
+	surfacePlane.classList.toggle(surfaceActiveClass, visibleSurfaces.length > 0);
+	surfacePlane.classList.toggle(surfaceBlurredClass, hasVisibleAdaptiveSheet);
+}
+
 function finishClose(element: HTMLElement): void {
 	element.classList.add("hidden");
 	element.classList.remove("surface-open", "surface-closing");
 	element.dispatchEvent(new CustomEvent("surface-closed"));
 	restoreFocus(element);
 	if (activeSurface === element) activeSurface = null;
+	refreshSurfacePlaneState();
 }
 
 function getInitialFocusTarget(element: HTMLElement): HTMLElement {
@@ -75,6 +88,7 @@ function hideSurface(element: HTMLElement, immediate = false): void {
 
 	element.classList.remove("surface-open");
 	element.classList.add("surface-closing");
+	refreshSurfacePlaneState();
 
 	if (immediate) {
 		finishClose(element);
@@ -108,9 +122,11 @@ export function show(elementId: string): void {
 		focusRestoreTargets.set(element, previousFocus);
 	}
 	element.classList.remove("hidden", "surface-closing", "surface-open");
+	refreshSurfacePlaneState();
 
 	requestAnimationFrame(() => {
 		element.classList.add("surface-open");
+		refreshSurfacePlaneState();
 		moveFocusIntoSurface(element);
 	});
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2553,12 +2553,20 @@ form {
 		-webkit-backdrop-filter 0.16s ease;
 }
 
-.surface-plane.surface-plane--active,
+.surface-plane.surface-plane--active {
+	pointer-events: auto;
+}
+
 .surface-plane:has(.surface-plane__item.surface-open) {
 	pointer-events: auto;
 }
 
-.surface-plane.surface-plane--blurred,
+.surface-plane.surface-plane--blurred {
+	background-color: rgb(0 0 0 / 12%);
+	backdrop-filter: blur(10px);
+	-webkit-backdrop-filter: blur(10px);
+}
+
 .surface-plane:has(.adaptive-sheet.surface-open) {
 	background-color: rgb(0 0 0 / 12%);
 	backdrop-filter: blur(10px);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2553,10 +2553,12 @@ form {
 		-webkit-backdrop-filter 0.16s ease;
 }
 
+.surface-plane.surface-plane--active,
 .surface-plane:has(.surface-plane__item.surface-open) {
 	pointer-events: auto;
 }
 
+.surface-plane.surface-plane--blurred,
 .surface-plane:has(.adaptive-sheet.surface-open) {
 	background-color: rgb(0 0 0 / 12%);
 	backdrop-filter: blur(10px);

--- a/tests/integration/services/surface-service.test.ts
+++ b/tests/integration/services/surface-service.test.ts
@@ -34,8 +34,8 @@ describe("Surface service", () => {
 
 		surfaceService.close("adaptive-test-sheet");
 
-		expect(surfacePlane?.classList.contains("surface-plane--active")).toBe(true);
-		expect(surfacePlane?.classList.contains("surface-plane--blurred")).toBe(true);
+		expect(surfacePlane?.classList.contains("surface-plane--active")).toBe(false);
+		expect(surfacePlane?.classList.contains("surface-plane--blurred")).toBe(false);
 
 		await vi.runOnlyPendingTimersAsync();
 

--- a/tests/integration/services/surface-service.test.ts
+++ b/tests/integration/services/surface-service.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { bootstrapDom } from "../../helpers/dom";
+
+describe("Surface service", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.useFakeTimers();
+		bootstrapDom(`
+			<div id="surface-plane" class="surface-plane">
+				<div id="adaptive-test-sheet" class="adaptive-sheet hidden">
+					<button type="button">Close</button>
+				</div>
+				<div id="plain-test-surface" class="hidden">
+					<button type="button">Close</button>
+				</div>
+			</div>
+		`);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("marks the surface plane as blurred while an adaptive sheet is visible", async () => {
+		const surfaceService = await import("../../../src/services/Surface.service");
+		const surfacePlane = document.querySelector<HTMLElement>("#surface-plane");
+
+		surfaceService.show("adaptive-test-sheet");
+		await vi.runOnlyPendingTimersAsync();
+
+		expect(surfacePlane?.classList.contains("surface-plane--active")).toBe(true);
+		expect(surfacePlane?.classList.contains("surface-plane--blurred")).toBe(true);
+
+		surfaceService.close("adaptive-test-sheet");
+
+		expect(surfacePlane?.classList.contains("surface-plane--active")).toBe(true);
+		expect(surfacePlane?.classList.contains("surface-plane--blurred")).toBe(true);
+
+		await vi.runOnlyPendingTimersAsync();
+
+		expect(surfacePlane?.classList.contains("surface-plane--active")).toBe(false);
+		expect(surfacePlane?.classList.contains("surface-plane--blurred")).toBe(false);
+	});
+
+	it("does not apply adaptive sheet blur for plain transient surfaces", async () => {
+		const surfaceService = await import("../../../src/services/Surface.service");
+		const surfacePlane = document.querySelector<HTMLElement>("#surface-plane");
+
+		surfaceService.show("plain-test-surface");
+		await vi.runOnlyPendingTimersAsync();
+
+		expect(surfacePlane?.classList.contains("surface-plane--active")).toBe(true);
+		expect(surfacePlane?.classList.contains("surface-plane--blurred")).toBe(false);
+	});
+});


### PR DESCRIPTION
Fixes #197

## Summary
- add explicit active and blurred state classes to the surface plane so adaptive sheets do not depend on CSS :has() for backdrop blur
- start the surface plane backdrop close animation when a sheet begins closing instead of after the sheet finishes
- cover the open and close backdrop behavior with Surface service regression tests

## Validation
- npm run type-check
- npm run test:vitest
- pre-push hook: npm run lint and npm run test