### PR TITLE
Replace image model enums with definitions

### DIFF
--- a/src/components/static/ChatInput.component.ts
+++ b/src/components/static/ChatInput.component.ts
@@ -79,7 +79,7 @@ let attachmentState: File[] = Array.from(attachmentsInput.files || []);
 let isInternetSearchEnabled = false;
 let dragDepth = 0;
 let currentHistoryImagePreview: HTMLElement | null = null;
-let isImageEditingActive = false;
+let isImageEditingModeActive = false;
 let isComposerAllowanceBlocked = false;
 let composerAllowanceBlockTitle = "Request unavailable";
 let composerAllowanceBlockText = "This request is currently unavailable.";
@@ -1325,9 +1325,9 @@ window.addEventListener(
 	"image-editing-toggled",
 	(event: any) =>
 		void (async () => {
-			isImageEditingActive = event.detail.enabled;
+			isImageEditingModeActive = event.detail.enabled;
 
-			if (!isImageEditingActive) {
+			if (!isImageEditingModeActive) {
 				// Clear history preview when editing is disabled
 				clearHistoryPreview();
 			} else {
@@ -1350,7 +1350,7 @@ window.addEventListener(
 	() =>
 		void (async () => {
 			// Hide history preview when attachments are added
-			if (isImageEditingActive) {
+			if (isImageEditingModeActive) {
 				clearHistoryPreview();
 				enforceImageLimitForModel();
 			}
@@ -1405,7 +1405,7 @@ window.addEventListener("attach-image-from-chat", (event: any) => {
 
 // Listen for edit model changes (model-specific image limit)
 window.addEventListener("edit-model-changed", () => {
-	if (isImageEditingActive) {
+	if (isImageEditingModeActive) {
 		enforceImageLimitForModel();
 	}
 });
@@ -1467,7 +1467,7 @@ function addAttachments(rawFiles: File[]): void {
 
 	if (added.length > 0) {
 		let finalAdded = added;
-		if (isImageEditingActive) {
+		if (isImageEditingModeActive) {
 			const editingModel = getSelectedEditingModel();
 			const maxImages = MODEL_IMAGE_LIMITS[editingModel];
 			if (maxImages) {

--- a/src/components/static/ChatInput.component.ts
+++ b/src/components/static/ChatInput.component.ts
@@ -15,7 +15,7 @@ import * as settingsService from "../../services/Settings.service";
 import * as chatsService from "../../services/Chats.service";
 import { getSelectedEditingModel } from "./ImageEditModelSelector.component";
 import { updateImageCreditsLabelVisibility } from "./ImageCreditsLabel.component";
-import { MODEL_IMAGE_LIMITS } from "../../constants/ImageModels";
+import { getImageModelDefinition } from "../../types/Models";
 import { SETTINGS_STORAGE_KEYS } from "../../constants/SettingsStorageKeys";
 import { openCustomerPortal } from "../../services/Supabase.service";
 import type { SubscriptionTier } from "../../types/Supabase";
@@ -1469,7 +1469,7 @@ function addAttachments(rawFiles: File[]): void {
 		let finalAdded = added;
 		if (isImageEditingModeActive) {
 			const editingModel = getSelectedEditingModel();
-			const maxImages = MODEL_IMAGE_LIMITS[editingModel];
+			const maxImages = getImageModelDefinition(editingModel)?.maxInputImages;
 			if (maxImages) {
 				const currentImageCount = attachmentState.filter((f) => f.type.startsWith("image/")).length;
 				const newImageFiles = added.filter((f) => f.type.startsWith("image/"));
@@ -1688,7 +1688,7 @@ function clearHistoryPreview(): void {
 
 function enforceImageLimitForModel(): void {
 	const editingModel = getSelectedEditingModel();
-	const maxImages = MODEL_IMAGE_LIMITS[editingModel];
+	const maxImages = getImageModelDefinition(editingModel)?.maxInputImages;
 	if (!maxImages) return;
 
 	const imageFiles = attachmentState.filter((file) => file.type.startsWith("image/"));

--- a/src/components/static/ImageEditModelSelector.component.ts
+++ b/src/components/static/ImageEditModelSelector.component.ts
@@ -1,6 +1,7 @@
 import { isImageGenerationAvailable } from "../../services/Supabase.service";
 import { dispatchAppEvent, onAppEvent } from "../../events";
-import { DEFAULT_IMAGE_EDIT_MODEL, ImageModelId, getImageModelDefinition } from "../../types/Models";
+import { DEFAULT_IMAGE_EDIT_MODEL, getImageModelDefinition } from "../../types/Models";
+import type { ImageModelId } from "../../types/Models";
 
 const imageEditModelSelector = document.querySelector<HTMLSelectElement>("#selectedImageEditingModel");
 if (!imageEditModelSelector) {

--- a/src/components/static/ImageEditModelSelector.component.ts
+++ b/src/components/static/ImageEditModelSelector.component.ts
@@ -1,5 +1,6 @@
 import { isImageGenerationAvailable } from "../../services/Supabase.service";
 import { dispatchAppEvent, onAppEvent } from "../../events";
+import { DEFAULT_IMAGE_EDIT_MODEL, ImageModelId, getImageModelDefinition } from "../../types/Models";
 
 const imageEditModelSelector = document.querySelector<HTMLSelectElement>("#selectedImageEditingModel");
 if (!imageEditModelSelector) {
@@ -62,6 +63,11 @@ onAppEvent("subscription-updated", () => {
 /**
  * Get the currently selected image editing model
  */
-export function getSelectedEditingModel(): string {
-	return imageEditModelSelector?.value || "seedream";
+export function getSelectedEditingModel(): ImageModelId {
+	const selectedModel = imageEditModelSelector?.value;
+	if (getImageModelDefinition(selectedModel)?.editing) {
+		return selectedModel as ImageModelId;
+	}
+
+	return DEFAULT_IMAGE_EDIT_MODEL;
 }

--- a/src/components/static/ImageModelSelector.component.ts
+++ b/src/components/static/ImageModelSelector.component.ts
@@ -1,4 +1,4 @@
-import { ImageModel } from "../../types/Models";
+import { IMAGE_MODELS } from "../../types/Models";
 import { isImageGenerationAvailable } from "../../services/Supabase.service";
 
 const imageModelSelector = document.querySelector<HTMLSelectElement>("#selectedImageModel");
@@ -27,20 +27,11 @@ async function updateImageModelSelectorState() {
 	}
 
 	// Ensure all model options are always present
-	Object.values(ImageModel).forEach((modelValue) => {
-		if (!Array.from(imageModelSelector.options).some((opt) => opt.value === modelValue)) {
+	IMAGE_MODELS.filter((model) => model.generation).forEach((model) => {
+		if (!Array.from(imageModelSelector.options).some((opt) => opt.value === model.id)) {
 			const option = document.createElement("option");
-			option.value = modelValue;
-			option.text = ((imageModelCodename: ImageModel): string => {
-				switch (imageModelCodename) {
-					case ImageModel.ILLUSTRIOUS:
-						return "Illustrious (Anime)";
-					case ImageModel.BLXL:
-						return "BLXL (Realism)";
-					default:
-						return "Undefined";
-				}
-			})(modelValue);
+			option.value = model.id;
+			option.text = model.label;
 			imageModelSelector.add(option);
 		}
 	});

--- a/src/constants/ImageModels.ts
+++ b/src/constants/ImageModels.ts
@@ -1,7 +1,0 @@
-import { ImageModelId } from "../types/Models";
-
-export const MODEL_IMAGE_LIMITS: Readonly<Partial<Record<ImageModelId, number>>> = {
-	[ImageModelId.QWEN]: 3,
-	[ImageModelId.SEEDREAM]: 5,
-	[ImageModelId.PRUNA]: 5
-} as const;

--- a/src/constants/ImageModels.ts
+++ b/src/constants/ImageModels.ts
@@ -1,5 +1,7 @@
-export const MODEL_IMAGE_LIMITS: Readonly<Record<string, number>> = {
-	qwen: 3,
-	seedream: 5,
-	pruna: 5
+import { ImageModelId } from "../types/Models";
+
+export const MODEL_IMAGE_LIMITS: Readonly<Partial<Record<ImageModelId, number>>> = {
+	[ImageModelId.QWEN]: 3,
+	[ImageModelId.SEEDREAM]: 5,
+	[ImageModelId.PRUNA]: 5
 } as const;

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -62,8 +62,7 @@ import { getSelectedEditingModel } from "../components/static/ImageEditModelSele
 
 import { isAbortError, throwAbortError } from "../utils/abort";
 import { dispatchAppEvent } from "../events";
-import { MODEL_IMAGE_LIMITS } from "../constants/ImageModels";
-import { DEFAULT_IMAGE_MODEL } from "../types/Models";
+import { DEFAULT_IMAGE_MODEL, getImageModelDefinition } from "../types/Models";
 import {
 	NARRATOR_PERSONALITY_ID,
 	createPersonalityMarkerMessage,
@@ -2580,7 +2579,7 @@ async function handleImageEditing(ctx: SendContext): Promise<HTMLElement | undef
 
 	const editingModel = getSelectedEditingModel();
 
-	const maxImages = MODEL_IMAGE_LIMITS[editingModel];
+	const maxImages = getImageModelDefinition(editingModel)?.maxInputImages;
 	if (maxImages && imagesToEdit.length > maxImages) {
 		const modelName = editingModel.charAt(0).toUpperCase() + editingModel.slice(1);
 		warn({

--- a/src/services/Settings.service.ts
+++ b/src/services/Settings.service.ts
@@ -2,7 +2,7 @@ import type { Content } from "@google/genai";
 import { HarmBlockThreshold, HarmCategory } from "@google/genai";
 import * as supabaseService from "./Supabase.service";
 import type { User } from "../types/User";
-import { DEFAULT_IMAGE_MODEL, getDefaultChatModel, getValidChatModel } from "../types/Models";
+import { DEFAULT_IMAGE_EDIT_MODEL, DEFAULT_IMAGE_MODEL, getDefaultChatModel, getValidChatModel } from "../types/Models";
 import * as syncService from "./Sync.service";
 import { SETTINGS_STORAGE_KEYS } from "../constants/SettingsStorageKeys";
 import { dispatchAppEvent, dispatchEmptyAppEvent } from "../events";
@@ -362,7 +362,8 @@ export function loadSettings() {
 		temperatureInput.value = localStorage.getItem(SETTINGS_STORAGE_KEYS.TEMPERATURE) || "60";
 		modelSelect.value = getSelectedOrFallbackModel();
 		imageModelSelect.value = localStorage.getItem(SETTINGS_STORAGE_KEYS.IMAGE_MODEL) || DEFAULT_IMAGE_MODEL;
-		imageEditModelSelector.value = localStorage.getItem(SETTINGS_STORAGE_KEYS.IMAGE_EDIT_MODEL) || "qwen";
+		imageEditModelSelector.value =
+			localStorage.getItem(SETTINGS_STORAGE_KEYS.IMAGE_EDIT_MODEL) || DEFAULT_IMAGE_EDIT_MODEL;
 		roleplaySuggestionModelSelect.value =
 			localStorage.getItem(SETTINGS_STORAGE_KEYS.ROLEPLAY_SUGGESTION_MODEL) || modelSelect.value;
 		autoscrollToggle.checked = localStorage.getItem(SETTINGS_STORAGE_KEYS.AUTOSCROLL)

--- a/src/types/Lora.ts
+++ b/src/types/Lora.ts
@@ -1,10 +1,10 @@
-import type { ImageModel } from "./Models";
+import type { ImageModelId } from "./Models";
 import { SETTINGS_STORAGE_KEYS } from "../constants/SettingsStorageKeys";
 
 export const LORA_STORAGE_KEY = SETTINGS_STORAGE_KEYS.LORAS;
 
 export interface LoRAInfo {
-	baseModel: ImageModel;
+	baseModel: ImageModelId;
 	name: string;
 	trainedWords: string[];
 	modelVersionId: string;

--- a/src/types/Lora.ts
+++ b/src/types/Lora.ts
@@ -1,10 +1,10 @@
-import type { ImageModelId } from "./Models";
+import type { BaseModel } from "./Models";
 import { SETTINGS_STORAGE_KEYS } from "../constants/SettingsStorageKeys";
 
 export const LORA_STORAGE_KEY = SETTINGS_STORAGE_KEYS.LORAS;
 
 export interface LoRAInfo {
-	baseModel: ImageModelId;
+	baseModel: BaseModel;
 	name: string;
 	trainedWords: string[];
 	modelVersionId: string;

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -43,6 +43,11 @@ export enum ImagePromptType {
 	SEMANTIC = "SEMANTIC"
 }
 
+export enum BaseModel {
+	SDXL = "sdxl",
+	ILLUSTRIOUS = "illustrious"
+}
+
 export interface ImageModelDefinition {
 	id: ImageModelId;
 	label: string;
@@ -50,6 +55,8 @@ export interface ImageModelDefinition {
 	generation: boolean;
 	editing: boolean;
 	promptType: ImagePromptType;
+	baseModel?: BaseModel;
+	maxInputImages?: number;
 }
 
 export const IMAGE_MODELS: ImageModelDefinition[] = [
@@ -59,7 +66,8 @@ export const IMAGE_MODELS: ImageModelDefinition[] = [
 		providers: [ImageModelProvider.EDGE],
 		generation: true,
 		editing: false,
-		promptType: ImagePromptType.TAG
+		promptType: ImagePromptType.TAG,
+		baseModel: BaseModel.ILLUSTRIOUS
 	},
 	{
 		id: ImageModelId.BLXL,
@@ -67,7 +75,8 @@ export const IMAGE_MODELS: ImageModelDefinition[] = [
 		providers: [ImageModelProvider.EDGE],
 		generation: true,
 		editing: false,
-		promptType: ImagePromptType.TAG
+		promptType: ImagePromptType.TAG,
+		baseModel: BaseModel.SDXL
 	},
 	{
 		id: ImageModelId.QWEN,
@@ -75,7 +84,8 @@ export const IMAGE_MODELS: ImageModelDefinition[] = [
 		providers: [ImageModelProvider.EDGE],
 		generation: false,
 		editing: true,
-		promptType: ImagePromptType.SEMANTIC
+		promptType: ImagePromptType.SEMANTIC,
+		maxInputImages: 3
 	},
 	{
 		id: ImageModelId.SEEDREAM,
@@ -83,7 +93,8 @@ export const IMAGE_MODELS: ImageModelDefinition[] = [
 		providers: [ImageModelProvider.EDGE],
 		generation: false,
 		editing: true,
-		promptType: ImagePromptType.SEMANTIC
+		promptType: ImagePromptType.SEMANTIC,
+		maxInputImages: 5
 	},
 	{
 		id: ImageModelId.PRUNA,
@@ -91,7 +102,8 @@ export const IMAGE_MODELS: ImageModelDefinition[] = [
 		providers: [ImageModelProvider.EDGE],
 		generation: false,
 		editing: true,
-		promptType: ImagePromptType.SEMANTIC
+		promptType: ImagePromptType.SEMANTIC,
+		maxInputImages: 5
 	}
 ];
 

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -24,29 +24,79 @@ const GEMINI_TO_OPENROUTER_CHAT_MODEL_IDS = new Map<string, string>([
 	[ChatModel.NANO_BANANA_2, "google/gemini-3.1-flash-image-preview"]
 ]);
 
-export enum ImageModel {
+export enum ImageModelId {
 	ILLUSTRIOUS = "illustrious",
-	BLXL = "biglust"
-}
-
-export enum ImageModelLabel {
-	ILLUSTRIOUS = "Illustrious (Anime)",
-	BLXL = "BLXL (Realism)"
-}
-
-export const DEFAULT_IMAGE_MODEL = ImageModel.ILLUSTRIOUS;
-
-export enum ImageEditModel {
+	BLXL = "biglust",
 	SEEDREAM = "seedream",
 	QWEN = "qwen",
 	PRUNA = "pruna"
 }
 
-export enum ImageEditModelLabel {
-	SEEDREAM = "Seedream 4.0 Edit",
-	QWEN = "Qwen Image Edit",
-	PRUNA = "P-Image Edit"
+export enum ImageModelProvider {
+	GOOGLE = "GOOGLE",
+	OPENROUTER = "OPENROUTER",
+	EDGE = "EDGE"
 }
+
+export enum ImagePromptType {
+	TAG = "TAG",
+	SEMANTIC = "SEMANTIC"
+}
+
+export interface ImageModelDefinition {
+	id: ImageModelId;
+	label: string;
+	providers: ImageModelProvider[];
+	generation: boolean;
+	editing: boolean;
+	promptType: ImagePromptType;
+}
+
+export const IMAGE_MODELS: ImageModelDefinition[] = [
+	{
+		id: ImageModelId.ILLUSTRIOUS,
+		label: "Illustrious (Anime)",
+		providers: [ImageModelProvider.EDGE],
+		generation: true,
+		editing: false,
+		promptType: ImagePromptType.TAG
+	},
+	{
+		id: ImageModelId.BLXL,
+		label: "BLXL (Realism)",
+		providers: [ImageModelProvider.EDGE],
+		generation: true,
+		editing: false,
+		promptType: ImagePromptType.TAG
+	},
+	{
+		id: ImageModelId.QWEN,
+		label: "Qwen Image Edit",
+		providers: [ImageModelProvider.EDGE],
+		generation: false,
+		editing: true,
+		promptType: ImagePromptType.SEMANTIC
+	},
+	{
+		id: ImageModelId.SEEDREAM,
+		label: "Seedream 4.0 Edit",
+		providers: [ImageModelProvider.EDGE],
+		generation: false,
+		editing: true,
+		promptType: ImagePromptType.SEMANTIC
+	},
+	{
+		id: ImageModelId.PRUNA,
+		label: "P-Image Edit",
+		providers: [ImageModelProvider.EDGE],
+		generation: false,
+		editing: true,
+		promptType: ImagePromptType.SEMANTIC
+	}
+];
+
+export const DEFAULT_IMAGE_MODEL = ImageModelId.ILLUSTRIOUS;
+export const DEFAULT_IMAGE_EDIT_MODEL = ImageModelId.QWEN;
 
 export type ModelProvider = "gemini" | "openrouter";
 
@@ -642,13 +692,10 @@ export function getPremiumEndpointChatModel(model: string | null | undefined): s
 	return mappedModel;
 }
 
-const imageModelLabelMap = new Map<string, string>([
-	[ImageModel.ILLUSTRIOUS, ImageModelLabel.ILLUSTRIOUS],
-	[ImageModel.BLXL, ImageModelLabel.BLXL],
-	[ImageEditModel.SEEDREAM, ImageEditModelLabel.SEEDREAM],
-	[ImageEditModel.QWEN, ImageEditModelLabel.QWEN],
-	[ImageEditModel.PRUNA, ImageEditModelLabel.PRUNA]
-]);
+export function getImageModelDefinition(model: string | null | undefined): ImageModelDefinition | undefined {
+	if (!model) return undefined;
+	return IMAGE_MODELS.find((definition) => definition.id === model);
+}
 
 export function formatOriginModelLabel(originModel: string | null | undefined): string {
 	if (!originModel) return "";
@@ -658,7 +705,7 @@ export function formatOriginModelLabel(originModel: string | null | undefined): 
 		return formatChatModelLabel(chatDefinition);
 	}
 
-	return imageModelLabelMap.get(originModel) ?? originModel;
+	return getImageModelDefinition(originModel)?.label ?? originModel;
 }
 
 export function getDefaultChatModel(access: ChatModelAccess): string {

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -704,9 +704,9 @@ export function getPremiumEndpointChatModel(model: string | null | undefined): s
 	return mappedModel;
 }
 
-export function getImageModelDefinition(model: string | null | undefined): ImageModelDefinition | undefined {
-	if (!model) return undefined;
-	return IMAGE_MODELS.find((definition) => definition.id === model);
+export function getImageModelDefinition(modelId: string | null | undefined): ImageModelDefinition | undefined {
+	if (!modelId) return undefined;
+	return IMAGE_MODELS.find((definition) => definition.id === modelId);
 }
 
 export function formatOriginModelLabel(originModel: string | null | undefined): string {

--- a/tests/integration/settings/lora-sync.test.ts
+++ b/tests/integration/settings/lora-sync.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SETTINGS_STORAGE_KEYS } from "../../../src/constants/SettingsStorageKeys";
-import { ImageModel } from "../../../src/types/Models";
+import { ImageModelId } from "../../../src/types/Models";
 import type { LoRAInfo } from "../../../src/types/Lora";
 
 const syncServiceMock = vi.hoisted(() => ({
@@ -22,7 +22,7 @@ vi.mock("../../../src/services/Supabase.service", () => ({
 }));
 
 const loraFixture: LoRAInfo = {
-	baseModel: ImageModel.ILLUSTRIOUS,
+	baseModel: ImageModelId.ILLUSTRIOUS,
 	name: "Test LoRA",
 	trainedWords: ["test"],
 	modelVersionId: "123",

--- a/tests/integration/settings/lora-sync.test.ts
+++ b/tests/integration/settings/lora-sync.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SETTINGS_STORAGE_KEYS } from "../../../src/constants/SettingsStorageKeys";
-import { ImageModelId } from "../../../src/types/Models";
+import { BaseModel } from "../../../src/types/Models";
 import type { LoRAInfo } from "../../../src/types/Lora";
 
 const syncServiceMock = vi.hoisted(() => ({
@@ -22,7 +22,7 @@ vi.mock("../../../src/services/Supabase.service", () => ({
 }));
 
 const loraFixture: LoRAInfo = {
-	baseModel: ImageModelId.ILLUSTRIOUS,
+	baseModel: BaseModel.ILLUSTRIOUS,
 	name: "Test LoRA",
 	trainedWords: ["test"],
 	modelVersionId: "123",

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	BaseModel,
 	DEFAULT_IMAGE_EDIT_MODEL,
 	DEFAULT_IMAGE_MODEL,
 	DEFAULT_OPENROUTER_TITLE_MODEL,
@@ -58,6 +59,17 @@ describe("image model definitions", () => {
 		for (const modelId of [ImageModelId.QWEN, ImageModelId.SEEDREAM, ImageModelId.PRUNA]) {
 			expect(getImageModelDefinition(modelId)?.promptType).toBe(ImagePromptType.SEMANTIC);
 		}
+	});
+
+	it("stores base-model compatibility independently from selectable model IDs", () => {
+		expect(getImageModelDefinition(ImageModelId.ILLUSTRIOUS)?.baseModel).toBe(BaseModel.ILLUSTRIOUS);
+		expect(getImageModelDefinition(ImageModelId.BLXL)?.baseModel).toBe(BaseModel.SDXL);
+	});
+
+	it("stores editing input image limits in image model metadata", () => {
+		expect(getImageModelDefinition(ImageModelId.QWEN)?.maxInputImages).toBe(3);
+		expect(getImageModelDefinition(ImageModelId.SEEDREAM)?.maxInputImages).toBe(5);
+		expect(getImageModelDefinition(ImageModelId.PRUNA)?.maxInputImages).toBe(5);
 	});
 });
 

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	DEFAULT_IMAGE_EDIT_MODEL,
+	DEFAULT_IMAGE_MODEL,
 	DEFAULT_OPENROUTER_TITLE_MODEL,
+	IMAGE_MODELS,
+	ImageModelId,
+	ImageModelProvider,
+	ImagePromptType,
 	getAccessibleRoleplaySuggestionModels,
 	getChatModelDefinition,
+	getImageModelDefinition,
 	getPremiumEndpointChatModel,
 	getValidChatModel,
 	getValidRoleplaySuggestionModel,
@@ -14,6 +21,43 @@ import {
 describe("default model roles", () => {
 	it("uses GLM 5 for local OpenRouter chat title generation", () => {
 		expect(DEFAULT_OPENROUTER_TITLE_MODEL).toBe("z-ai/glm-5");
+	});
+});
+
+describe("image model definitions", () => {
+	it("represents current image generation and editing models once", () => {
+		const modelIds = IMAGE_MODELS.map((model) => model.id);
+
+		expect(new Set(modelIds).size).toBe(modelIds.length);
+		expect(modelIds.sort()).toEqual(
+			[
+				ImageModelId.ILLUSTRIOUS,
+				ImageModelId.BLXL,
+				ImageModelId.QWEN,
+				ImageModelId.SEEDREAM,
+				ImageModelId.PRUNA
+			].sort()
+		);
+	});
+
+	it("keeps image defaults pointed at valid model capabilities", () => {
+		expect(getImageModelDefinition(DEFAULT_IMAGE_MODEL)?.generation).toBe(true);
+		expect(getImageModelDefinition(DEFAULT_IMAGE_EDIT_MODEL)?.editing).toBe(true);
+	});
+
+	it("records edge provider support for current image models", () => {
+		for (const model of IMAGE_MODELS) {
+			expect(model.providers).toContain(ImageModelProvider.EDGE);
+		}
+	});
+
+	it("stores prompt type per image model", () => {
+		expect(getImageModelDefinition(ImageModelId.ILLUSTRIOUS)?.promptType).toBe(ImagePromptType.TAG);
+		expect(getImageModelDefinition(ImageModelId.BLXL)?.promptType).toBe(ImagePromptType.TAG);
+
+		for (const modelId of [ImageModelId.QWEN, ImageModelId.SEEDREAM, ImageModelId.PRUNA]) {
+			expect(getImageModelDefinition(modelId)?.promptType).toBe(ImagePromptType.SEMANTIC);
+		}
 	});
 });
 


### PR DESCRIPTION
## Summary
- Rename image model identifiers to ImageModelId and add unified IMAGE_MODELS metadata
- Represent current generation and editing models with provider, capability, and prompt-type metadata
- Update selectors, defaults, LoRA typing, and model tests to use the new source of truth

## Tests
- npm run type-check
- npm run test:vitest -- tests/unit/models.test.ts
- npm run test:vitest -- tests/integration/settings/lora-sync.test.ts
- npm run lint
- npm run test

Closes #204