### PR TITLE
Prepare release 1.8.6

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1601,16 +1601,16 @@
 					<h1 id="header-version">What's New in</h1>
 					<ul id="changelog">
 						<li>
-							<b>Richer model picker:</b> Browse models by provider family, search faster, and pin
-							favorites for quicker access
+							<b>More OpenRouter models:</b> New GLM, Qwen, and Grok options are available, with updated
+							roleplay suggestions for fresh model choices
 						</li>
 						<li>
-							<b>More model choices:</b> New OpenRouter options are available, including expanded Gemini,
-							Grok, Qwen, DeepSeek, and Inception models
+							<b>More reliable settings sync:</b> Theme, premium endpoint, onboarding, API key, and LoRA
+							preferences now stay aligned more consistently across devices
 						</li>
 						<li>
-							<b>Safer large sends:</b> Zodiac now warns when attachments or messages are too large,
-							helping prevent failed requests before they start
+							<b>Smoother app surfaces:</b> Floating sheets now blur and close more cleanly, avoiding a
+							broken backdrop on affected screens
 						</li>
 					</ul>
 				</div>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -57,7 +57,7 @@ export function lightenCard(element: HTMLElement) {
 }
 
 export function getVersion() {
-	return "1.8.5";
+	return "1.8.6";
 }
 
 export function getSanitized(string: string) {


### PR DESCRIPTION
## Summary
- Bump Zodiac to 1.8.6
- Update the in-app changelog for the latest model, sync, and surface fixes

## Testing
- npm run type-check
- npx vitest run --config vitest.config.mts tests/unit/models.test.ts tests/integration/services/surface-service.test.ts tests/integration/services/settings-push-queue.test.ts tests/integration/settings/theme-sync.test.ts tests/integration/settings/premium-endpoint-sync.test.ts tests/integration/settings/lora-sync.test.ts
- pre-push hook: npm run lint and npm run test