### PR TITLE
Sync theme, premium endpoint, onboarding, and LoRA settings changes

### DIFF
--- a/src/components/static/ApiKeyInput.component.ts
+++ b/src/components/static/ApiKeyInput.component.ts
@@ -2,6 +2,7 @@ import { getSubscriptionTier, type SubscriptionTier } from "../../services/Supab
 import { dispatchAppEvent, onAppEvent } from "../../events";
 import { SETTINGS_STORAGE_KEYS } from "../../constants/SettingsStorageKeys";
 import { validateGeminiApiKey, validateOpenRouterApiKey } from "../../services/ApiKeyValidation.service";
+import * as syncService from "../../services/Sync.service";
 
 const geminiApiKeyInput = document.querySelector<HTMLInputElement>("#apiKeyInput");
 const openRouterApiKeyInput = document.querySelector<HTMLInputElement>("#openRouterApiKeyInput");
@@ -89,6 +90,7 @@ ensuredPreferPremiumCheckbox.addEventListener("change", () => {
 		ensuredPreferPremiumCheckbox.checked.toString()
 	);
 	dispatchAppEvent("premium-endpoint-preference-changed", { preferred: ensuredPreferPremiumCheckbox.checked });
+	queuePremiumEndpointSettingsSync();
 });
 
 onAppEvent("auth-state-changed", (event) => {
@@ -106,6 +108,7 @@ onAppEvent("auth-state-changed", (event) => {
 		if (savedPreference === null) {
 			ensuredPreferPremiumCheckbox.checked = true;
 			localStorage.setItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT, "true");
+			queuePremiumEndpointSettingsSync();
 		}
 	} else {
 		ensuredPreferPremiumToggle.classList.add("hidden");
@@ -136,4 +139,11 @@ attachValidation({
 export function shouldPreferPremiumEndpoint(): boolean {
 	const saved = localStorage.getItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT);
 	return saved === null ? true : saved === "true";
+}
+
+function queuePremiumEndpointSettingsSync(): void {
+	if (!syncService.isSyncActive()) return;
+	syncService.pushCurrentSettings().catch((error) => {
+		console.warn("Failed to sync premium endpoint settings", error);
+	});
 }

--- a/src/components/static/ApiKeyInput.component.ts
+++ b/src/components/static/ApiKeyInput.component.ts
@@ -29,6 +29,8 @@ const ensuredGeminiError = geminiError;
 const ensuredOpenRouterError = openRouterError;
 const ensuredPreferPremiumToggle = preferPremiumToggle;
 const ensuredPreferPremiumCheckbox = preferPremiumCheckbox;
+let isPaidAccount = false;
+let hasObservedSyncedSettingsPull = false;
 
 function applyPremiumPreferenceFromStorage(): void {
 	const savedPreference = localStorage.getItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT);
@@ -42,6 +44,16 @@ function applyPremiumPreferenceFromStorage(): void {
 function rehydratePremiumPreferenceFromStorage(): void {
 	applyPremiumPreferenceFromStorage();
 	dispatchAppEvent("premium-endpoint-preference-changed", { preferred: ensuredPreferPremiumCheckbox.checked });
+}
+
+function persistDefaultPremiumPreferenceAfterSyncedSettingsPull(): void {
+	if (!isPaidAccount || !hasObservedSyncedSettingsPull) return;
+	if (localStorage.getItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT) !== null) return;
+
+	ensuredPreferPremiumCheckbox.checked = true;
+	localStorage.setItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT, "true");
+	dispatchAppEvent("premium-endpoint-preference-changed", { preferred: true });
+	queuePremiumEndpointSettingsSync();
 }
 
 function clearValidationState(input: HTMLInputElement, errorElement: HTMLElement): void {
@@ -97,6 +109,7 @@ onAppEvent("auth-state-changed", (event) => {
 	const { subscription: sub } = event.detail;
 	const savedPreference = localStorage.getItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT);
 	if (!sub) {
+		isPaidAccount = false;
 		ensuredPreferPremiumToggle.classList.add("hidden");
 		ensuredPreferPremiumCheckbox.checked = false;
 		return;
@@ -104,20 +117,22 @@ onAppEvent("auth-state-changed", (event) => {
 
 	const tier: SubscriptionTier = getSubscriptionTier(sub);
 	if (tier === "pro" || tier === "pro_plus" || tier === "max") {
+		isPaidAccount = true;
 		ensuredPreferPremiumToggle.classList.remove("hidden");
 		if (savedPreference === null) {
 			ensuredPreferPremiumCheckbox.checked = true;
-			localStorage.setItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT, "true");
-			queuePremiumEndpointSettingsSync();
 		}
 	} else {
+		isPaidAccount = false;
 		ensuredPreferPremiumToggle.classList.add("hidden");
 		ensuredPreferPremiumCheckbox.checked = false;
 	}
 });
 
 onAppEvent("sync-data-pulled", () => {
+	hasObservedSyncedSettingsPull = true;
 	rehydratePremiumPreferenceFromStorage();
+	persistDefaultPremiumPreferenceAfterSyncedSettingsPull();
 });
 
 onAppEvent("settings-loaded-from-storage", () => {
@@ -142,8 +157,5 @@ export function shouldPreferPremiumEndpoint(): boolean {
 }
 
 function queuePremiumEndpointSettingsSync(): void {
-	if (!syncService.isSyncActive()) return;
-	syncService.pushCurrentSettings().catch((error) => {
-		console.warn("Failed to sync premium endpoint settings", error);
-	});
+	syncService.queueSettingsPush({ label: "premium endpoint settings" });
 }

--- a/src/components/static/Onboarding.component.ts
+++ b/src/components/static/Onboarding.component.ts
@@ -783,7 +783,7 @@ function setupApiKeySetup(): void {
 	// Reset next button state when input changes
 	const handleApiKeyInputChange = async (args: { statusElement: HTMLDivElement; storageKey: string }) => {
 		localStorage.removeItem(args.storageKey);
-		queueOnboardingSettingsSync();
+		queueOnboardingSettingsSync({ debounceMs: syncService.SETTINGS_PUSH_DEBOUNCE_MS });
 		hideApiKeyStatus(args.statusElement);
 		const hasValidatedKey =
 			apiKeyStatus!.classList.contains("status-success") ||
@@ -1271,10 +1271,10 @@ function applyThemeSettings(): void {
 	}
 }
 
-function queueOnboardingSettingsSync(): void {
-	if (!syncService.isSyncActive()) return;
-	syncService.pushCurrentSettings().catch((error) => {
-		console.warn("Failed to sync onboarding settings", error);
+function queueOnboardingSettingsSync(options: { debounceMs?: number } = {}): void {
+	syncService.queueSettingsPush({
+		label: "onboarding settings",
+		debounceMs: options.debounceMs
 	});
 }
 

--- a/src/components/static/Onboarding.component.ts
+++ b/src/components/static/Onboarding.component.ts
@@ -701,6 +701,7 @@ function setupApiKeySetup(): void {
 
 			showApiKeyStatus(args.statusElement, args.successMessage, "success");
 			localStorage.setItem(args.storageKey, apiKey);
+			queueOnboardingSettingsSync();
 			settingsService.loadSettings();
 			await refreshOnboardingModelOptions(localStorage.getItem(SETTINGS_STORAGE_KEYS.MODEL) || undefined);
 			updateApiKeyNextState();
@@ -782,6 +783,7 @@ function setupApiKeySetup(): void {
 	// Reset next button state when input changes
 	const handleApiKeyInputChange = async (args: { statusElement: HTMLDivElement; storageKey: string }) => {
 		localStorage.removeItem(args.storageKey);
+		queueOnboardingSettingsSync();
 		hideApiKeyStatus(args.statusElement);
 		const hasValidatedKey =
 			apiKeyStatus!.classList.contains("status-success") ||
@@ -1161,6 +1163,7 @@ function setupSummary(): void {
 
 				// Apply theme settings from onboarding state before everything else
 				applyThemeSettings();
+				queueOnboardingSettingsSync();
 
 				// Apply Easy path settings for ALL outcomes
 				const selectedPath = onboardingService.getState().selectedPath;
@@ -1243,6 +1246,7 @@ async function applyEasyPathSettings(): Promise<void> {
 
 	// Reload settings to apply changes to UI
 	settingsService.loadSettings();
+	queueOnboardingSettingsSync();
 }
 
 /**
@@ -1265,6 +1269,13 @@ function applyThemeSettings(): void {
 			themeService.setMode(selectedMode, "manual");
 		}
 	}
+}
+
+function queueOnboardingSettingsSync(): void {
+	if (!syncService.isSyncActive()) return;
+	syncService.pushCurrentSettings().catch((error) => {
+		console.warn("Failed to sync onboarding settings", error);
+	});
 }
 
 /**
@@ -1893,6 +1904,7 @@ function setupAdvancedSettings(): void {
 
 		// Reload settings to apply changes to UI
 		settingsService.loadSettings();
+		queueOnboardingSettingsSync();
 
 		// Go to summary
 		onboardingService.goToStep(OnboardingStep.SUMMARY);

--- a/src/components/static/RoleplayComposer.component.ts
+++ b/src/components/static/RoleplayComposer.component.ts
@@ -426,10 +426,7 @@ function persistFavoriteActions(): void {
 }
 
 function queueRoleplaySettingsSync(): void {
-	if (!syncService.isSyncActive()) return;
-	syncService.pushCurrentSettings().catch((error) => {
-		console.warn("Failed to sync roleplay settings", error);
-	});
+	syncService.queueSettingsPush({ label: "roleplay settings" });
 }
 
 function discardActionState(actionIds: Iterable<string>): void {

--- a/src/components/static/ThemeControls.component.ts
+++ b/src/components/static/ThemeControls.component.ts
@@ -109,8 +109,5 @@ onAppEvent("settings-loaded-from-storage", rehydrateFromStorage);
 onAppEvent("sync-data-pulled", rehydrateFromStorage);
 
 function queueThemeSettingsSync() {
-	if (!syncService.isSyncActive()) return;
-	syncService.pushCurrentSettings().catch((error) => {
-		console.warn("Failed to sync theme settings", error);
-	});
+	syncService.queueSettingsPush({ label: "theme settings" });
 }

--- a/src/components/static/ThemeControls.component.ts
+++ b/src/components/static/ThemeControls.component.ts
@@ -2,6 +2,8 @@ import { themeService } from "../../services/Theme.service";
 import type { ColorTheme } from "../../types/Theme";
 import * as toastService from "../../services/Toast.service";
 import { ToastSeverity } from "../../types/Toast";
+import { onAppEvent } from "../../events";
+import * as syncService from "../../services/Sync.service";
 
 // Query all required elements
 const modeInput = document.querySelector<HTMLInputElement>("#themeMode");
@@ -45,16 +47,21 @@ initialize();
 
 function handleModeInput(event: Event) {
 	const input = event.currentTarget as HTMLInputElement;
+	let didUpdateTheme = false;
 
 	if (input.value === MODE_TO_VALUE.auto) {
 		themeService.setAutoMode();
+		didUpdateTheme = true;
 	} else if (input.value === MODE_TO_VALUE.light) {
 		themeService.setMode("light", "manual");
+		didUpdateTheme = true;
 	} else if (input.value === MODE_TO_VALUE.dark) {
 		themeService.setMode("dark", "manual");
+		didUpdateTheme = true;
 	}
 
 	updateUI();
+	if (didUpdateTheme) queueThemeSettingsSync();
 }
 
 function handleThemeClick(event: Event) {
@@ -75,6 +82,7 @@ function handleThemeClick(event: Event) {
 
 	themeService.setColorTheme(theme);
 	updateUI();
+	queueThemeSettingsSync();
 }
 
 function updateUI() {
@@ -89,5 +97,20 @@ function updateUI() {
 	themeButtons.forEach((button) => {
 		const theme = button.getAttribute("data-theme");
 		button.classList.toggle("active", theme === currentTheme.colorTheme);
+	});
+}
+
+function rehydrateFromStorage() {
+	themeService.reloadFromStorage();
+	updateUI();
+}
+
+onAppEvent("settings-loaded-from-storage", rehydrateFromStorage);
+onAppEvent("sync-data-pulled", rehydrateFromStorage);
+
+function queueThemeSettingsSync() {
+	if (!syncService.isSyncActive()) return;
+	syncService.pushCurrentSettings().catch((error) => {
+		console.warn("Failed to sync theme settings", error);
 	});
 }

--- a/src/services/Lora.service.ts
+++ b/src/services/Lora.service.ts
@@ -50,10 +50,7 @@ function writeToLocalstorage(list: string[]): void {
 }
 
 function queueLoraSettingsSync(): void {
-	if (!syncService.isSyncActive()) return;
-	syncService.pushCurrentSettings().catch((error) => {
-		console.warn("Failed to sync LoRA settings", error);
-	});
+	syncService.queueSettingsPush({ label: "LoRA settings" });
 }
 
 function deleteFromLocalstorage(modelVersionId: string): void {

--- a/src/services/Lora.service.ts
+++ b/src/services/Lora.service.ts
@@ -2,6 +2,7 @@ import type { LoRAInfo, LoRAState } from "../types/Lora";
 import { LORA_STORAGE_KEY } from "../types/Lora";
 import { supabase } from "./Supabase.service";
 import { dispatchEmptyAppEvent } from "../events";
+import * as syncService from "./Sync.service";
 
 let loras: LoRAInfo[] = [];
 let loraState: LoRAState[] = [];
@@ -47,11 +48,20 @@ function readFromLocalstorage(): string[] {
 function writeToLocalstorage(list: string[]): void {
 	localStorage.setItem(LORA_STORAGE_KEY, JSON.stringify(list));
 }
+
+function queueLoraSettingsSync(): void {
+	if (!syncService.isSyncActive()) return;
+	syncService.pushCurrentSettings().catch((error) => {
+		console.warn("Failed to sync LoRA settings", error);
+	});
+}
+
 function deleteFromLocalstorage(modelVersionId: string): void {
 	console.log("Deleting LoRA from localstorage:", modelVersionId);
 	const urls = readFromLocalstorage();
 	const filtered = urls.filter((url) => !url.includes(modelVersionId));
 	writeToLocalstorage(filtered);
+	queueLoraSettingsSync();
 }
 
 export function getAll(): LoRAInfo[] {
@@ -70,6 +80,7 @@ export async function add(url: string): Promise<LoRAInfo | void> {
 	if (loraDetails && loraDetails.length > 0) {
 		urls.push(loraDetails[0].url);
 		writeToLocalstorage(urls);
+		queueLoraSettingsSync();
 
 		loras.push(...loraDetails);
 		return loraDetails[0];

--- a/src/services/Pinning.service.ts
+++ b/src/services/Pinning.service.ts
@@ -28,10 +28,7 @@ function writePinnedIds(storageKey: string, ids: string[]): void {
 }
 
 function queueSyncSettingsPush(): void {
-	if (!syncService.isSyncActive()) return;
-	syncService.pushCurrentSettings().catch((error) => {
-		console.warn("Failed to sync pinning settings", error);
-	});
+	syncService.queueSettingsPush({ label: "pinning settings" });
 }
 
 export function getPinnedChatIds(): string[] {

--- a/src/services/Settings.service.ts
+++ b/src/services/Settings.service.ts
@@ -460,12 +460,8 @@ export function saveSettings() {
 	debouncedSyncPush();
 }
 
-let syncPushTimer: ReturnType<typeof setTimeout> | null = null;
 function debouncedSyncPush() {
-	if (syncPushTimer) clearTimeout(syncPushTimer);
-	syncPushTimer = setTimeout(() => {
-		syncService.pushCurrentSettings().catch(() => {});
-	}, 2000);
+	syncService.queueSettingsPush({ label: "settings", debounceMs: syncService.SETTINGS_PUSH_DEBOUNCE_MS });
 }
 
 export function getSettings() {

--- a/src/services/Sync.service.ts
+++ b/src/services/Sync.service.ts
@@ -101,11 +101,16 @@ const CHAT_DELETE_MARK_BATCH_SIZE = 500;
 const MESSAGE_DECRYPT_CONCURRENCY = 4;
 const MAX_OFFLINE_RETRIES = 5;
 const QUOTA_TOAST_DEDUP_MS = 30_000;
+export const SETTINGS_PUSH_DEBOUNCE_MS = 2_000;
 /** Client-side page size for reading messages from Supabase. Independent of
  *  the server-side PostgREST max-rows setting (typically 1000 on hosted
  *  Supabase). Cursor-based paging handles lower server caps safely. */
 const READ_PAGE_SIZE = 500;
 let quotaToastShownAt = 0;
+let settingsPushTimer: ReturnType<typeof setTimeout> | null = null;
+let settingsPushInFlight = false;
+let settingsPushPending = false;
+let settingsPushPendingLabel = "settings";
 
 function areSyncHooksSuppressed(): boolean {
 	return suppressSyncHooksDepth > 0;
@@ -1952,6 +1957,53 @@ export async function pushCurrentSettings(): Promise<boolean> {
 	}
 
 	return pushSettings(settings);
+}
+
+export function queueSettingsPush(options: { label?: string; debounceMs?: number } = {}): void {
+	if (!isSyncActive()) return;
+
+	const label = options.label ?? "settings";
+	const debounceMs = options.debounceMs ?? 0;
+	if (debounceMs > 0) {
+		if (settingsPushTimer) clearTimeout(settingsPushTimer);
+		settingsPushPendingLabel = label;
+		settingsPushTimer = setTimeout(() => {
+			settingsPushTimer = null;
+			enqueueSettingsPush(label);
+		}, debounceMs);
+		return;
+	}
+
+	if (settingsPushTimer) {
+		clearTimeout(settingsPushTimer);
+		settingsPushTimer = null;
+	}
+	enqueueSettingsPush(label);
+}
+
+function enqueueSettingsPush(label: string): void {
+	settingsPushPending = true;
+	settingsPushPendingLabel = label;
+	void drainQueuedSettingsPush();
+}
+
+async function drainQueuedSettingsPush(): Promise<void> {
+	if (settingsPushInFlight) return;
+
+	settingsPushInFlight = true;
+	try {
+		while (settingsPushPending && isSyncActive()) {
+			settingsPushPending = false;
+			const label = settingsPushPendingLabel;
+			try {
+				await pushCurrentSettings();
+			} catch (error) {
+				console.warn(`Failed to sync ${label}`, error);
+			}
+		}
+	} finally {
+		settingsPushInFlight = false;
+	}
 }
 
 function hasInlineMediaAboveThreshold(message: any): boolean {

--- a/tests/integration/messages/roleplay-composer-model-dropdown.test.ts
+++ b/tests/integration/messages/roleplay-composer-model-dropdown.test.ts
@@ -49,7 +49,7 @@ vi.mock("../../../src/services/Supabase.service", () => ({
 
 vi.mock("../../../src/services/Sync.service", () => ({
 	isSyncActive: vi.fn(() => false),
-	pushCurrentSettings: vi.fn(async () => true)
+	queueSettingsPush: vi.fn()
 }));
 
 vi.mock("../../../src/services/Toast.service", () => ({

--- a/tests/integration/messages/roleplay-composer.test.ts
+++ b/tests/integration/messages/roleplay-composer.test.ts
@@ -76,9 +76,8 @@ vi.mock("../../../src/services/Supabase.service", () => ({
 
 vi.mock("../../../src/services/Sync.service", () => ({
 	isSyncActive: vi.fn(() => testState.syncActive),
-	pushCurrentSettings: vi.fn(async () => {
+	queueSettingsPush: vi.fn(() => {
 		testState.syncPushCount += 1;
-		return true;
 	})
 }));
 

--- a/tests/integration/services/settings-push-queue.test.ts
+++ b/tests/integration/services/settings-push-queue.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SETTINGS_STORAGE_KEYS } from "../../../src/constants/SettingsStorageKeys";
+
+const syncTestState = vi.hoisted(() => {
+	const state = {
+		encryptedSettings: [] as Array<Record<string, string>>,
+		activeUpserts: 0,
+		maxConcurrentUpserts: 0,
+		pendingUpserts: [] as Array<() => void>,
+		from: vi.fn((table: string) => {
+			if (table === "user_sync_preferences") {
+				return {
+					select: vi.fn(() => ({
+						eq: vi.fn(() => ({
+							maybeSingle: vi.fn(async () => ({
+								data: {
+									sync_enabled: true,
+									encryption_salt: "aa",
+									key_verification: "bb",
+									key_verification_iv: "cc"
+								},
+								error: null
+							}))
+						}))
+					}))
+				};
+			}
+
+			if (table === "user_synced_settings") {
+				return {
+					upsert: vi.fn(
+						() =>
+							new Promise<{ error: null }>((resolve) => {
+								state.activeUpserts += 1;
+								state.maxConcurrentUpserts = Math.max(state.maxConcurrentUpserts, state.activeUpserts);
+								state.pendingUpserts.push(() => {
+									state.activeUpserts -= 1;
+									resolve({ error: null });
+								});
+							})
+					)
+				};
+			}
+
+			throw new Error(`Unexpected table: ${table}`);
+		}),
+		reset() {
+			this.encryptedSettings = [];
+			this.activeUpserts = 0;
+			this.maxConcurrentUpserts = 0;
+			this.pendingUpserts = [];
+			this.from.mockClear();
+		},
+		resolveNextUpsert() {
+			const resolve = this.pendingUpserts.shift();
+			if (!resolve) throw new Error("No pending settings upsert to resolve");
+			resolve();
+		}
+	};
+	return state;
+});
+
+vi.mock("../../../src/services/Supabase.service", () => ({
+	supabase: {
+		from: syncTestState.from
+	},
+	getCurrentUser: vi.fn(async () => ({ id: "user-1" })),
+	getSubscriptionTier: vi.fn(() => "pro"),
+	getUserSubscription: vi.fn(async () => null)
+}));
+
+vi.mock("../../../src/services/Crypto.service", () => ({
+	isUnlocked: vi.fn(() => true),
+	getCachedKey: vi.fn(() => ({})),
+	fromHex: vi.fn(() => new Uint8Array([1])),
+	toHex: vi.fn(() => "hex"),
+	encrypt: vi.fn(async (_key: CryptoKey, plaintext: string) => {
+		syncTestState.encryptedSettings.push(JSON.parse(plaintext));
+		return { ciphertext: new Uint8Array([1]), iv: new Uint8Array([2]) };
+	})
+}));
+
+vi.mock("../../../src/services/BlobStore.service", () => ({
+	BLOB_SIZE_THRESHOLD: 1_000_000,
+	clearCache: vi.fn()
+}));
+
+vi.mock("../../../src/services/Toast.service", () => ({
+	warn: vi.fn()
+}));
+
+vi.mock("../../../src/services/Db.service", () => ({
+	db: {}
+}));
+
+vi.mock("../../../src/utils/helpers", () => ({
+	fileToBase64: vi.fn()
+}));
+
+vi.mock("../../../src/events", () => ({
+	dispatchAppEvent: vi.fn()
+}));
+
+async function importActiveSyncService() {
+	const syncService = await import("../../../src/services/Sync.service");
+	await syncService.fetchSyncPreferences();
+	return syncService;
+}
+
+describe("settings push queue", () => {
+	beforeEach(() => {
+		vi.useRealTimers();
+		vi.resetModules();
+		localStorage.clear();
+		syncTestState.reset();
+	});
+
+	it("collapses debounced settings pushes into one trailing upload", async () => {
+		vi.useFakeTimers();
+		const syncService = await importActiveSyncService();
+
+		localStorage.setItem(SETTINGS_STORAGE_KEYS.MODEL, "first-model");
+		syncService.queueSettingsPush({ label: "settings", debounceMs: 2000 });
+
+		localStorage.setItem(SETTINGS_STORAGE_KEYS.MODEL, "second-model");
+		syncService.queueSettingsPush({ label: "settings", debounceMs: 2000 });
+
+		await vi.advanceTimersByTimeAsync(1999);
+		expect(syncTestState.encryptedSettings).toEqual([]);
+
+		await vi.advanceTimersByTimeAsync(1);
+
+		expect(syncTestState.encryptedSettings).toEqual([{ [SETTINGS_STORAGE_KEYS.MODEL]: "second-model" }]);
+		syncTestState.resolveNextUpsert();
+	});
+
+	it("serializes immediate settings pushes so the latest snapshot uploads last", async () => {
+		const syncService = await importActiveSyncService();
+
+		localStorage.setItem(SETTINGS_STORAGE_KEYS.MODEL, "first-model");
+		syncService.queueSettingsPush({ label: "settings" });
+
+		await vi.waitFor(() => expect(syncTestState.pendingUpserts).toHaveLength(1));
+
+		localStorage.setItem(SETTINGS_STORAGE_KEYS.MODEL, "second-model");
+		syncService.queueSettingsPush({ label: "settings" });
+
+		await Promise.resolve();
+		expect(syncTestState.encryptedSettings).toEqual([{ [SETTINGS_STORAGE_KEYS.MODEL]: "first-model" }]);
+		expect(syncTestState.pendingUpserts).toHaveLength(1);
+
+		syncTestState.resolveNextUpsert();
+		await vi.waitFor(() => expect(syncTestState.pendingUpserts).toHaveLength(1));
+
+		expect(syncTestState.encryptedSettings).toEqual([
+			{ [SETTINGS_STORAGE_KEYS.MODEL]: "first-model" },
+			{ [SETTINGS_STORAGE_KEYS.MODEL]: "second-model" }
+		]);
+		expect(syncTestState.maxConcurrentUpserts).toBe(1);
+
+		syncTestState.resolveNextUpsert();
+	});
+});

--- a/tests/integration/settings/lora-sync.test.ts
+++ b/tests/integration/settings/lora-sync.test.ts
@@ -6,7 +6,7 @@ import type { LoRAInfo } from "../../../src/types/Lora";
 
 const syncServiceMock = vi.hoisted(() => ({
 	isSyncActive: vi.fn(() => true),
-	pushCurrentSettings: vi.fn(async () => true)
+	queueSettingsPush: vi.fn()
 }));
 
 const supabaseMock = vi.hoisted(() => ({
@@ -36,7 +36,7 @@ describe("LoRA synced settings", () => {
 		vi.resetModules();
 		localStorage.clear();
 		syncServiceMock.isSyncActive.mockReturnValue(true);
-		syncServiceMock.pushCurrentSettings.mockClear();
+		syncServiceMock.queueSettingsPush.mockClear();
 		supabaseMock.functions.invoke.mockReset();
 		supabaseMock.functions.invoke.mockResolvedValue({ data: [loraFixture], error: null });
 	});
@@ -47,7 +47,8 @@ describe("LoRA synced settings", () => {
 		await loraService.add(loraFixture.url);
 
 		expect(JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEYS.LORAS) ?? "[]")).toEqual([loraFixture.url]);
-		expect(syncServiceMock.pushCurrentSettings).toHaveBeenCalledTimes(1);
+		expect(syncServiceMock.queueSettingsPush).toHaveBeenCalledTimes(1);
+		expect(syncServiceMock.queueSettingsPush).toHaveBeenLastCalledWith({ label: "LoRA settings" });
 	});
 
 	it("pushes current settings when a LoRA URL is deleted", async () => {
@@ -57,6 +58,7 @@ describe("LoRA synced settings", () => {
 		loraService.deleteLora(loraFixture.modelVersionId);
 
 		expect(JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEYS.LORAS) ?? "[]")).toEqual([]);
-		expect(syncServiceMock.pushCurrentSettings).toHaveBeenCalledTimes(1);
+		expect(syncServiceMock.queueSettingsPush).toHaveBeenCalledTimes(1);
+		expect(syncServiceMock.queueSettingsPush).toHaveBeenLastCalledWith({ label: "LoRA settings" });
 	});
 });

--- a/tests/integration/settings/lora-sync.test.ts
+++ b/tests/integration/settings/lora-sync.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SETTINGS_STORAGE_KEYS } from "../../../src/constants/SettingsStorageKeys";
+import { ImageModel } from "../../../src/types/Models";
+import type { LoRAInfo } from "../../../src/types/Lora";
+
+const syncServiceMock = vi.hoisted(() => ({
+	isSyncActive: vi.fn(() => true),
+	pushCurrentSettings: vi.fn(async () => true)
+}));
+
+const supabaseMock = vi.hoisted(() => ({
+	functions: {
+		invoke: vi.fn()
+	}
+}));
+
+vi.mock("../../../src/services/Sync.service", () => syncServiceMock);
+
+vi.mock("../../../src/services/Supabase.service", () => ({
+	supabase: supabaseMock
+}));
+
+const loraFixture: LoRAInfo = {
+	baseModel: ImageModel.ILLUSTRIOUS,
+	name: "Test LoRA",
+	trainedWords: ["test"],
+	modelVersionId: "123",
+	url: "https://civitai.com/models/example?modelVersionId=123",
+	downloadUrl: "https://example.com/lora.safetensors",
+	fileName: "lora.safetensors"
+};
+
+describe("LoRA synced settings", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		localStorage.clear();
+		syncServiceMock.isSyncActive.mockReturnValue(true);
+		syncServiceMock.pushCurrentSettings.mockClear();
+		supabaseMock.functions.invoke.mockReset();
+		supabaseMock.functions.invoke.mockResolvedValue({ data: [loraFixture], error: null });
+	});
+
+	it("pushes current settings when a LoRA URL is added", async () => {
+		const loraService = await import("../../../src/services/Lora.service");
+
+		await loraService.add(loraFixture.url);
+
+		expect(JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEYS.LORAS) ?? "[]")).toEqual([loraFixture.url]);
+		expect(syncServiceMock.pushCurrentSettings).toHaveBeenCalledTimes(1);
+	});
+
+	it("pushes current settings when a LoRA URL is deleted", async () => {
+		localStorage.setItem(SETTINGS_STORAGE_KEYS.LORAS, JSON.stringify([loraFixture.url]));
+		const loraService = await import("../../../src/services/Lora.service");
+
+		loraService.deleteLora(loraFixture.modelVersionId);
+
+		expect(JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEYS.LORAS) ?? "[]")).toEqual([]);
+		expect(syncServiceMock.pushCurrentSettings).toHaveBeenCalledTimes(1);
+	});
+});

--- a/tests/integration/settings/premium-endpoint-sync.test.ts
+++ b/tests/integration/settings/premium-endpoint-sync.test.ts
@@ -13,6 +13,7 @@ vi.mock("../../../src/services/ApiKeyValidation.service", () => ({
 }));
 
 vi.mock("../../../src/services/Sync.service", () => ({
+	isSyncActive: vi.fn(() => true),
 	applySyncedSettingsToLocalStorage: vi.fn(async () => {
 		localStorage.setItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT, "false");
 		return true;
@@ -80,6 +81,30 @@ describe("premium endpoint synced settings", () => {
 
 		expect(apiKeyInputComponent.shouldPreferPremiumEndpoint()).toBe(false);
 		expect(toggle?.checked).toBe(false);
+	});
+
+	it("pushes synced settings when the user changes the premium endpoint toggle", async () => {
+		const apiKeyInputComponent = await import("../../../src/components/static/ApiKeyInput.component");
+		const syncService = await import("../../../src/services/Sync.service");
+		const toggle = document.querySelector<HTMLInputElement>("#preferPremiumEndpoint");
+
+		expect(apiKeyInputComponent.shouldPreferPremiumEndpoint()).toBe(true);
+
+		toggle!.checked = false;
+		toggle!.dispatchEvent(new Event("change", { bubbles: true }));
+
+		expect(apiKeyInputComponent.shouldPreferPremiumEndpoint()).toBe(false);
+		expect(syncService.pushCurrentSettings).toHaveBeenCalledTimes(1);
+	});
+
+	it("pushes synced settings when a paid account defaults the premium endpoint preference", async () => {
+		const apiKeyInputComponent = await import("../../../src/components/static/ApiKeyInput.component");
+		const syncService = await import("../../../src/services/Sync.service");
+
+		window.dispatchEvent(new CustomEvent("auth-state-changed", { detail: { loggedIn: true, subscription: {} } }));
+
+		expect(apiKeyInputComponent.shouldPreferPremiumEndpoint()).toBe(true);
+		expect(syncService.pushCurrentSettings).toHaveBeenCalledTimes(1);
 	});
 
 	it("reapplies model-driven thinking constraints after synced settings replace stale local state", async () => {

--- a/tests/integration/settings/premium-endpoint-sync.test.ts
+++ b/tests/integration/settings/premium-endpoint-sync.test.ts
@@ -18,7 +18,7 @@ vi.mock("../../../src/services/Sync.service", () => ({
 		localStorage.setItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT, "false");
 		return true;
 	}),
-	pushCurrentSettings: vi.fn(async () => true)
+	queueSettingsPush: vi.fn()
 }));
 
 function bootstrapSettingsDom(): void {
@@ -61,6 +61,7 @@ function bootstrapSettingsDom(): void {
 describe("premium endpoint synced settings", () => {
 	beforeEach(() => {
 		vi.resetModules();
+		vi.clearAllMocks();
 		localStorage.clear();
 		bootstrapSettingsDom();
 	});
@@ -94,17 +95,38 @@ describe("premium endpoint synced settings", () => {
 		toggle!.dispatchEvent(new Event("change", { bubbles: true }));
 
 		expect(apiKeyInputComponent.shouldPreferPremiumEndpoint()).toBe(false);
-		expect(syncService.pushCurrentSettings).toHaveBeenCalledTimes(1);
+		expect(syncService.queueSettingsPush).toHaveBeenCalledTimes(1);
+		expect(syncService.queueSettingsPush).toHaveBeenLastCalledWith({ label: "premium endpoint settings" });
 	});
 
-	it("pushes synced settings when a paid account defaults the premium endpoint preference", async () => {
+	it("waits for synced settings to pull before pushing a paid account premium endpoint default", async () => {
 		const apiKeyInputComponent = await import("../../../src/components/static/ApiKeyInput.component");
 		const syncService = await import("../../../src/services/Sync.service");
 
 		window.dispatchEvent(new CustomEvent("auth-state-changed", { detail: { loggedIn: true, subscription: {} } }));
 
 		expect(apiKeyInputComponent.shouldPreferPremiumEndpoint()).toBe(true);
-		expect(syncService.pushCurrentSettings).toHaveBeenCalledTimes(1);
+		expect(localStorage.getItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT)).toBeNull();
+		expect(syncService.queueSettingsPush).not.toHaveBeenCalled();
+
+		window.dispatchEvent(new CustomEvent("sync-data-pulled", { detail: {} }));
+
+		expect(apiKeyInputComponent.shouldPreferPremiumEndpoint()).toBe(true);
+		expect(localStorage.getItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT)).toBe("true");
+		expect(syncService.queueSettingsPush).toHaveBeenCalledTimes(1);
+		expect(syncService.queueSettingsPush).toHaveBeenLastCalledWith({ label: "premium endpoint settings" });
+	});
+
+	it("does not overwrite a pulled premium endpoint preference with the paid account default", async () => {
+		const apiKeyInputComponent = await import("../../../src/components/static/ApiKeyInput.component");
+		const syncService = await import("../../../src/services/Sync.service");
+
+		window.dispatchEvent(new CustomEvent("auth-state-changed", { detail: { loggedIn: true, subscription: {} } }));
+		localStorage.setItem(SETTINGS_STORAGE_KEYS.PREFER_PREMIUM_ENDPOINT, "false");
+		window.dispatchEvent(new CustomEvent("sync-data-pulled", { detail: {} }));
+
+		expect(apiKeyInputComponent.shouldPreferPremiumEndpoint()).toBe(false);
+		expect(syncService.queueSettingsPush).not.toHaveBeenCalled();
 	});
 
 	it("reapplies model-driven thinking constraints after synced settings replace stale local state", async () => {

--- a/tests/integration/settings/theme-sync.test.ts
+++ b/tests/integration/settings/theme-sync.test.ts
@@ -5,7 +5,7 @@ import { addHighlightThemeLink, bootstrapDom } from "../../helpers/dom";
 
 const syncServiceMock = vi.hoisted(() => ({
 	isSyncActive: vi.fn(() => true),
-	pushCurrentSettings: vi.fn(async () => true)
+	queueSettingsPush: vi.fn()
 }));
 
 vi.mock("../../../src/services/Sync.service", () => syncServiceMock);
@@ -43,7 +43,7 @@ describe("synced theme settings", () => {
 	beforeEach(() => {
 		vi.resetModules();
 		syncServiceMock.isSyncActive.mockReturnValue(true);
-		syncServiceMock.pushCurrentSettings.mockClear();
+		syncServiceMock.queueSettingsPush.mockClear();
 		bootstrapThemeControlsDom();
 		addHighlightThemeLink();
 	});
@@ -70,7 +70,7 @@ describe("synced theme settings", () => {
 		expect(
 			document.querySelector<HTMLButtonElement>('.theme-btn[data-theme="blue"]')?.classList.contains("active")
 		).toBe(true);
-		expect(syncServiceMock.pushCurrentSettings).not.toHaveBeenCalled();
+		expect(syncServiceMock.queueSettingsPush).not.toHaveBeenCalled();
 	});
 
 	it("pushes current settings when the user changes theme color or mode", async () => {
@@ -84,11 +84,13 @@ describe("synced theme settings", () => {
 		document.querySelector<HTMLButtonElement>('.theme-btn[data-theme="red"]')?.click();
 
 		expect(themeService.getSettings().colorTheme).toBe("red");
-		expect(syncServiceMock.pushCurrentSettings).toHaveBeenCalledTimes(1);
+		expect(syncServiceMock.queueSettingsPush).toHaveBeenCalledTimes(1);
+		expect(syncServiceMock.queueSettingsPush).toHaveBeenLastCalledWith({ label: "theme settings" });
 
 		document.querySelector<HTMLButtonElement>('[data-value="2"]')?.click();
 
 		expect(themeService.getSettings().mode).toBe("dark");
-		expect(syncServiceMock.pushCurrentSettings).toHaveBeenCalledTimes(2);
+		expect(syncServiceMock.queueSettingsPush).toHaveBeenCalledTimes(2);
+		expect(syncServiceMock.queueSettingsPush).toHaveBeenLastCalledWith({ label: "theme settings" });
 	});
 });

--- a/tests/integration/settings/theme-sync.test.ts
+++ b/tests/integration/settings/theme-sync.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SETTINGS_STORAGE_KEYS } from "../../../src/constants/SettingsStorageKeys";
+import { addHighlightThemeLink, bootstrapDom } from "../../helpers/dom";
+
+const syncServiceMock = vi.hoisted(() => ({
+	isSyncActive: vi.fn(() => true),
+	pushCurrentSettings: vi.fn(async () => true)
+}));
+
+vi.mock("../../../src/services/Sync.service", () => syncServiceMock);
+
+function setStoredTheme(colorTheme: string, mode: "light" | "dark"): void {
+	localStorage.setItem(
+		SETTINGS_STORAGE_KEYS.THEME_SETTINGS,
+		JSON.stringify({
+			colorTheme,
+			mode,
+			preference: "manual"
+		})
+	);
+}
+
+function bootstrapThemeControlsDom(): void {
+	bootstrapDom(`
+		<div class="stepped-slider">
+			<input type="hidden" id="themeMode" value="1">
+			<button class="stepped-slider-btn" data-value="0" data-icon="light_mode">Light</button>
+			<button class="stepped-slider-btn" data-value="1" data-icon="contrast">Auto</button>
+			<button class="stepped-slider-btn" data-value="2" data-icon="dark_mode">Dark</button>
+		</div>
+		<div class="theme-selector">
+			<button class="theme-btn" data-theme="blue" aria-label="Blue theme"></button>
+			<button class="theme-btn" data-theme="red" aria-label="Red theme"></button>
+			<button class="theme-btn" data-theme="green" aria-label="Green theme"></button>
+			<button class="theme-btn" data-theme="purple" aria-label="Purple theme"></button>
+			<button class="theme-btn" data-theme="monochrome" aria-label="Monochrome theme"></button>
+		</div>
+	`);
+}
+
+describe("synced theme settings", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		syncServiceMock.isSyncActive.mockReturnValue(true);
+		syncServiceMock.pushCurrentSettings.mockClear();
+		bootstrapThemeControlsDom();
+		addHighlightThemeLink();
+	});
+
+	it("rehydrates applied styles and controls after synced settings replace storage", async () => {
+		setStoredTheme("red", "dark");
+
+		const { themeService } = await import("../../../src/services/Theme.service");
+		themeService.initialize();
+		await import("../../../src/components/static/SteppedSlider.component");
+		await import("../../../src/components/static/ThemeControls.component");
+
+		expect(document.documentElement.getAttribute("data-theme")).toBe("red");
+		expect(document.documentElement.getAttribute("data-mode")).toBe("dark");
+		expect(document.querySelector<HTMLInputElement>("#themeMode")?.value).toBe("2");
+
+		setStoredTheme("blue", "light");
+		window.dispatchEvent(new CustomEvent("settings-loaded-from-storage", { detail: {} }));
+
+		expect(document.documentElement.getAttribute("data-theme")).toBe("blue");
+		expect(document.documentElement.getAttribute("data-mode")).toBe("light");
+		expect(document.querySelector<HTMLInputElement>("#themeMode")?.value).toBe("0");
+		expect(document.querySelector<HTMLButtonElement>('[data-value="0"]')?.classList.contains("active")).toBe(true);
+		expect(
+			document.querySelector<HTMLButtonElement>('.theme-btn[data-theme="blue"]')?.classList.contains("active")
+		).toBe(true);
+		expect(syncServiceMock.pushCurrentSettings).not.toHaveBeenCalled();
+	});
+
+	it("pushes current settings when the user changes theme color or mode", async () => {
+		setStoredTheme("blue", "light");
+
+		const { themeService } = await import("../../../src/services/Theme.service");
+		themeService.initialize();
+		await import("../../../src/components/static/SteppedSlider.component");
+		await import("../../../src/components/static/ThemeControls.component");
+
+		document.querySelector<HTMLButtonElement>('.theme-btn[data-theme="red"]')?.click();
+
+		expect(themeService.getSettings().colorTheme).toBe("red");
+		expect(syncServiceMock.pushCurrentSettings).toHaveBeenCalledTimes(1);
+
+		document.querySelector<HTMLButtonElement>('[data-value="2"]')?.click();
+
+		expect(themeService.getSettings().mode).toBe("dark");
+		expect(syncServiceMock.pushCurrentSettings).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
## Summary
- Sync premium endpoint preference changes when the toggle is updated or auto-defaulted for paid accounts.
- Sync theme changes and rehydrate theme controls when synced settings are pulled back into local storage.
- Sync onboarding API key and preference updates, plus LoRA add/remove changes, so local-first settings stay aligned across devices.
- Add integration coverage for premium endpoint, theme, and LoRA sync behavior.

## Testing
- Added integration tests covering settings push behavior and UI rehydration after synced storage updates.
- Verified theme controls, premium endpoint preference, and LoRA list persistence paths at the service/component boundary.
- Not run (not requested)

Closes #191 