### PR TITLE
Port image models to dedicated routes

### DIFF
--- a/src/components/static/ChatInput.component.ts
+++ b/src/components/static/ChatInput.component.ts
@@ -1432,9 +1432,12 @@ function addAttachments(rawFiles: File[]): void {
 	let limitReached = false;
 	const added: File[] = [];
 	const existingSignatures = new Set(attachmentState.map(getFileSignature));
+	const attachmentLimit = isImageEditingModeActive
+		? (IMAGE_MODELS.find((model) => model.id === getSelectedEditingModel())?.maxInputImages ?? MAX_ATTACHMENTS)
+		: MAX_ATTACHMENTS;
 
 	for (const file of files) {
-		if (attachmentState.length + added.length >= MAX_ATTACHMENTS) {
+		if (attachmentState.length + added.length >= attachmentLimit) {
 			limitReached = true;
 			break;
 		}
@@ -1541,7 +1544,7 @@ function addAttachments(rawFiles: File[]): void {
 	if (limitReached) {
 		toastService.warn({
 			title: "Attachment limit reached",
-			text: `You can attach up to ${MAX_ATTACHMENTS} files per message.`
+			text: `You can attach up to ${attachmentLimit} files for this request.`
 		});
 	}
 }

--- a/src/components/static/ImageCreditsLabel.component.ts
+++ b/src/components/static/ImageCreditsLabel.component.ts
@@ -4,31 +4,27 @@ import { getLoraState } from "../../services/Lora.service";
 import {
 	getCurrentUser,
 	getMegaCreditsRecord,
-	getNanoBananaDailyUsageRecord,
 	getSubscriptionTier,
 	getUserSubscription
 } from "../../services/Supabase.service";
-import { ChatModel, getChatModelDefinition, getPremiumEndpointChatModel } from "../../types/Models";
+import { getChatModelDefinition } from "../../types/Models";
 import * as overlayService from "../../services/Overlay.service";
 import { dispatchAppEvent } from "../../events";
-import { shouldPreferPremiumEndpoint } from "./ApiKeyInput.component";
+import {
+	hasGeminiApiKey,
+	hasOpenRouterApiKey,
+	shouldPreferPremiumEndpoint,
+	shouldPreferPremiumImageEndpoint
+} from "./ApiKeyInput.component";
+import { DEFAULT_IMAGE_MODEL, IMAGE_MODELS } from "../../constants/ImageModels";
+import { getSelectedEditingModel } from "./ImageEditModelSelector.component";
+import { resolveImageModelRoute } from "../../utils/imageModelRouting";
+import { loraArchitectureFromCivitaiBaseModel } from "../../constants/Loras";
 
 const imageCreditsLabel = document.querySelector<HTMLDivElement>("#image-credits-label");
 const imageCreditsPopover = document.querySelector<HTMLDivElement>("#image-credits-popover");
 const imageModelSelector = document.querySelector<HTMLSelectElement>("#selectedImageModel");
 const modelSelector = document.querySelector<HTMLSelectElement>("#selectedModel");
-
-const PRO_NANO_BANANA_DAILY_LIMIT = 20;
-const NANO_BANANA_MODELS = new Set<string>(
-	[
-		ChatModel.NANO_BANANA,
-		ChatModel.NANO_BANANA_PRO,
-		ChatModel.NANO_BANANA_2,
-		getPremiumEndpointChatModel(ChatModel.NANO_BANANA),
-		getPremiumEndpointChatModel(ChatModel.NANO_BANANA_PRO),
-		getPremiumEndpointChatModel(ChatModel.NANO_BANANA_2)
-	].filter((model): model is string => !!model)
-);
 
 if (!imageCreditsLabel || !imageCreditsPopover) {
 	console.error("Image credits label component initialization failed");
@@ -37,12 +33,10 @@ if (!imageCreditsLabel || !imageCreditsPopover) {
 
 let imageCredits: number | null | undefined = undefined;
 let megaCredits: number | null | undefined = undefined;
-let nanoBananaUsageCount = 0;
-let nanoBananaUsageDate: string | null = null;
 let subscriptionTier: "free" | "pro" | "pro_plus" | "max" | "canceled" = "free";
 let isPopoverVisible = false;
 
-type AllowanceMode = "image" | "mega" | "nano" | null;
+type AllowanceMode = "image" | "mega" | null;
 
 // Click handler for the label
 imageCreditsLabel.addEventListener("click", (e) => {
@@ -115,7 +109,16 @@ window.addEventListener("chat-model-changed", () => {
 	renderLabel();
 });
 
+window.addEventListener("edit-model-changed", () => {
+	renderLabel();
+});
+
 window.addEventListener("premium-endpoint-preference-changed", () => {
+	updateImageCreditsLabelVisibility();
+	renderLabel();
+});
+
+window.addEventListener("image-premium-endpoint-preference-changed", () => {
 	updateImageCreditsLabelVisibility();
 	renderLabel();
 });
@@ -151,15 +154,45 @@ function selectedChatModelConsumesImageCredits(): boolean {
 	return getChatModelDefinition(getSelectedChatModel())?.consumesImageCredits === true;
 }
 
-function getAllowanceMode(): AllowanceMode {
-	if (isImageEditingActive() || isImageModeActive()) {
-		return "image";
+function getActiveImageModel() {
+	if (isImageEditingActive()) {
+		return IMAGE_MODELS.find((model) => model.id === getSelectedEditingModel() && model.editing);
 	}
 
-	// The chat-model allowances below (image-credit models, mega credits, the Nano Banana daily
-	// allowance) are metered server-side and only consumed when the request goes through the premium
-	// endpoint. With it disabled the request uses the user's own API key and nothing is charged, so
-	// don't surface these allowance labels.
+	if (isImageModeActive()) {
+		return IMAGE_MODELS.find(
+			(model) => model.id === (imageModelSelector?.value || DEFAULT_IMAGE_MODEL) && model.generation
+		);
+	}
+
+	return undefined;
+}
+
+function getActiveImageRoute() {
+	const model = getActiveImageModel();
+	if (!model) return null;
+	return resolveImageModelRoute(model, shouldPreferPremiumImageEndpoint(), {
+		edgeCredits: Number(imageCredits ?? 0) > 0,
+		geminiKey: hasGeminiApiKey(),
+		openRouterKey: hasOpenRouterApiKey()
+	});
+}
+
+function getCompatibleActiveLoraCount(): number {
+	const architecture = getActiveImageModel()?.loraArchitecture;
+	if (!architecture) return 0;
+	return getLoraState().filter(
+		(state) => state.enabled && loraArchitectureFromCivitaiBaseModel(state.lora.baseModel) === architecture
+	).length;
+}
+
+function getAllowanceMode(): AllowanceMode {
+	if (isImageEditingActive() || isImageModeActive()) {
+		return getActiveImageRoute()?.route === "edge" ? "image" : null;
+	}
+
+	// Chat-model allowances are only consumed through the premium endpoint. BYOK requests do not
+	// consume them, so the label stays hidden when that route is selected.
 	if (!shouldPreferPremiumEndpoint()) {
 		return null;
 	}
@@ -175,35 +208,13 @@ function getAllowanceMode(): AllowanceMode {
 		return "mega";
 	}
 
-	if (subscriptionTier === "pro" && selectedModel && NANO_BANANA_MODELS.has(selectedModel)) {
-		return "nano";
-	}
-
 	return null;
-}
-
-function getTodayIsoDate(): string {
-	const now = new Date();
-	const year = now.getFullYear();
-	const month = String(now.getMonth() + 1).padStart(2, "0");
-	const day = String(now.getDate()).padStart(2, "0");
-	return `${year}-${month}-${day}`;
-}
-
-function getEffectiveNanoBananaUsageCount(): number {
-	return nanoBananaUsageDate === getTodayIsoDate() ? nanoBananaUsageCount : 0;
-}
-
-function getRemainingNanoBananaUses(): number {
-	return Math.max(PRO_NANO_BANANA_DAILY_LIMIT - getEffectiveNanoBananaUsageCount(), 0);
 }
 
 async function refreshSupplementalAllowanceState(): Promise<void> {
 	const currentUser = await getCurrentUser();
 	if (!currentUser) {
 		megaCredits = undefined;
-		nanoBananaUsageCount = 0;
-		nanoBananaUsageDate = null;
 		subscriptionTier = "free";
 		updateImageCreditsLabelVisibility();
 		renderLabel();
@@ -218,15 +229,6 @@ async function refreshSupplementalAllowanceState(): Promise<void> {
 		megaCredits = megaCreditsRecord?.remaining_mega_credits ?? 0;
 	} else {
 		megaCredits = undefined;
-	}
-
-	if (subscriptionTier === "pro") {
-		const nanoUsageRecord = await getNanoBananaDailyUsageRecord();
-		nanoBananaUsageCount = Number(nanoUsageRecord?.usage_count ?? 0);
-		nanoBananaUsageDate = nanoUsageRecord?.usage_date ?? getTodayIsoDate();
-	} else {
-		nanoBananaUsageCount = 0;
-		nanoBananaUsageDate = null;
 	}
 
 	updateImageCreditsLabelVisibility();
@@ -244,6 +246,9 @@ function calculateCreditsNeeded(): number {
 	if (!isEditing && !isGenerating) {
 		return 0;
 	}
+	if (getAllowanceMode() !== "image") {
+		return 0;
+	}
 
 	if (isEditing) {
 		// Image editing always costs 1 credit (no LoRAs)
@@ -251,8 +256,7 @@ function calculateCreditsNeeded(): number {
 	}
 
 	// Image generation
-	const loraState = getLoraState();
-	const activeLorasCount = loraState.filter((state) => state.enabled).length;
+	const activeLorasCount = getCompatibleActiveLoraCount();
 
 	if (activeLorasCount === 0) {
 		return 1; // Base cost
@@ -272,10 +276,6 @@ function hasInsufficientMegaCredits(): boolean {
 	return getAllowanceMode() === "mega" && Number(megaCredits ?? 0) < 1;
 }
 
-function hasInsufficientNanoAllowance(): boolean {
-	return getAllowanceMode() === "nano" && getRemainingNanoBananaUses() < 1;
-}
-
 function checkAndDispatchInsufficientCreditsState(): void {
 	const allowanceMode = getAllowanceMode();
 	const isInsufficient = hasInsufficientCredits();
@@ -291,15 +291,6 @@ function checkAndDispatchInsufficientCreditsState(): void {
 			blocked: hasInsufficientMegaCredits(),
 			title: "Insufficient Mega Credits",
 			text: "This model costs 1 Mega Credit per request. Choose another model or upgrade to Max for unlimited Mega access."
-		});
-		return;
-	}
-
-	if (allowanceMode === "nano") {
-		dispatchAppEvent("composer-allowance-blocked", {
-			blocked: hasInsufficientNanoAllowance(),
-			title: "Nano Banana Daily Limit Reached",
-			text: `Pro includes ${PRO_NANO_BANANA_DAILY_LIMIT} Nano Banana requests per day. Try again tomorrow or switch models.`
 		});
 		return;
 	}
@@ -324,15 +315,6 @@ function renderLabel(): void {
 		} else {
 			imageCreditsLabel.textContent = `${megaCredits} Mega Credits`;
 		}
-
-		checkAndDispatchInsufficientCreditsState();
-		if (isPopoverVisible) renderPopoverContent();
-		return;
-	}
-
-	if (allowanceMode === "nano") {
-		const remainingNanoUses = getRemainingNanoBananaUses();
-		imageCreditsLabel.textContent = remainingNanoUses > 0 ? `${remainingNanoUses} Nano Left` : "Nano Limit Reached";
 
 		checkAndDispatchInsufficientCreditsState();
 		if (isPopoverVisible) renderPopoverContent();
@@ -382,42 +364,9 @@ function renderPopoverContent(): void {
 		return;
 	}
 
-	if (allowanceMode === "nano") {
-		const usageCount = getEffectiveNanoBananaUsageCount();
-		const remaining = getRemainingNanoBananaUses();
-		imageCreditsPopover.innerHTML = `
-            <div class="image-credits-popover-header">
-                <h4>Nano Banana Daily Allowance</h4>
-                <button class="image-credits-popover-close btn-textual material-symbols-outlined" aria-label="Close">close</button>
-            </div>
-            <div class="image-credits-popover-body">
-                <div class="credit-breakdown-item">
-                    <span class="material-symbols-outlined credit-icon">image</span>
-                    <span class="credit-description">Nano Banana request</span>
-                    <span class="credit-amount">1 daily use</span>
-                </div>
-                <div class="credit-breakdown-simple-item">
-                    <span class="credit-simple-label">Daily limit</span>
-                    <span class="credit-simple-value">${PRO_NANO_BANANA_DAILY_LIMIT}</span>
-                </div>
-                <div class="credit-breakdown-simple-item">
-                    <span class="credit-simple-label">Used today</span>
-                    <span class="credit-simple-value">${usageCount}</span>
-                </div>
-                <div class="credit-breakdown-remaining">
-                    <span class="credit-remaining-label">Remaining after request</span>
-                    <span class="credit-remaining-amount">${Math.max(remaining - 1, 0)}</span>
-                </div>
-            </div>
-        `;
-		bindPopoverButtons();
-		return;
-	}
-
 	const isEditing = isImageEditingActive();
 	const isGenerating = isImageModeActive();
-	const loraState = getLoraState();
-	const activeLorasCount = loraState.filter((state) => state.enabled).length;
+	const activeLorasCount = getCompatibleActiveLoraCount();
 	const creditsNeeded = calculateCreditsNeeded();
 	const totalCredits = imageCredits ?? 0;
 

--- a/src/components/static/ProfilePanel.component.ts
+++ b/src/components/static/ProfilePanel.component.ts
@@ -17,7 +17,6 @@ const infoCard = document.querySelector<HTMLElement>("#profile-info-card");
 const infoHeader = document.querySelector<HTMLElement>("#profile-info-card .collapsible-card-header");
 const remainingImageGenerations = document.querySelector<HTMLSpanElement>("#subscription-remaining-generations");
 const remainingMegaCredits = document.querySelector<HTMLSpanElement>("#subscription-remaining-mega-credits");
-const remainingNanoBanana = document.querySelector<HTMLSpanElement>("#subscription-remaining-nano-banana");
 const accountCard = document.querySelector<HTMLElement>("#account-info-card");
 const accountHeader = document.querySelector<HTMLElement>("#account-info-card .collapsible-card-header");
 const accountEmailEl = document.querySelector<HTMLSpanElement>("#account-email");
@@ -41,7 +40,6 @@ if (
 	!infoHeader ||
 	!remainingImageGenerations ||
 	!remainingMegaCredits ||
-	!remainingNanoBanana ||
 	!accountCard ||
 	!accountHeader ||
 	!accountEmailEl ||
@@ -54,9 +52,6 @@ if (
 
 const ensuredRemainingImageGenerations = remainingImageGenerations;
 const ensuredRemainingMegaCredits = remainingMegaCredits;
-const ensuredRemainingNanoBanana = remainingNanoBanana;
-
-const PRO_NANO_BANANA_DAILY_LIMIT = 20;
 
 function setProfileSavePending(isPending: boolean) {
 	isSavingProfile = isPending;
@@ -73,19 +68,6 @@ async function updateProfile(user: User): Promise<void> {
 	}
 }
 
-function getTodayIsoDate() {
-	const now = new Date();
-	const year = now.getFullYear();
-	const month = String(now.getMonth() + 1).padStart(2, "0");
-	const day = String(now.getDate()).padStart(2, "0");
-	return `${year}-${month}-${day}`;
-}
-
-function getEffectiveNanoUsageCount(record: supabaseService.NanoBananaDailyUsageRecord | null): number {
-	if (!record) return 0;
-	return record.usage_date === getTodayIsoDate() ? Number(record.usage_count ?? 0) : 0;
-}
-
 async function refreshSubscriptionAllowances(): Promise<void> {
 	const subscription = await supabaseService.getUserSubscription();
 	const tier = supabaseService.getSubscriptionTier(subscription);
@@ -100,16 +82,6 @@ async function refreshSubscriptionAllowances(): Promise<void> {
 		ensuredRemainingMegaCredits.textContent = "Unlimited";
 	} else {
 		ensuredRemainingMegaCredits.textContent = "—";
-	}
-
-	if (tier === "pro") {
-		const nanoUsageRecord = await supabaseService.getNanoBananaDailyUsageRecord();
-		const remaining = Math.max(PRO_NANO_BANANA_DAILY_LIMIT - getEffectiveNanoUsageCount(nanoUsageRecord), 0);
-		ensuredRemainingNanoBanana.textContent = `${remaining} left today`;
-	} else if (tier === "pro_plus" || tier === "max") {
-		ensuredRemainingNanoBanana.textContent = "Unlimited";
-	} else {
-		ensuredRemainingNanoBanana.textContent = "—";
 	}
 }
 

--- a/src/components/static/ShowSubscriptionOptions.component.ts
+++ b/src/components/static/ShowSubscriptionOptions.component.ts
@@ -2,11 +2,13 @@ import * as overlayService from "../../services/Overlay.service";
 import { getCurrentUser } from "../../services/Supabase.service";
 
 const button = document.querySelector("#btn-show-subscription-options");
+const closeButton = document.querySelector("#btn-close-subscription");
 
-if (!button) {
-	console.error("Show Subscription Options button not found");
-	throw new Error("Show Subscription Options button not found");
+if (!button || !closeButton) {
+	throw new Error("Missing subscription options controls");
 }
+
+closeButton.addEventListener("click", () => overlayService.closeOverlay());
 
 button.addEventListener(
 	"click",

--- a/src/constants/ImageModels.ts
+++ b/src/constants/ImageModels.ts
@@ -81,6 +81,46 @@ export const IMAGE_MODELS: ImageModelDefinition[] = [
 		editing: true,
 		promptType: ImagePromptType.SEMANTIC,
 		maxInputImages: 5
+	},
+	{
+		id: ImageModelId.GEMINI_2_5_FLASH_IMAGE,
+		label: "Nano Banana",
+		providers: [ImageModelProvider.EDGE, ImageModelProvider.OPENROUTER, ImageModelProvider.GOOGLE],
+		generation: true,
+		editing: true,
+		promptType: ImagePromptType.SEMANTIC,
+		maxInputImages: 5,
+		openRouterModelId: "google/gemini-2.5-flash-image"
+	},
+	{
+		id: ImageModelId.GEMINI_3_PRO_IMAGE_PREVIEW,
+		label: "Nano Banana Pro",
+		providers: [ImageModelProvider.EDGE, ImageModelProvider.OPENROUTER, ImageModelProvider.GOOGLE],
+		generation: true,
+		editing: true,
+		promptType: ImagePromptType.SEMANTIC,
+		maxInputImages: 5,
+		openRouterModelId: "google/gemini-3-pro-image-preview"
+	},
+	{
+		id: ImageModelId.GEMINI_3_1_FLASH_IMAGE_PREVIEW,
+		label: "Nano Banana 2",
+		providers: [ImageModelProvider.EDGE, ImageModelProvider.OPENROUTER, ImageModelProvider.GOOGLE],
+		generation: true,
+		editing: true,
+		promptType: ImagePromptType.SEMANTIC,
+		maxInputImages: 5,
+		openRouterModelId: "google/gemini-3.1-flash-image-preview"
+	},
+	{
+		id: ImageModelId.GROK_IMAGINE_IMAGE_QUALITY,
+		label: "Grok Imagine Image Quality",
+		providers: [ImageModelProvider.EDGE, ImageModelProvider.OPENROUTER],
+		generation: true,
+		editing: true,
+		promptType: ImagePromptType.SEMANTIC,
+		maxInputImages: 3,
+		openRouterModelId: "x-ai/grok-imagine-image-quality"
 	}
 ];
 

--- a/src/index.html
+++ b/src/index.html
@@ -1775,10 +1775,6 @@
 									<span class="setting-label">Mega credits</span>
 									<span id="subscription-remaining-mega-credits">—</span>
 								</div>
-								<div class="subscription-row">
-									<span class="setting-label">Nano Banana allowance</span>
-									<span id="subscription-remaining-nano-banana">—</span>
-								</div>
 							</div>
 							<div class="subscription-card-footer">
 								<button class="btn btn-primary" id="btn-top-up-credits">Get More Image Credits</button>
@@ -1964,15 +1960,11 @@
 									<div class="subscription-stat-grid">
 										<div class="subscription-stat">
 											<span class="subscription-stat-label">Mega Credits</span>
-											<strong>50 / month</strong>
+											<strong>100 / month</strong>
 										</div>
 										<div class="subscription-stat">
 											<span class="subscription-stat-label">Image Credits</span>
 											<strong>50 / month</strong>
-										</div>
-										<div class="subscription-stat">
-											<span class="subscription-stat-label">Nano-Banana</span>
-											<strong>20 / day</strong>
 										</div>
 									</div>
 
@@ -2052,15 +2044,11 @@
 									<div class="subscription-stat-grid">
 										<div class="subscription-stat">
 											<span class="subscription-stat-label">Mega Credits</span>
-											<strong>300 / month</strong>
+											<strong>400 / month</strong>
 										</div>
 										<div class="subscription-stat">
 											<span class="subscription-stat-label">Image Credits</span>
-											<strong>600 / month</strong>
-										</div>
-										<div class="subscription-stat">
-											<span class="subscription-stat-label">Nano-Banana</span>
-											<strong>Unlimited</strong>
+											<strong>500 / month</strong>
 										</div>
 									</div>
 
@@ -2068,10 +2056,6 @@
 										<li class="feature-item feature-item-inherited">
 											<span class="feature-icon">+</span
 											><span class="feature-text">Everything in Pro, and...</span>
-										</li>
-										<li class="feature-item">
-											<span class="feature-icon">✓</span
-											><span class="feature-text">Unlimited Nano-Banana usage</span>
 										</li>
 										<li class="feature-item">
 											<span class="feature-icon">✓</span
@@ -2139,11 +2123,7 @@
 										</div>
 										<div class="subscription-stat">
 											<span class="subscription-stat-label">Image Credits</span>
-											<strong>1500 / month</strong>
-										</div>
-										<div class="subscription-stat">
-											<span class="subscription-stat-label">Nano-Banana</span>
-											<strong>Unlimited</strong>
+											<strong>1000 / month</strong>
 										</div>
 									</div>
 
@@ -2183,7 +2163,7 @@
 								<div class="subscription-faq-header">
 									<p class="subscription-faq-eyebrow">Need to know</p>
 									<h2 id="subscription-faq-title">Frequently asked questions</h2>
-									<p>Quick answers about premium models, Nano Banana, and standalone image usage.</p>
+									<p>Quick answers about premium models and standalone image usage.</p>
 								</div>
 
 								<div class="subscription-faq-grid">
@@ -2198,12 +2178,11 @@
 									</details>
 
 									<details class="subscription-faq-item">
-										<summary>What's the difference between Nano Banana and Image Credits?</summary>
+										<summary>How do Image Credits work?</summary>
 										<p>
-											Nano Banana is Gemini's chat-native image model inside the normal
-											conversation flow. On Pro, it has a daily allowance. On Pro Plus and Max, it
-											is unlimited. Image Credits are for the dedicated image generation and
-											editing models, and those are consumed per request.
+											Image Credits power Zodiac's dedicated image generation and editing models.
+											Each completed EDGE-routed image request consumes credits, while requests
+											using your own Google or OpenRouter API key do not.
 										</p>
 									</details>
 
@@ -2616,8 +2595,8 @@
 							>
 							<div>
 								<p>
-									<strong>Gemini 3 Pro Image (nano-banana pro)</strong> may require billing to be
-									enabled on the Google Cloud interface as Google doesn't offer that model for free.
+									<strong>Nano Banana Pro</strong> may require billing to be enabled on the Google
+									Cloud interface as Google doesn't offer that model for free.
 								</p>
 								<p>
 									If you don't have billing enabled but still wish to use these models, you may

--- a/src/index.html
+++ b/src/index.html
@@ -1831,9 +1831,16 @@
 
 				<div id="form-subscription" class="hidden" data-billing="yearly">
 					<div class="subscription-shell">
+						<button
+							type="button"
+							id="btn-close-subscription"
+							class="subscription-close-button btn-textual"
+							aria-label="Close plans"
+						>
+							<span class="material-symbols-outlined" aria-hidden="true">close</span>
+						</button>
 						<div class="subscription-header">
 							<p class="subscription-eyebrow">Premium Plans</p>
-							<h1>Zodiac, tailored to you.</h1>
 						</div>
 
 						<div class="subscription-toolbar" aria-label="Billing preview">
@@ -1853,8 +1860,7 @@
 									aria-pressed="true"
 								>
 									<span class="subscription-billing-label">Yearly</span>
-									<span class="subscription-billing-separator" aria-hidden="true">•</span>
-									<span class="subscription-billing-note">Up to 2 months off</span>
+									<span class="subscription-billing-note">2 months off</span>
 								</button>
 							</div>
 							<div class="subscription-trust-row" aria-hidden="true">
@@ -1872,7 +1878,6 @@
 								<div class="subscription-card-header">
 									<div class="subscription-plan-heading">
 										<div class="tier-badge tier-badge-free">Free</div>
-										<p class="subscription-plan-subtitle">Local-first</p>
 									</div>
 									<div class="subscription-plan-pill-row">
 										<span class="subscription-plan-pill">BYOK</span>
@@ -1925,7 +1930,6 @@
 								<div class="subscription-card-header">
 									<div class="subscription-plan-heading">
 										<div class="tier-badge tier-badge-pro">Pro</div>
-										<p class="subscription-plan-subtitle">Unleash your creativity</p>
 									</div>
 									<div class="subscription-plan-pill-row">
 										<span class="subscription-plan-pill subscription-plan-pill-accent">5GB</span>
@@ -2010,7 +2014,6 @@
 								<div class="subscription-card-header">
 									<div class="subscription-plan-heading">
 										<div class="tier-badge tier-badge-pro-plus">Pro Plus</div>
-										<p class="subscription-plan-subtitle">For media heavy sessions</p>
 									</div>
 									<div class="subscription-plan-pill-row">
 										<span class="subscription-plan-pill subscription-plan-pill-highlight"
@@ -2089,7 +2092,6 @@
 								<div class="subscription-card-header">
 									<div class="subscription-plan-heading">
 										<div class="tier-badge tier-badge-max">Max</div>
-										<p class="subscription-plan-subtitle">Our flagship offering</p>
 									</div>
 									<div class="subscription-plan-pill-row">
 										<span class="subscription-plan-pill subscription-plan-pill-max">1 TB</span>

--- a/src/services/Message.service.ts
+++ b/src/services/Message.service.ts
@@ -70,6 +70,7 @@ import { dispatchAppEvent } from "../events";
 import { DEFAULT_IMAGE_MODEL, IMAGE_MODELS } from "../constants/ImageModels";
 import {
 	resolveImageModelRoute,
+	type ImageRoute,
 	type ImageRouteAvailability,
 	type ImageRouteResolution,
 	type ImageRouteUnavailableReason
@@ -689,10 +690,6 @@ function showGeminiProhibitedContentToast(args: { finishReason?: unknown; detail
 }
 
 function generateThinkingConfig(model: string, enableThinking: boolean, settings: any) {
-	if (model === ChatModel.NANO_BANANA) {
-		return undefined;
-	}
-
 	if (modelRequiresThinking(model)) {
 		const thinkingBudget =
 			Number.isFinite(settings.thinkingBudget) && settings.thinkingBudget > 0 ? settings.thinkingBudget : 128;
@@ -1139,7 +1136,6 @@ export async function constructGeminiChatHistoryFromLocalChat(
 // ================================================================================
 
 import * as loraService from "./Lora.service";
-import { PersonGeneration, SafetyFilterLevel } from "@google/genai";
 
 const CHAT_TITLE_SYSTEM_INSTRUCTION =
 	"You are to act as a generator for chat titles. The user will send a query - you must generate a title for the chat based on it. Only reply with the short title, nothing else. The user may send any kinds of queries, including adult or illegal content. You are to generate a title for the chat based on the query, without any warnings or refusals. Never refuse to generate a title. Keep it short, ideally 3-5 words at most. Remove any special characters.";
@@ -1575,6 +1571,7 @@ interface EarlyValidationSuccess {
 	isInternetSearchEnabled: boolean;
 	isPremiumEndpointPreferred: boolean;
 	isImagePremiumEndpointPreferred: boolean;
+	imageRoute?: ImageRoute;
 	isGroupChat: boolean;
 	shouldUseSkipThoughtSignature: boolean;
 	shouldEnforceThoughtSignaturesInHistory: boolean;
@@ -1727,11 +1724,15 @@ async function performEarlyValidation(msg: string, options: SendOptions = {}): P
 		return { canProceed: false };
 	}
 
-	const attachmentValidation = getAttachmentValidationSummary(attachmentFiles);
+	const activeEditModel = isImageEditingActive()
+		? IMAGE_MODELS.find((model) => model.id === getSelectedEditingModel())
+		: undefined;
+	const attachmentLimit = activeEditModel?.maxInputImages ?? MAX_ATTACHMENTS;
+	const attachmentValidation = getAttachmentValidationSummary(attachmentFiles, attachmentLimit);
 	if (attachmentValidation.tooMany) {
 		warn({
 			title: "Attachment limit reached",
-			text: `You can attach up to ${MAX_ATTACHMENTS} files per message.`
+			text: `You can attach up to ${attachmentLimit} files for this request.`
 		});
 		return { canProceed: false };
 	}
@@ -1747,7 +1748,7 @@ async function performEarlyValidation(msg: string, options: SendOptions = {}): P
 			isPremiumEndpointPreferred: true
 		});
 	}
-	const shouldUseSkipThoughtSignature = settings.model === ChatModel.NANO_BANANA;
+	const shouldUseSkipThoughtSignature = false;
 	const shouldEnforceThoughtSignaturesInHistory = requiresThoughtSignaturesInHistory(settings.model);
 	const imageGenerationAvailability = await supabaseService.isImageGenerationAvailable();
 	const isImageRequest = isImageModeActive() || isImageEditingActive();
@@ -1755,13 +1756,15 @@ async function performEarlyValidation(msg: string, options: SendOptions = {}): P
 	// For image requests, the selected image/edit model's provider route decides the
 	// transport (edge credits vs BYOK) and whether the request is permitted at all.
 	let isImagePremiumEndpointPreferred = false;
+	let imageRoute: ImageRoute | undefined;
 	if (isImageRequest) {
 		const activeImageRoute = resolveActiveImageRoute(settings, imageGenerationAvailability.type === "all");
 		if (activeImageRoute && activeImageRoute.resolution.route === null) {
 			warnImageRouteUnavailable(activeImageRoute.resolution.reason, activeImageRoute.isEditing);
 			return { canProceed: false };
 		}
-		isImagePremiumEndpointPreferred = activeImageRoute?.resolution.route === "edge";
+		imageRoute = activeImageRoute?.resolution.route ?? undefined;
+		isImagePremiumEndpointPreferred = imageRoute === "edge";
 	}
 
 	const hasLocalApiKey = hasLocalApiKeyForModel(settings.model, settings);
@@ -1814,6 +1817,7 @@ async function performEarlyValidation(msg: string, options: SendOptions = {}): P
 		isInternetSearchEnabled,
 		isPremiumEndpointPreferred,
 		isImagePremiumEndpointPreferred,
+		imageRoute,
 		isGroupChat,
 		shouldUseSkipThoughtSignature,
 		shouldEnforceThoughtSignaturesInHistory
@@ -1839,6 +1843,7 @@ interface SendContext {
 	historyImageDataUri: string | null;
 	isPremiumEndpointPreferred: boolean;
 	isImagePremiumEndpointPreferred: boolean;
+	imageRoute?: ImageRoute;
 	shouldUseSkipThoughtSignature: boolean;
 	abortController: AbortController;
 	messageContent: Element;
@@ -1861,6 +1866,7 @@ async function buildSendContext(
 		isInternetSearchEnabled,
 		isPremiumEndpointPreferred,
 		isImagePremiumEndpointPreferred,
+		imageRoute,
 		shouldUseSkipThoughtSignature,
 		shouldEnforceThoughtSignaturesInHistory
 	} = validation;
@@ -1878,7 +1884,7 @@ async function buildSendContext(
 		responseMimeType: "text/plain",
 		tools: isInternetSearchEnabled ? [{ googleSearch: {} }] : undefined,
 		thinkingConfig: thinkingConfig,
-		imageConfig: settings.model === ChatModel.NANO_BANANA_PRO ? { imageSize: "4K" } : undefined
+		imageConfig: undefined
 	};
 
 	const currentChat = options.targetChatId
@@ -1963,6 +1969,7 @@ async function buildSendContext(
 		historyImageDataUri,
 		isPremiumEndpointPreferred,
 		isImagePremiumEndpointPreferred,
+		imageRoute,
 		shouldUseSkipThoughtSignature,
 		abortController,
 		messageContent: responseElement.querySelector(".message-text .message-text-content")!,
@@ -2532,100 +2539,48 @@ async function handleTextChatLocalSdk(ctx: SendContext, state: TextChatResponseS
 const IMAGE_GENERATION_SLUG = "handle-max-request-x";
 const IMAGE_EDITING_SLUG = "handle-edit-request-x";
 
-async function handleImageGeneration(ctx: SendContext): Promise<HTMLElement | undefined> {
-	const imageGenerationModel = ctx.settings.imageModel || DEFAULT_IMAGE_MODEL;
-	const payload = {
-		model: imageGenerationModel,
-		prompt: ctx.msg,
-		config: {
-			numberOfImages: 1,
-			outputMimeType: "image/jpeg",
-			personGeneration: PersonGeneration.ALLOW_ADULT,
-			aspectRatio: "1:1",
-			safetyFilterLevel: SafetyFilterLevel.BLOCK_LOW_AND_ABOVE
-		},
-		loras: loraService.getLoraState()
-	};
-
-	let b64: string;
-	let returnedMimeType: string;
-
-	if (ctx.isImagePremiumEndpointPreferred) {
-		const endpoint = `${SUPABASE_URL}/functions/v1/${IMAGE_GENERATION_SLUG}`;
-		const response = await fetch(endpoint, {
-			method: "POST",
-			headers: { ...(await getAuthHeaders()), "Content-Type": "application/json" },
-			body: JSON.stringify(payload),
-			signal: ctx.abortController?.signal
-		});
-
-		if (!response.ok) {
-			const errorData = await response.json();
-			setUserMessageRequestSlug(ctx.userMessage, errorData?.requestId);
-			await appendRequestSlugToStoredMessage({
-				chatId: ctx.chatId,
-				messageIndex: ctx.userIndex,
-				requestSlug: errorData?.requestId
-			});
-			const responseError = errorData.error;
-			danger({ text: responseError, title: "Image generation failed" });
-			const modelMessage = createImageGenerationErrorMessage(ctx.selectedPersonalityId, imageGenerationModel);
-			await updateChatMessage(ctx.chatId, ctx.modelIndex, modelMessage);
-			await finalizeResponseElement({
-				chatId: ctx.chatId,
-				messageIndex: ctx.modelIndex,
-				responseElement: ctx.responseElement,
-				message: modelMessage
-			});
-			endGeneration(ctx.chatId);
-			return ctx.userMessageElement;
-		}
-
-		const requestId = response.headers.get("X-Request-Id") ?? undefined;
-		setUserMessageRequestSlug(ctx.userMessage, requestId);
-		await appendRequestSlugToStoredMessage({
-			chatId: ctx.chatId,
-			messageIndex: ctx.userIndex,
-			requestSlug: requestId
-		});
-		const arrayBuf = await response.arrayBuffer();
-		b64 = await helpers.arrayBufferToBase64(arrayBuf);
-		returnedMimeType = response.headers.get("Content-Type") || "image/png";
-	} else {
-		const ai = ctx.ai;
-		if (!ai) {
-			throw new Error("Gemini client is not available for image generation.");
-		}
-
-		const response = await ai.models.generateImages(payload);
-		if (!response || !response.generatedImages || !response.generatedImages[0]?.image?.imageBytes) {
-			const extraMessage = response?.generatedImages?.[0]?.raiFilteredReason;
-			danger({ text: `${extraMessage ? "Reason: " + extraMessage : ""}`, title: "Image generation failed" });
-			const modelMessage = createImageGenerationErrorMessage(ctx.selectedPersonalityId, imageGenerationModel);
-			await updateChatMessage(ctx.chatId, ctx.modelIndex, modelMessage);
-			await finalizeResponseElement({
-				chatId: ctx.chatId,
-				messageIndex: ctx.modelIndex,
-				responseElement: ctx.responseElement,
-				message: modelMessage
-			});
-			endGeneration(ctx.chatId);
-			return ctx.userMessageElement;
-		}
-		b64 = response.generatedImages[0].image.imageBytes;
-		returnedMimeType = response.generatedImages[0].image.mimeType || "image/png";
+function getImageModel(modelId: string, capability: "generation" | "editing") {
+	const model = IMAGE_MODELS.find((candidate) => candidate.id === modelId && candidate[capability]);
+	if (!model) {
+		throw new Error(`Selected image ${capability} model is unavailable.`);
 	}
+	return model;
+}
 
-	const modelMessage: Message = {
-		role: "model",
-		parts: [{ text: "Here's the image you requested~", thoughtSignature: SKIP_THOUGHT_SIGNATURE_VALIDATOR }],
-		personalityid: ctx.selectedPersonalityId,
-		generatedImages: [
-			{ mimeType: returnedMimeType, base64: b64, thoughtSignature: SKIP_THOUGHT_SIGNATURE_VALIDATOR }
-		],
-		originModel: imageGenerationModel
-	};
+function getGeminiImageApiKey(settings: ReturnType<typeof settingsService.getSettings>): string {
+	return (settings.geminiApiKey || settings.apiKey || "").trim();
+}
 
+function dataUriToInlineData(dataUri: string): { mimeType: string; data: string } {
+	const match = dataUri.match(/^data:([^;]+);base64,(.+)$/);
+	if (!match) {
+		throw new Error("Image data is not a valid base64 data URI.");
+	}
+	return { mimeType: match[1], data: match[2] };
+}
+
+async function saveImageRequestId(ctx: SendContext, requestId?: string): Promise<void> {
+	setUserMessageRequestSlug(ctx.userMessage, requestId);
+	await appendRequestSlugToStoredMessage({
+		chatId: ctx.chatId,
+		messageIndex: ctx.userIndex,
+		requestSlug: requestId
+	});
+}
+
+async function failImageRequest(
+	ctx: SendContext,
+	originModel: string,
+	kind: "generation" | "editing",
+	error: unknown
+): Promise<HTMLElement> {
+	const title = kind === "generation" ? "Image generation failed" : "Image editing failed";
+	const message = error instanceof Error ? error.message : "An unexpected error occurred.";
+	danger({ title, text: message });
+	const modelMessage =
+		kind === "generation"
+			? createImageGenerationErrorMessage(ctx.selectedPersonalityId, originModel)
+			: createImageEditingErrorMessage(ctx.selectedPersonalityId, originModel);
 	await updateChatMessage(ctx.chatId, ctx.modelIndex, modelMessage);
 	await finalizeResponseElement({
 		chatId: ctx.chatId,
@@ -2633,9 +2588,159 @@ async function handleImageGeneration(ctx: SendContext): Promise<HTMLElement | un
 		responseElement: ctx.responseElement,
 		message: modelMessage
 	});
-	void supabaseService.refreshImageGenerationRecord();
 	endGeneration(ctx.chatId);
 	return ctx.userMessageElement;
+}
+
+async function completeImageRequest(args: {
+	ctx: SendContext;
+	originModel: string;
+	text: string;
+	image: { base64: string; mimeType: string };
+	refreshCredits: boolean;
+}): Promise<HTMLElement> {
+	const modelMessage: Message = {
+		role: "model",
+		parts: [{ text: args.text, thoughtSignature: SKIP_THOUGHT_SIGNATURE_VALIDATOR }],
+		personalityid: args.ctx.selectedPersonalityId,
+		generatedImages: [
+			{
+				mimeType: args.image.mimeType,
+				base64: args.image.base64,
+				thoughtSignature: SKIP_THOUGHT_SIGNATURE_VALIDATOR
+			}
+		],
+		originModel: args.originModel
+	};
+	await updateChatMessage(args.ctx.chatId, args.ctx.modelIndex, modelMessage);
+	await finalizeResponseElement({
+		chatId: args.ctx.chatId,
+		messageIndex: args.ctx.modelIndex,
+		responseElement: args.ctx.responseElement,
+		message: modelMessage
+	});
+	if (args.refreshCredits) {
+		void supabaseService.refreshImageGenerationRecord();
+	}
+	endGeneration(args.ctx.chatId);
+	return args.ctx.userMessageElement;
+}
+
+async function requestGoogleImage(args: {
+	apiKey: string;
+	model: string;
+	prompt: string;
+	images?: string[];
+}): Promise<{ base64: string; mimeType: string }> {
+	const ai = new GoogleGenAI({ apiKey: args.apiKey });
+	const parts = [
+		...(args.images ?? []).map((image) => ({ inlineData: dataUriToInlineData(image) })),
+		{ text: args.prompt }
+	];
+	const response = await ai.models.generateContent({
+		model: args.model,
+		contents: [{ role: "user", parts }],
+		config: { responseModalities: ["IMAGE"] }
+	} as any);
+	const result = await processGeminiLocalSdkResponse({
+		response,
+		process: {
+			includeThoughts: false,
+			useSkipThoughtSignature: true,
+			skipThoughtSignatureValidator: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+			abortMode: "throw",
+			throwOnBlocked: false
+		}
+	});
+	const image = result.images[0];
+	if (!image?.base64) {
+		throw new Error("Google did not return an image.");
+	}
+	return { base64: image.base64, mimeType: image.mimeType };
+}
+
+async function requestOpenRouterImage(args: {
+	apiKey: string;
+	model: string;
+	prompt: string;
+	images?: string[];
+	signal?: AbortSignal;
+}): Promise<{ base64: string; mimeType: string }> {
+	const content = [
+		...(args.images ?? []).map((image) => ({ type: "image_url" as const, image_url: { url: image } })),
+		{ type: "text" as const, text: args.prompt }
+	];
+	const result = await requestOpenRouterCompletion({
+		apiKey: args.apiKey,
+		request: {
+			model: args.model,
+			messages: [{ role: "user", content }],
+			stream: false,
+			modalities: ["image"]
+		},
+		signal: args.signal
+	});
+	const image = result.images?.[0];
+	if (!image?.base64) {
+		throw new Error("OpenRouter did not return an image.");
+	}
+	return { base64: image.base64, mimeType: image.mimeType };
+}
+
+async function handleImageGeneration(ctx: SendContext): Promise<HTMLElement | undefined> {
+	const imageGenerationModel = ctx.settings.imageModel || DEFAULT_IMAGE_MODEL;
+	try {
+		const model = getImageModel(imageGenerationModel, "generation");
+		let image: { base64: string; mimeType: string };
+		if (ctx.imageRoute === "edge") {
+			const response = await fetch(`${SUPABASE_URL}/functions/v1/${IMAGE_GENERATION_SLUG}`, {
+				method: "POST",
+				headers: { ...(await getAuthHeaders()), "Content-Type": "application/json" },
+				body: JSON.stringify({
+					prompt: ctx.msg,
+					model: model.id,
+					loras: loraService.getLoraState(),
+					negative_prompt: ""
+				}),
+				signal: ctx.abortController.signal
+			});
+			if (!response.ok) {
+				const errorData = await response.json().catch(() => ({}));
+				await saveImageRequestId(ctx, errorData?.requestId);
+				throw new Error(errorData?.error || `Image endpoint error: ${response.status}`);
+			}
+			await saveImageRequestId(ctx, response.headers.get("X-Request-Id") ?? undefined);
+			image = {
+				base64: await helpers.arrayBufferToBase64(await response.arrayBuffer()),
+				mimeType: response.headers.get("Content-Type") || "image/png"
+			};
+		} else if (ctx.imageRoute === "google") {
+			image = await requestGoogleImage({
+				apiKey: getGeminiImageApiKey(ctx.settings),
+				model: model.id,
+				prompt: ctx.msg
+			});
+		} else if (ctx.imageRoute === "openrouter") {
+			image = await requestOpenRouterImage({
+				apiKey: ctx.settings.openRouterApiKey.trim(),
+				model: model.openRouterModelId || model.id,
+				prompt: ctx.msg,
+				signal: ctx.abortController.signal
+			});
+		} else {
+			throw new Error("No image route is available.");
+		}
+
+		return await completeImageRequest({
+			ctx,
+			originModel: model.id,
+			text: "Here's the image you requested~",
+			image,
+			refreshCredits: ctx.imageRoute === "edge"
+		});
+	} catch (error) {
+		return await failImageRequest(ctx, imageGenerationModel, "generation", error);
+	}
 }
 
 // ================================================================================
@@ -2668,8 +2773,8 @@ async function handleImageEditing(ctx: SendContext): Promise<HTMLElement | undef
 	}
 
 	const editingModel = getSelectedEditingModel();
-
-	const maxImages = IMAGE_MODELS.find((model) => model.id === editingModel)?.maxInputImages;
+	const model = getImageModel(editingModel, "editing");
+	const maxImages = model.maxInputImages;
 	if (maxImages && imagesToEdit.length > maxImages) {
 		const modelName = editingModel.charAt(0).toUpperCase() + editingModel.slice(1);
 		warn({
@@ -2680,92 +2785,51 @@ async function handleImageEditing(ctx: SendContext): Promise<HTMLElement | undef
 	}
 
 	try {
-		const endpoint = `${SUPABASE_URL}/functions/v1/${IMAGE_EDITING_SLUG}`;
-		const response = await fetch(endpoint, {
-			method: "POST",
-			headers: { ...(await getAuthHeaders()), "Content-Type": "application/json" },
-			body: JSON.stringify({ images: imagesToEdit, prompt: ctx.msg, editingModel }),
-			signal: ctx.abortController?.signal
-		});
-
-		if (!response.ok) {
-			const errorData = await response.json();
-			setUserMessageRequestSlug(ctx.userMessage, errorData?.requestId);
-			await appendRequestSlugToStoredMessage({
-				chatId: ctx.chatId,
-				messageIndex: ctx.userIndex,
-				requestSlug: errorData?.requestId
+		let image: { base64: string; mimeType: string };
+		if (ctx.imageRoute === "edge") {
+			const response = await fetch(`${SUPABASE_URL}/functions/v1/${IMAGE_EDITING_SLUG}`, {
+				method: "POST",
+				headers: { ...(await getAuthHeaders()), "Content-Type": "application/json" },
+				body: JSON.stringify({ images: imagesToEdit, prompt: ctx.msg, editingModel: model.id }),
+				signal: ctx.abortController.signal
 			});
-			danger({ text: errorData.error || "Unknown error", title: "Image editing failed" });
-			const modelMessage = createImageEditingErrorMessage(ctx.selectedPersonalityId, editingModel);
-			await updateChatMessage(ctx.chatId, ctx.modelIndex, modelMessage);
-			await finalizeResponseElement({
-				chatId: ctx.chatId,
-				messageIndex: ctx.modelIndex,
-				responseElement: ctx.responseElement,
-				message: modelMessage
+			const result = await response.json().catch(() => ({}));
+			await saveImageRequestId(ctx, result?.requestId ?? response.headers.get("X-Request-Id") ?? undefined);
+			if (!response.ok) {
+				throw new Error(result?.error || `Image endpoint error: ${response.status}`);
+			}
+			if (!result?.image) {
+				throw new Error("No image data returned from server.");
+			}
+			image = { base64: result.image, mimeType: result.mimeType || "image/png" };
+		} else if (ctx.imageRoute === "google") {
+			image = await requestGoogleImage({
+				apiKey: getGeminiImageApiKey(ctx.settings),
+				model: model.id,
+				prompt: ctx.msg,
+				images: imagesToEdit
 			});
-			endGeneration(ctx.chatId);
-			return ctx.userMessageElement;
+		} else if (ctx.imageRoute === "openrouter") {
+			image = await requestOpenRouterImage({
+				apiKey: ctx.settings.openRouterApiKey.trim(),
+				model: model.openRouterModelId || model.id,
+				prompt: ctx.msg,
+				images: imagesToEdit,
+				signal: ctx.abortController.signal
+			});
+		} else {
+			throw new Error("No image route is available.");
 		}
 
-		const result = await response.json();
-		setUserMessageRequestSlug(ctx.userMessage, result?.requestId);
-		await appendRequestSlugToStoredMessage({
-			chatId: ctx.chatId,
-			messageIndex: ctx.userIndex,
-			requestSlug: result?.requestId
+		return await completeImageRequest({
+			ctx,
+			originModel: model.id,
+			text: "Here's your edited image~",
+			image,
+			refreshCredits: ctx.imageRoute === "edge"
 		});
-		const editedImageBase64 = result.image;
-		const mimeType = result.mimeType || "image/png";
-
-		if (!editedImageBase64) {
-			danger({ title: "Image editing failed", text: "No image data returned from server." });
-			const modelMessage = createImageEditingErrorMessage(ctx.selectedPersonalityId, editingModel);
-			await updateChatMessage(ctx.chatId, ctx.modelIndex, modelMessage);
-			await finalizeResponseElement({
-				chatId: ctx.chatId,
-				messageIndex: ctx.modelIndex,
-				responseElement: ctx.responseElement,
-				message: modelMessage
-			});
-			endGeneration(ctx.chatId);
-			return ctx.userMessageElement;
-		}
-
-		const modelMessage: Message = {
-			role: "model",
-			parts: [{ text: "Here's your edited image~", thoughtSignature: SKIP_THOUGHT_SIGNATURE_VALIDATOR }],
-			personalityid: ctx.selectedPersonalityId,
-			generatedImages: [
-				{ mimeType, base64: editedImageBase64, thoughtSignature: SKIP_THOUGHT_SIGNATURE_VALIDATOR }
-			],
-			originModel: editingModel
-		};
-
-		await updateChatMessage(ctx.chatId, ctx.modelIndex, modelMessage);
-		await finalizeResponseElement({
-			chatId: ctx.chatId,
-			messageIndex: ctx.modelIndex,
-			responseElement: ctx.responseElement,
-			message: modelMessage
-		});
-		void supabaseService.refreshImageGenerationRecord();
-		endGeneration(ctx.chatId);
-		return ctx.userMessageElement;
-	} catch (error: any) {
-		console.error("Image editing error:", error);
-		danger({ title: "Image editing failed", text: error.message || "An unexpected error occurred" });
-		const modelMessage = createImageEditingErrorMessage(ctx.selectedPersonalityId, editingModel);
-		await updateChatMessage(ctx.chatId, ctx.modelIndex, modelMessage);
-		await finalizeResponseElement({
-			chatId: ctx.chatId,
-			messageIndex: ctx.modelIndex,
-			responseElement: ctx.responseElement,
-			message: modelMessage
-		});
-		endGeneration(ctx.chatId);
-		return ctx.userMessageElement;
+	} catch (error) {
+		return await failImageRequest(ctx, editingModel, "editing", error);
 	}
 }
 

--- a/src/services/Supabase.service.ts
+++ b/src/services/Supabase.service.ts
@@ -9,25 +9,17 @@ import type {
 	UserSubscription,
 	ImageGenerationRecord,
 	MarketplacePersonaInfo,
-	MegaCreditsRecord,
-	NanoBananaDailyUsageRecord
+	MegaCreditsRecord
 } from "../types/Supabase";
 import { dispatchAppEvent } from "../events";
 
-export type {
-	SubscriptionTier,
-	UserSubscription,
-	ImageGenerationRecord,
-	MarketplacePersonaInfo,
-	MegaCreditsRecord,
-	NanoBananaDailyUsageRecord
-};
+export type { SubscriptionTier, UserSubscription, ImageGenerationRecord, MarketplacePersonaInfo, MegaCreditsRecord };
 
 let userCache: SupabaseUser | null = null;
 let hydratedSessionUserId: string | null = null;
 
 export const SUPABASE_URL = "https://hglcltvwunzynnzduauy.supabase.co";
-export const PRO_REQUEST_FUNCTION_NAME = "handle-pro-request";
+export const PRO_REQUEST_FUNCTION_NAME = "handle-pro-request-x";
 export const PRO_REQUEST_ENDPOINT = `${SUPABASE_URL}/functions/v1/${PRO_REQUEST_FUNCTION_NAME}`;
 const SUPABASE_ANON_KEY =
 	"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhnbGNsdHZ3dW56eW5uemR1YXV5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM3MTIzOTIsImV4cCI6MjA2OTI4ODM5Mn0.q4VZu-0vEZVdjSXAhlSogB9ihfPVwero0S4UFVCvMDQ";
@@ -435,22 +427,6 @@ export async function getMegaCreditsRecord(): Promise<MegaCreditsRecord | null> 
 		.maybeSingle();
 	if (error) {
 		console.error("Get mega credits record error:", error.message);
-		return null;
-	}
-	return data;
-}
-
-export async function getNanoBananaDailyUsageRecord(): Promise<NanoBananaDailyUsageRecord | null> {
-	const currentUser = await getCurrentUser();
-	if (!currentUser) return null;
-	const { data, error } = await supabase
-		.from("nano_banana_daily_usage")
-		.select("user_id, usage_date, usage_count")
-		.eq("user_id", currentUser.id)
-		.limit(1)
-		.maybeSingle();
-	if (error) {
-		console.error("Get nano banana daily usage record error:", error.message);
 		return null;
 	}
 	return data;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1267,8 +1267,6 @@ form {
 
 	.subscription-card-collapsed .popular-badge {
 		top: -8px;
-		padding: 0.35rem 1rem;
-		font-size: 0.75rem;
 	}
 
 	/* Expanded state */
@@ -1903,7 +1901,8 @@ form {
 	left: auto;
 	right: 1rem;
 	transform: none;
-	padding: 0.45rem 0.75rem;
+	padding: 0.35rem 1rem;
+	font-size: 0.75rem;
 	border-radius: 999px;
 	background: linear-gradient(135deg, #0f766e, #14b8a6);
 	box-shadow: 0 10px 24px rgba(15, 118, 110, 0.24);
@@ -2316,7 +2315,7 @@ form {
 
 #form-subscription .subscription-faq-grid {
 	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
+	grid-template-columns: 1fr;
 	gap: 0.85rem;
 }
 
@@ -2377,10 +2376,6 @@ form {
 	#form-subscription .subscription-grid-showcase {
 		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
-
-	#form-subscription .subscription-faq-grid {
-		grid-template-columns: 1fr;
-	}
 }
 
 @media (max-width: 1032px) {
@@ -2429,10 +2424,6 @@ form {
 @media (max-width: 700px) {
 	#form-subscription .subscription-header h1 {
 		max-width: 100%;
-	}
-
-	#form-subscription .subscription-stat-grid {
-		grid-template-columns: 1fr;
 	}
 
 	#form-subscription .subscription-trust-row {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2379,7 +2379,7 @@ form {
 	}
 
 	#form-subscription .subscription-grid-showcase {
-		grid-template-columns: 1fr;
+		grid-template-columns: minmax(0, 1fr);
 		gap: 1rem;
 	}
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1024,7 +1024,9 @@ form {
 	border-radius: 1.5rem;
 	padding: 2rem;
 	box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
-	transition: all 0.3s ease;
+	transition:
+		box-shadow 0.3s ease,
+		border-color 0.3s ease;
 	position: relative;
 	border: 2px solid transparent;
 	display: flex;
@@ -1033,7 +1035,6 @@ form {
 }
 
 .subscription-card:hover {
-	transform: translateY(-8px);
 	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
 }
 
@@ -1233,7 +1234,7 @@ form {
 
 	/* Collapsed state */
 	.subscription-card-collapsed {
-		padding: 1rem 1rem 0.7rem !important;
+		padding: 1.5rem !important;
 	}
 
 	.subscription-card-collapsed .subscription-card-body {
@@ -1268,11 +1269,6 @@ form {
 		top: -8px;
 		padding: 0.35rem 1rem;
 		font-size: 0.75rem;
-	}
-
-	.subscription-card-collapsed:hover {
-		transform: translateY(-2px);
-		box-shadow: 0 8px 25px rgba(0, 0, 0, 0.12);
 	}
 
 	/* Expanded state */
@@ -1446,7 +1442,6 @@ form {
 }
 
 .subscription-card:hover {
-	transform: translateY(-6px);
 	box-shadow: 0 22px 70px rgba(0, 0, 0, 0.18);
 }
 
@@ -1538,6 +1533,40 @@ form {
 	box-shadow: var(--subscription-card-shadow);
 }
 
+#form-subscription .subscription-close-button {
+	display: none;
+}
+
+#overlay:has(> .overlay-content > #form-subscription:not(.hidden)) > .header {
+	display: none;
+}
+
+#overlay > .overlay-content > #form-subscription .subscription-close-button {
+	position: absolute;
+	top: 1rem;
+	right: 1rem;
+	z-index: 3;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.5rem;
+	height: 2.5rem;
+	padding: 0;
+	border: 1px solid rgba(148, 163, 184, 0.22);
+	border-radius: 0.75rem;
+	color: inherit;
+	background: rgba(15, 23, 42, 0.12);
+}
+
+#overlay > .overlay-content > #form-subscription .subscription-close-button:hover {
+	background: rgba(148, 163, 184, 0.18);
+}
+
+#overlay > .overlay-content > #form-subscription .subscription-close-button:focus-visible {
+	outline: 2px solid currentColor;
+	outline-offset: 2px;
+}
+
 #form-subscription .subscription-shell::before {
 	content: "";
 	position: absolute;
@@ -1578,18 +1607,9 @@ form {
 	color: inherit;
 	background: none;
 	-webkit-text-fill-color: currentColor;
-	font-size: clamp(2.5rem, 5vw, 4.35rem);
+	font-size: 3rem;
 	line-height: 0.95;
 	letter-spacing: -0.045em;
-}
-
-#form-subscription .subscription-header p:last-child {
-	max-width: 48rem;
-	margin: 0;
-	color: inherit;
-	opacity: 0.78;
-	font-size: 1.02rem;
-	line-height: 1.65;
 }
 
 #form-subscription .subscription-toolbar {
@@ -1608,12 +1628,14 @@ form {
 :is(#form-subscription, #onboarding-plan-selection) .subscription-billing-toggle {
 	display: inline-flex;
 	align-items: center;
-	gap: 0.55rem;
-	flex-wrap: wrap;
+	gap: 0.3rem;
+	padding: 0.25rem;
+	border-radius: 0.75rem;
+	border: 1px solid rgba(148, 163, 184, 0.22);
+	background: rgba(15, 23, 42, 0.12);
 }
 
-:is(#form-subscription, #onboarding-plan-selection) .subscription-billing-option,
-:is(#form-subscription, #onboarding-plan-selection) .subscription-plan-pill {
+:is(#form-subscription, #onboarding-plan-selection) .subscription-billing-option {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -1623,6 +1645,16 @@ form {
 	font-size: 0.78rem;
 	font-weight: 700;
 	letter-spacing: 0.04em;
+}
+
+:is(#form-subscription, #onboarding-plan-selection) .subscription-plan-pill {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0.3rem 0.5rem;
+	border-radius: 999px;
+	font-size: 0.65rem;
+	font-weight: 700;
 }
 
 :is(#form-subscription, #onboarding-plan-selection) .subscription-billing-option {
@@ -1635,33 +1667,15 @@ form {
 	gap: 0.35rem;
 	color: inherit;
 	font-family: inherit;
-	border: 1px solid rgba(148, 163, 184, 0.22);
+	border-radius: 0.5rem;
 	transition:
 		background-color 0.2s ease,
-		border-color 0.2s ease,
-		box-shadow 0.2s ease,
 		color 0.2s ease;
-	background: rgba(255, 255, 255, 0.08);
-}
-
-:is(#form-subscription, #onboarding-plan-selection) .subscription-billing-label {
-	line-height: 1.1;
-}
-
-:is(#form-subscription, #onboarding-plan-selection) .subscription-billing-note {
-	font-size: 0.7rem;
-	line-height: 1;
-	letter-spacing: 0.02em;
-	opacity: 0.82;
-}
-
-:is(#form-subscription, #onboarding-plan-selection) .subscription-billing-separator {
-	font-size: 0.8rem;
-	opacity: 0.6;
+	background: transparent;
 }
 
 :is(#form-subscription, #onboarding-plan-selection) .subscription-billing-option:hover {
-	background: rgba(255, 255, 255, 0.14);
+	background: rgba(255, 255, 255, 0.08);
 }
 
 :is(#form-subscription, #onboarding-plan-selection) .subscription-billing-option-active:hover,
@@ -1675,7 +1689,20 @@ form {
 }
 
 :is(#form-subscription, #onboarding-plan-selection) .subscription-billing-option[aria-pressed="true"] {
-	color: inherit;
+	color: #f8fafc;
+}
+
+:is(#form-subscription, #onboarding-plan-selection) .subscription-billing-label {
+	line-height: 1.1;
+}
+
+:is(#form-subscription, #onboarding-plan-selection) .subscription-billing-note {
+	font-size: 0.6rem;
+
+	line-height: 1;
+	opacity: 0.8;
+	/* reduce spacing between characters */
+	letter-spacing: -0.02em;
 }
 
 :is(#form-subscription, #onboarding-plan-selection) .billing-only-yearly {
@@ -1693,8 +1720,6 @@ form {
 :is(#form-subscription, #onboarding-plan-selection) .subscription-billing-option-active {
 	background: linear-gradient(135deg, #0f766e, #0369a1);
 	color: #f8fafc;
-	border-color: rgba(14, 116, 144, 0.55);
-	box-shadow: 0 10px 24px rgba(3, 105, 161, 0.28);
 }
 
 #form-subscription .subscription-trust-row {
@@ -1741,7 +1766,6 @@ form {
 	box-shadow: 0 18px 45px rgba(15, 23, 42, 0.16);
 	backdrop-filter: blur(14px);
 	transition:
-		transform 0.28s ease,
 		box-shadow 0.28s ease,
 		border-color 0.28s ease,
 		background-color 0.28s ease;
@@ -1763,22 +1787,18 @@ form {
 	inset: 0;
 	border-radius: inherit;
 	pointer-events: none;
-	transition:
-		opacity 0.32s ease,
-		transform 0.42s ease;
+	transition: opacity 0.32s ease;
 }
 
 #form-subscription .subscription-plan::before {
 	background: var(--subscription-plan-hover-overlay);
 	opacity: 0;
-	transform: scale(0.985);
 	z-index: 0;
 }
 
 #form-subscription .subscription-plan::after {
 	background: var(--subscription-plan-facet-overlay);
 	opacity: 0;
-	transform: scale(1.015);
 	z-index: 0;
 }
 
@@ -1788,19 +1808,16 @@ form {
 }
 
 #form-subscription .subscription-plan:hover {
-	transform: translateY(-6px);
 	border-color: var(--subscription-plan-hover-border);
 	box-shadow: var(--subscription-plan-hover-shadow);
 }
 
 #form-subscription .subscription-plan:hover::before {
 	opacity: var(--subscription-plan-hover-overlay-opacity);
-	transform: scale(1);
 }
 
 #form-subscription .subscription-plan:hover::after {
 	opacity: var(--subscription-plan-facet-opacity);
-	transform: scale(1);
 }
 
 #form-subscription .subscription-card-popular {
@@ -1947,7 +1964,7 @@ form {
 #form-subscription .subscription-plan-pill-row {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 0.5rem;
+	gap: 0.3rem;
 }
 
 #form-subscription .subscription-plan-pill {
@@ -2055,7 +2072,7 @@ form {
 
 #form-subscription .subscription-stat-grid {
 	display: grid;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
+	grid-template-columns: repeat(2, minmax(0, 1fr));
 	width: 100%;
 	gap: 0.65rem;
 }
@@ -2065,7 +2082,6 @@ form {
 	flex-direction: column;
 	justify-content: space-between;
 	gap: 0.5rem;
-	min-height: 6.25rem;
 	padding: 0.9rem 0.85rem;
 	border-radius: 1rem;
 	background: rgba(255, 255, 255, 0.06);
@@ -2388,7 +2404,7 @@ form {
 	}
 
 	#form-subscription .subscription-plan {
-		padding: 1rem;
+		padding: 1.5rem;
 	}
 
 	#form-subscription .subscription-card-header {
@@ -2405,14 +2421,14 @@ form {
 	}
 
 	#form-subscription .subscription-card-body {
-		width: calc(100% + 2rem);
-		margin-inline: -1rem;
+		width: calc(100% + 3rem);
+		margin-inline: -1.5rem;
 	}
 }
 
 @media (max-width: 700px) {
 	#form-subscription .subscription-header h1 {
-		max-width: 10ch;
+		max-width: 100%;
 	}
 
 	#form-subscription .subscription-stat-grid {

--- a/src/types/ImageModels.ts
+++ b/src/types/ImageModels.ts
@@ -7,7 +7,11 @@ export enum ImageModelId {
 	SEEDREAM_5_0_PRO = "seedream-5-0-pro",
 	SEEDREAM_4_5 = "seedream-4-5",
 	QWEN_2_0_PRO = "qwen-2-0-pro",
-	QWEN_2_0 = "qwen-2-0"
+	QWEN_2_0 = "qwen-2-0",
+	GEMINI_2_5_FLASH_IMAGE = "gemini-2.5-flash-image",
+	GEMINI_3_PRO_IMAGE_PREVIEW = "gemini-3-pro-image-preview",
+	GEMINI_3_1_FLASH_IMAGE_PREVIEW = "gemini-3.1-flash-image-preview",
+	GROK_IMAGINE_IMAGE_QUALITY = "grok-imagine-image-quality"
 }
 
 export enum ImageModelProvider {
@@ -38,4 +42,6 @@ export interface ImageModelDefinition {
 	/** Absent means the model does not support LoRAs (e.g. provider-hosted API models). */
 	loraArchitecture?: LoraArchitecture;
 	maxInputImages?: number;
+	/** OpenRouter uses a provider-prefixed model ID for some Google image models. */
+	openRouterModelId?: string;
 }

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -62,7 +62,7 @@ export const DEFAULT_OPENROUTER_NARRATOR_MODEL = DEFAULT_OPENROUTER_CHAT_MODEL;
 export const DEFAULT_OPENROUTER_TITLE_MODEL = "z-ai/glm-5";
 const UI_DISABLED_CHAT_MODELS = new Set(["openai/gpt-5.4-pro"]);
 
-export function requiresThoughtSignaturesInHistory(model: string): boolean {
+export function requiresThoughtSignaturesInHistory(_model: string): boolean {
 	return false;
 }
 

--- a/src/types/Models.ts
+++ b/src/types/Models.ts
@@ -13,9 +13,6 @@ export enum ChatModel {
 	FLASH = "gemini-3.5-flash",
 	FLASH_3_PREV = "gemini-3-flash-preview",
 	FLASH_LITE = "gemini-3.1-flash-lite",
-	NANO_BANANA = "gemini-2.5-flash-image",
-	NANO_BANANA_PRO = "gemini-3-pro-image-preview",
-	NANO_BANANA_2 = "gemini-3.1-flash-image-preview",
 	PRO_2_5 = "gemini-2.5-pro",
 	FLASH_2_5 = "gemini-2.5-flash",
 	FLASH_LITE_2_5 = "gemini-2.5-flash-lite"
@@ -28,10 +25,7 @@ const GEMINI_TO_OPENROUTER_CHAT_MODEL_IDS = new Map<string, string>([
 	[ChatModel.FLASH_2_5, "google/gemini-2.5-flash"],
 	[ChatModel.FLASH_LITE_2_5, "google/gemini-2.5-flash-lite"],
 	[ChatModel.PRO, "google/gemini-3.1-pro-preview"],
-	[ChatModel.PRO_2_5, "google/gemini-2.5-pro"],
-	[ChatModel.NANO_BANANA, "google/gemini-2.5-flash-image"],
-	[ChatModel.NANO_BANANA_PRO, "google/gemini-3-pro-image-preview"],
-	[ChatModel.NANO_BANANA_2, "google/gemini-3.1-flash-image-preview"]
+	[ChatModel.PRO_2_5, "google/gemini-2.5-pro"]
 ]);
 
 export type ModelProvider = "gemini" | "openrouter";
@@ -69,7 +63,7 @@ export const DEFAULT_OPENROUTER_TITLE_MODEL = "z-ai/glm-5";
 const UI_DISABLED_CHAT_MODELS = new Set(["openai/gpt-5.4-pro"]);
 
 export function requiresThoughtSignaturesInHistory(model: string): boolean {
-	return model === ChatModel.NANO_BANANA_PRO || model === ChatModel.NANO_BANANA_2;
+	return false;
 }
 
 export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
@@ -171,46 +165,6 @@ export const GEMINI_CHAT_MODELS: ChatModelDefinition[] = [
 		supportsImageInput: false,
 		supportsFileInput: true,
 		supportsImageOutput: false
-	},
-	{
-		id: ChatModel.NANO_BANANA,
-		label: "Gemini 2.5 Flash Image (Nano Banana)",
-		provider: "gemini",
-		localOnly: true,
-		mega: false,
-		modelPickerGroup: "Flash",
-		supportsThinking: true,
-		supportsTemperature: true,
-		supportsImageInput: true,
-		supportsFileInput: true,
-		supportsImageOutput: true
-	},
-	{
-		id: ChatModel.NANO_BANANA_PRO,
-		label: "Gemini 3.0 Pro Image (Nano Banana Pro)",
-		provider: "gemini",
-		localOnly: true,
-		mega: false,
-		modelPickerGroup: "Pro",
-		supportsThinking: true,
-		requiresThinking: true,
-		supportsTemperature: true,
-		supportsImageInput: true,
-		supportsFileInput: true,
-		supportsImageOutput: true
-	},
-	{
-		id: ChatModel.NANO_BANANA_2,
-		label: "Gemini 3.1 Flash Image (Nano Banana 2)",
-		provider: "gemini",
-		localOnly: true,
-		mega: false,
-		modelPickerGroup: "Flash",
-		supportsThinking: true,
-		supportsTemperature: true,
-		supportsImageInput: true,
-		supportsFileInput: true,
-		supportsImageOutput: true
 	}
 ];
 
@@ -236,9 +190,6 @@ export const OPENROUTER_CHAT_MODELS: ChatModelDefinition[] = [
 	openRouterGeminiVariant(ChatModel.FLASH_LITE_2_5, "google/gemini-2.5-flash-lite"),
 	openRouterGeminiVariant(ChatModel.PRO, "google/gemini-3.1-pro-preview"),
 	openRouterGeminiVariant(ChatModel.PRO_2_5, "google/gemini-2.5-pro"),
-	openRouterGeminiVariant(ChatModel.NANO_BANANA, "google/gemini-2.5-flash-image"),
-	openRouterGeminiVariant(ChatModel.NANO_BANANA_PRO, "google/gemini-3-pro-image-preview"),
-	openRouterGeminiVariant(ChatModel.NANO_BANANA_2, "google/gemini-3.1-flash-image-preview"),
 	{
 		id: "openai/gpt-5.4",
 		label: "GPT-5.4",
@@ -398,19 +349,6 @@ export const OPENROUTER_CHAT_MODELS: ChatModelDefinition[] = [
 		supportsImageOutput: false
 	},
 	{
-		id: "x-ai/grok-imagine-image-quality",
-		label: "Grok Imagine Image Quality",
-		provider: "openrouter",
-		mega: false,
-		supportsThinking: false,
-		supportsTemperature: true,
-		supportsImageInput: true,
-		supportsFileInput: false,
-		supportsImageOutput: true,
-		outputModalities: ["image"],
-		consumesImageCredits: true
-	},
-	{
 		id: "google/gemma-4-31b-it",
 		label: "Gemma 4 31B",
 		provider: "openrouter",
@@ -558,6 +496,17 @@ export const OPENROUTER_CHAT_MODELS: ChatModelDefinition[] = [
 export const CHAT_MODELS: ChatModelDefinition[] = [...GEMINI_CHAT_MODELS, ...OPENROUTER_CHAT_MODELS];
 
 const chatModelMap = new Map(CHAT_MODELS.map((model) => [model.id, model]));
+const legacyOpenRouterImageModelIds = new Set([
+	"google/gemini-2.5-flash-image",
+	"google/gemini-3-pro-image-preview",
+	"google/gemini-3.1-flash-image-preview",
+	"x-ai/grok-imagine-image-quality"
+]);
+const legacyOpenRouterImageModelIdToImageModelId = new Map([
+	["google/gemini-2.5-flash-image", "gemini-2.5-flash-image"],
+	["google/gemini-3-pro-image-preview", "gemini-3-pro-image-preview"],
+	["google/gemini-3.1-flash-image-preview", "gemini-3.1-flash-image-preview"]
+]);
 
 export function getChatModelDefinition(model: string | null | undefined): ChatModelDefinition | undefined {
 	if (!model) return undefined;
@@ -573,7 +522,10 @@ export function isGeminiModel(model: string | null | undefined): boolean {
 }
 
 export function isOpenRouterModel(model: string | null | undefined): boolean {
-	return getChatModelDefinition(model)?.provider === "openrouter";
+	return (
+		!!model &&
+		(getChatModelDefinition(model)?.provider === "openrouter" || legacyOpenRouterImageModelIds.has(model))
+	);
 }
 
 export function modelSupportsThinking(model: string | null | undefined): boolean {
@@ -636,7 +588,8 @@ export function formatOriginModelLabel(originModel: string | null | undefined): 
 		return formatChatModelLabel(chatDefinition);
 	}
 
-	return IMAGE_MODELS.find((model) => model.id === originModel)?.label ?? originModel;
+	const imageModelId = legacyOpenRouterImageModelIdToImageModelId.get(originModel) ?? originModel;
+	return IMAGE_MODELS.find((model) => model.id === imageModelId)?.label ?? originModel;
 }
 
 export function getDefaultChatModel(access: ChatModelAccess): string {

--- a/src/types/Supabase.ts
+++ b/src/types/Supabase.ts
@@ -23,13 +23,6 @@ export interface MegaCreditsRecord {
 	[key: string]: unknown;
 }
 
-export interface NanoBananaDailyUsageRecord {
-	user_id: string;
-	usage_date: string;
-	usage_count: number;
-	[key: string]: unknown;
-}
-
 export type MarketplacePersonaInfo =
 	| {
 			id: string;

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -112,7 +112,10 @@ export function validateAttachmentFile(file: File): AttachmentValidationResult {
 	return { ok: true, policy, extension };
 }
 
-export function getAttachmentValidationSummary(files: ArrayLike<File> | Iterable<File>): {
+export function getAttachmentValidationSummary(
+	files: ArrayLike<File> | Iterable<File>,
+	maxAttachments = MAX_ATTACHMENTS
+): {
 	ok: boolean;
 	errors: AttachmentValidationFailure[];
 	tooMany: boolean;
@@ -122,9 +125,9 @@ export function getAttachmentValidationSummary(files: ArrayLike<File> | Iterable
 		.map(validateAttachmentFile)
 		.filter((result): result is AttachmentValidationFailure => !result.ok);
 	return {
-		ok: fileList.length <= MAX_ATTACHMENTS && errors.length === 0,
+		ok: fileList.length <= maxAttachments && errors.length === 0,
 		errors,
-		tooMany: fileList.length > MAX_ATTACHMENTS
+		tooMany: fileList.length > maxAttachments
 	};
 }
 

--- a/tests/e2e/smoke/app-smoke.spec.ts
+++ b/tests/e2e/smoke/app-smoke.spec.ts
@@ -119,3 +119,40 @@ test("user attaches a file by drag and drop", async ({ page }) => {
 			previewNames: ["notes.txt"]
 		});
 });
+
+test("dedicated image models are available only in image selectors", async ({ page }) => {
+	await stubExternalTraffic(page, []);
+	await seedLocalSettings(page);
+	await page.goto("/");
+
+	const imageModelIds = await page
+		.locator("#selectedImageModel option")
+		.evaluateAll((options) => options.map((option) => (option as HTMLOptionElement).value));
+	const editModelIds = await page
+		.locator("#selectedImageEditingModel option")
+		.evaluateAll((options) => options.map((option) => (option as HTMLOptionElement).value));
+	const chatModelIds = await page
+		.locator("#selectedModel option")
+		.evaluateAll((options) => options.map((option) => (option as HTMLOptionElement).value));
+
+	for (const modelId of [
+		"gemini-2.5-flash-image",
+		"gemini-3-pro-image-preview",
+		"gemini-3.1-flash-image-preview",
+		"grok-imagine-image-quality"
+	]) {
+		expect(imageModelIds).toContain(modelId);
+		expect(editModelIds).toContain(modelId);
+		expect(chatModelIds).not.toContain(modelId);
+	}
+	expect(chatModelIds).not.toContain("google/gemini-2.5-flash-image");
+	expect(chatModelIds).not.toContain("x-ai/grok-imagine-image-quality");
+
+	await page.locator(".navbar-tab").nth(2).click();
+	await page.locator('[data-settings-target="image"]').click();
+	await expect(page.locator("#selectedImageModel")).toBeVisible();
+	await expect(page.locator("#prefer-premium-image-endpoint-toggle")).toHaveClass(/hidden/);
+	await page.locator("#selectedImageModel").selectOption("gemini-2.5-flash-image");
+	await page.locator("#btn-image").click();
+	await expect(page.locator("#btn-send")).toBeEnabled();
+});

--- a/tests/e2e/subscription/mobile-layout.spec.ts
+++ b/tests/e2e/subscription/mobile-layout.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+import { seedLocalSettings, stubExternalTraffic } from "../helpers/app";
+
+test("keeps subscription plan cards within the pricing panel on mobile", async ({ page }) => {
+	await page.setViewportSize({ width: 390, height: 844 });
+	await stubExternalTraffic(page, []);
+	await seedLocalSettings(page);
+	await page.goto("/");
+
+	await page.locator("#overlay, #form-subscription").evaluateAll((elements) => {
+		for (const element of elements) {
+			element.classList.remove("hidden");
+			(element as HTMLElement).style.opacity = "1";
+		}
+	});
+
+	const shell = page.locator("#form-subscription .subscription-shell");
+	await expect(shell).toBeVisible();
+
+	const layout = await page.evaluate(() => {
+		const content = document.querySelector<HTMLElement>("#overlay > .overlay-content");
+		const shell = document.querySelector<HTMLElement>("#form-subscription .subscription-shell");
+		const cards = Array.from(document.querySelectorAll<HTMLElement>("#form-subscription .subscription-plan"));
+
+		if (!content || !shell) throw new Error("Missing subscription layout elements");
+
+		const shellBounds = shell.getBoundingClientRect();
+		return {
+			hasHorizontalOverflow: content.scrollWidth > content.clientWidth || shell.scrollWidth > shell.clientWidth,
+			cardsFit: cards.every((card) => {
+				const bounds = card.getBoundingClientRect();
+				return bounds.left >= shellBounds.left && bounds.right <= shellBounds.right;
+			})
+		};
+	});
+
+	expect(layout.cardsFit, "Subscription cards should not be clipped by the pricing panel").toBe(true);
+	expect(layout.hasHorizontalOverflow, "Subscription pricing should not overflow horizontally").toBe(false);
+});

--- a/tests/e2e/subscription/mobile-layout.spec.ts
+++ b/tests/e2e/subscription/mobile-layout.spec.ts
@@ -51,6 +51,44 @@ test("keeps subscription plan cards within the pricing panel on mobile", async (
 	expect(layout.hasHorizontalOverflow, "Subscription pricing should not overflow horizontally").toBe(false);
 });
 
+test("keeps the best-value badge compact and credit cards side by side on mobile", async ({ page }) => {
+	await page.setViewportSize({ width: 496, height: 961 });
+	await stubExternalTraffic(page, []);
+	await seedLocalSettings(page);
+	await page.goto("/");
+	await openSubscriptionOverlay(page);
+
+	const proPlusCard = page.locator("#profile-pro-plus-card");
+	const badge = proPlusCard.locator(".popular-badge");
+	const collapsedBadgeStyle = await badge.evaluate((element) => {
+		const style = getComputedStyle(element);
+		return { fontSize: style.fontSize, padding: style.padding };
+	});
+
+	await proPlusCard.locator(".subscription-card-header").click();
+	await expect(proPlusCard).toHaveClass(/subscription-card-expanded/);
+	expect(await badge.evaluate((element) => getComputedStyle(element).fontSize)).toBe(collapsedBadgeStyle.fontSize);
+	expect(await badge.evaluate((element) => getComputedStyle(element).padding)).toBe(collapsedBadgeStyle.padding);
+
+	const statColumns = await proPlusCard
+		.locator(".subscription-stat-grid")
+		.evaluate((element) => getComputedStyle(element).gridTemplateColumns.split(" ").length);
+	expect(statColumns, "Credit cards should remain side by side on mobile").toBe(2);
+});
+
+test("renders FAQ questions in one column at desktop widths", async ({ page }) => {
+	await page.setViewportSize({ width: 1600, height: 1000 });
+	await stubExternalTraffic(page, []);
+	await seedLocalSettings(page);
+	await page.goto("/");
+	await openSubscriptionOverlay(page);
+
+	const faqColumns = await page
+		.locator("#form-subscription .subscription-faq-grid")
+		.evaluate((element) => getComputedStyle(element).gridTemplateColumns.split(" ").length);
+	expect(faqColumns, "FAQ questions should not be displayed side by side").toBe(1);
+});
+
 test("plans use their own close button instead of the overlay back bar", async ({ page }) => {
 	await stubExternalTraffic(page, []);
 	await seedLocalSettings(page);

--- a/tests/e2e/subscription/mobile-layout.spec.ts
+++ b/tests/e2e/subscription/mobile-layout.spec.ts
@@ -1,21 +1,34 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { seedLocalSettings, stubExternalTraffic } from "../helpers/app";
 
+async function openSubscriptionOverlay(page: Page): Promise<void> {
+	await page.evaluate(async () => {
+		const importModule = new Function("path", "return import(path);") as (path: string) => Promise<any>;
+		const overlayService = await importModule("/services/Overlay.service.ts");
+		overlayService.show("form-subscription");
+	});
+}
+
 test("keeps subscription plan cards within the pricing panel on mobile", async ({ page }) => {
-	await page.setViewportSize({ width: 390, height: 844 });
+	await page.setViewportSize({ width: 496, height: 961 });
 	await stubExternalTraffic(page, []);
 	await seedLocalSettings(page);
 	await page.goto("/");
 
-	await page.locator("#overlay, #form-subscription").evaluateAll((elements) => {
-		for (const element of elements) {
-			element.classList.remove("hidden");
-			(element as HTMLElement).style.opacity = "1";
-		}
-	});
+	await openSubscriptionOverlay(page);
 
 	const shell = page.locator("#form-subscription .subscription-shell");
 	await expect(shell).toBeVisible();
+	const firstCard = page.locator("#profile-free-card");
+	await expect(firstCard).toHaveClass(/subscription-card-collapsed/);
+	const collapsedPadding = await firstCard.evaluate((card) => getComputedStyle(card).padding);
+
+	await firstCard.locator(".subscription-card-header").click();
+	await expect(firstCard).toHaveClass(/subscription-card-expanded/);
+	expect(await firstCard.evaluate((card) => getComputedStyle(card).padding)).toBe(collapsedPadding);
+
+	await firstCard.hover();
+	expect(await firstCard.evaluate((card) => getComputedStyle(card).transform)).toBe("none");
 
 	const layout = await page.evaluate(() => {
 		const content = document.querySelector<HTMLElement>("#overlay > .overlay-content");
@@ -36,4 +49,18 @@ test("keeps subscription plan cards within the pricing panel on mobile", async (
 
 	expect(layout.cardsFit, "Subscription cards should not be clipped by the pricing panel").toBe(true);
 	expect(layout.hasHorizontalOverflow, "Subscription pricing should not overflow horizontally").toBe(false);
+});
+
+test("plans use their own close button instead of the overlay back bar", async ({ page }) => {
+	await stubExternalTraffic(page, []);
+	await seedLocalSettings(page);
+	await page.goto("/");
+	await openSubscriptionOverlay(page);
+
+	await expect(page.locator("#overlay > .header")).toBeHidden();
+	const closeButton = page.getByRole("button", { name: "Close plans" });
+	await expect(closeButton).toBeVisible();
+
+	await closeButton.click();
+	await expect(page.locator("#overlay")).toHaveClass(/hidden/);
 });

--- a/tests/integration/attachments/chat-input-attachments.test.ts
+++ b/tests/integration/attachments/chat-input-attachments.test.ts
@@ -249,6 +249,19 @@ describe("ChatInput attachment drop workflow", () => {
 		);
 	});
 
+	it("enforces the selected image editor's five image input limit", async () => {
+		const imageEditSelector = await import("../../../src/components/static/ImageEditModelSelector.component");
+		vi.mocked(imageEditSelector.getSelectedEditingModel).mockReturnValue("gemini-3-pro-image-preview" as any);
+		window.dispatchEvent(new CustomEvent("image-editing-toggled", { detail: { enabled: true } }));
+
+		const files = Array.from({ length: 6 }, (_, index) =>
+			createFile(`image-${index + 1}.png`, "image/png", "image")
+		);
+		dispatchDrop(files);
+
+		expect(getInputFiles()).toHaveLength(5);
+	});
+
 	it("drop dedupes duplicate files", async () => {
 		const toastService = await import("../../../src/services/Toast.service");
 		const duplicateFile = createFile("notes.txt", "text/plain", "hello world");

--- a/tests/integration/messages/message-send.test.ts
+++ b/tests/integration/messages/message-send.test.ts
@@ -15,6 +15,7 @@ type MockOpenRouterResult = {
 	text: string;
 	thinking?: string;
 	finishReason?: string;
+	image?: { mimeType: string; base64: string };
 };
 
 type MockSettings = {
@@ -38,6 +39,7 @@ type MockSettings = {
 const testState = vi.hoisted(() => ({
 	personas: new Map<string, Personality>(),
 	openRouterResults: [] as MockOpenRouterResult[],
+	googleGenerateContent: vi.fn(),
 	settings: {
 		apiKey: "",
 		geminiApiKey: "",
@@ -55,6 +57,16 @@ const testState = vi.hoisted(() => ({
 		dynamicGroupChatPingOnly: false,
 		autoscroll: true
 	} as MockSettings
+}));
+
+vi.mock("@google/genai", () => ({
+	GoogleGenAI: class {
+		models = { generateContent: testState.googleGenerateContent };
+		chats = { create: vi.fn() };
+	},
+	createPartFromUri: vi.fn(),
+	BlockedReason: { PROHIBITED_CONTENT: "PROHIBITED_CONTENT" },
+	FinishReason: { PROHIBITED_CONTENT: "PROHIBITED_CONTENT", OTHER: "OTHER" }
 }));
 
 const defaultPersona: Personality = {
@@ -131,6 +143,7 @@ vi.mock("../../../src/services/OpenRouter.service", () => ({
 		async (args: {
 			onText?: (payload: { text: string }) => void | Promise<void>;
 			onThinking?: (payload: { thinking: string }) => void | Promise<void>;
+			onImage?: (payload: { mimeType: string; base64: string }) => void | Promise<void>;
 		}) => {
 			const next = testState.openRouterResults.shift();
 			if (!next) {
@@ -143,11 +156,15 @@ vi.mock("../../../src/services/OpenRouter.service", () => ({
 			if (args.onText) {
 				await args.onText({ text: next.text });
 			}
+			if (next.image && args.onImage) {
+				await args.onImage(next.image);
+			}
 
 			return {
 				text: next.text,
 				thinking: next.thinking ?? "",
-				finishReason: next.finishReason
+				finishReason: next.finishReason,
+				images: next.image ? [next.image] : []
 			};
 		}
 	)
@@ -410,6 +427,7 @@ describe("Message send lifecycle", () => {
 		});
 		testState.personas.clear();
 		testState.openRouterResults.length = 0;
+		testState.googleGenerateContent.mockReset();
 		testState.settings.model = "openai/gpt-5.4";
 		testState.settings.streamResponses = false;
 		testState.settings.enableThinking = false;
@@ -673,6 +691,13 @@ describe("Message send lifecycle", () => {
 			expect.stringContaining("/functions/v1/handle-max-request"),
 			expect.any(Object)
 		);
+		const requestOptions = (fetchMock.mock.calls as unknown as Array<[string, RequestInit]>)[0]?.[1];
+		expect(JSON.parse(String(requestOptions.body))).toEqual({
+			prompt: "Draw a comet",
+			model: "illustrious",
+			loras: [],
+			negative_prompt: ""
+		});
 		expect(toastService.warn).not.toHaveBeenCalled();
 
 		const persistedChat = await testDb.chats.get(chatId);
@@ -682,6 +707,99 @@ describe("Message send lifecycle", () => {
 			mimeType: "image/png",
 			base64: "mock-b64"
 		});
+	});
+
+	it("routes a dedicated image model through OpenRouter without EDGE credits", async () => {
+		seedMockPersonas([
+			{
+				id: "persona-openrouter-image",
+				persona: { name: "OpenRouter Image Persona", description: "Handles image generations." }
+			}
+		]);
+		testState.settings.imageModel = "gemini-2.5-flash-image";
+
+		const { db: testDb, chatsService, messageService } = await loadServices();
+		db = testDb;
+		const chatId = await createAndLoadChat({
+			chatsService,
+			chat: makeChat({ id: "chat-openrouter-image", title: "OpenRouter Image Chat", content: [] })
+		});
+
+		const imageButton = await import("../../../src/components/static/ImageButton.component");
+		const imageEditButton = await import("../../../src/components/static/ImageEditButton.component");
+		const apiKeyInput = await import("../../../src/components/static/ApiKeyInput.component");
+		const supabaseService = await import("../../../src/services/Supabase.service");
+		const openRouterService = await import("../../../src/services/OpenRouter.service");
+		vi.mocked(imageButton.isImageModeActive).mockReturnValue(true);
+		vi.mocked(imageEditButton.isImageEditingActive).mockReturnValue(false);
+		vi.mocked(apiKeyInput.shouldPreferPremiumImageEndpoint).mockReturnValue(false);
+		vi.mocked(apiKeyInput.hasOpenRouterApiKey).mockReturnValue(true);
+		vi.mocked(supabaseService.isImageGenerationAvailable).mockResolvedValue({ enabled: true, type: "google_only" });
+		testState.openRouterResults.push({ text: "", image: { mimeType: "image/png", base64: "openrouter-b64" } });
+
+		await messageService.send("Draw a comet", {
+			targetChatId: chatId,
+			selectedPersonalityId: "persona-openrouter-image",
+			attachmentFiles: makeEmptyFileList()
+		});
+
+		expect(vi.mocked(openRouterService.requestOpenRouterCompletion)).toHaveBeenCalledWith(
+			expect.objectContaining({
+				apiKey: "test-openrouter-key",
+				request: expect.objectContaining({
+					model: "google/gemini-2.5-flash-image",
+					modalities: ["image"]
+				})
+			})
+		);
+		const persistedChat = await testDb.chats.get(chatId);
+		expect(persistedChat?.content.at(-1)?.generatedImages?.[0]).toMatchObject({ base64: "openrouter-b64" });
+	});
+
+	it("routes a dedicated image model through Google without EDGE credits", async () => {
+		seedMockPersonas([
+			{
+				id: "persona-google-image",
+				persona: { name: "Google Image Persona", description: "Handles image generations." }
+			}
+		]);
+		testState.settings.imageModel = "gemini-3-pro-image-preview";
+		testState.settings.geminiApiKey = "test-gemini-key";
+
+		const { db: testDb, chatsService, messageService } = await loadServices();
+		db = testDb;
+		const chatId = await createAndLoadChat({
+			chatsService,
+			chat: makeChat({ id: "chat-google-image", title: "Google Image Chat", content: [] })
+		});
+
+		const imageButton = await import("../../../src/components/static/ImageButton.component");
+		const imageEditButton = await import("../../../src/components/static/ImageEditButton.component");
+		const apiKeyInput = await import("../../../src/components/static/ApiKeyInput.component");
+		const supabaseService = await import("../../../src/services/Supabase.service");
+		vi.mocked(imageButton.isImageModeActive).mockReturnValue(true);
+		vi.mocked(imageEditButton.isImageEditingActive).mockReturnValue(false);
+		vi.mocked(apiKeyInput.shouldPreferPremiumImageEndpoint).mockReturnValue(false);
+		vi.mocked(apiKeyInput.hasGeminiApiKey).mockReturnValue(true);
+		vi.mocked(supabaseService.isImageGenerationAvailable).mockResolvedValue({ enabled: true, type: "google_only" });
+		testState.googleGenerateContent.mockResolvedValue({
+			candidates: [{ content: { parts: [{ inlineData: { data: "google-b64", mimeType: "image/png" } }] } }]
+		});
+
+		await messageService.send("Draw a comet", {
+			targetChatId: chatId,
+			selectedPersonalityId: "persona-google-image",
+			attachmentFiles: makeEmptyFileList()
+		});
+
+		expect(testState.googleGenerateContent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model: "gemini-3-pro-image-preview",
+				config: { responseModalities: ["IMAGE"] }
+			})
+		);
+		const persistedChat = await testDb.chats.get(chatId);
+		expect(persistedChat?.content.at(-1)?.generatedImages?.[0]).toMatchObject({ base64: "google-b64" });
 	});
 
 	it("sends a message and stores ordered mocked replies in an RPG group chat", async () => {

--- a/tests/integration/profile/profile-panel-save.test.ts
+++ b/tests/integration/profile/profile-panel-save.test.ts
@@ -16,7 +16,6 @@ vi.mock("../../../src/services/Supabase.service", () => ({
 	getSubscriptionTier: vi.fn(() => "free"),
 	getImageGenerationRecord: vi.fn(async () => null),
 	getMegaCreditsRecord: vi.fn(async () => null),
-	getNanoBananaDailyUsageRecord: vi.fn(async () => null),
 	getCurrentUserEmail: vi.fn(async () => "test@example.com"),
 	sendPasswordResetEmail: vi.fn(async () => undefined)
 }));
@@ -59,7 +58,6 @@ function mountProfileDom(): void {
 		<button id="btn-manage-subscription"></button>
 		<span id="subscription-remaining-generations"></span>
 		<span id="subscription-remaining-mega-credits"></span>
-		<span id="subscription-remaining-nano-banana"></span>
 		<div id="profile-info-card" class="collapsed"><div class="collapsible-card-header"></div></div>
 		<div id="profile-info-content"></div>
 		<div id="account-info-card" class="collapsed"><div class="collapsible-card-header"></div></div>

--- a/tests/integration/settings/image-model-selectors.test.ts
+++ b/tests/integration/settings/image-model-selectors.test.ts
@@ -129,4 +129,22 @@ describe("image model selectors", () => {
 		expect(localStorage.getItem(SETTINGS_STORAGE_KEYS.IMAGE_MODEL)).toBe(DEFAULT_IMAGE_MODEL);
 		expect(localStorage.getItem(SETTINGS_STORAGE_KEYS.IMAGE_EDIT_MODEL)).toBe(DEFAULT_IMAGE_EDIT_MODEL);
 	});
+
+	it("keeps dedicated image model settings restored by sync", async () => {
+		localStorage.setItem(SETTINGS_STORAGE_KEYS.IMAGE_MODEL, "gemini-3-pro-image-preview");
+		localStorage.setItem(SETTINGS_STORAGE_KEYS.IMAGE_EDIT_MODEL, "gemini-3.1-flash-image-preview");
+
+		await import("../../../src/components/static/ImageModelSelector.component");
+		await import("../../../src/components/static/ImageEditModelSelector.component");
+		const settingsService = await import("../../../src/services/Settings.service");
+
+		settingsService.loadSettings();
+
+		expect(document.querySelector<HTMLSelectElement>("#selectedImageModel")?.value).toBe(
+			"gemini-3-pro-image-preview"
+		);
+		expect(document.querySelector<HTMLSelectElement>("#selectedImageEditingModel")?.value).toBe(
+			"gemini-3.1-flash-image-preview"
+		);
+	});
 });

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -7,8 +7,6 @@ import {
 	ImagePromptType,
 	getAccessibleRoleplaySuggestionModels,
 	getChatModelDefinition,
-	getPremiumEndpointChatModel,
-	getValidChatModel,
 	getValidRoleplaySuggestionModel,
 	modelRequiresThinking,
 	type ChatModelAccess
@@ -36,7 +34,11 @@ describe("image model definitions", () => {
 				ImageModelId.SEEDREAM_5_0_PRO,
 				ImageModelId.SEEDREAM_4_5,
 				ImageModelId.QWEN_2_0_PRO,
-				ImageModelId.QWEN_2_0
+				ImageModelId.QWEN_2_0,
+				ImageModelId.GEMINI_2_5_FLASH_IMAGE,
+				ImageModelId.GEMINI_3_PRO_IMAGE_PREVIEW,
+				ImageModelId.GEMINI_3_1_FLASH_IMAGE_PREVIEW,
+				ImageModelId.GROK_IMAGINE_IMAGE_QUALITY
 			].sort()
 		);
 	});
@@ -46,10 +48,25 @@ describe("image model definitions", () => {
 		expect(IMAGE_MODELS.find((model) => model.id === DEFAULT_IMAGE_EDIT_MODEL)?.editing).toBe(true);
 	});
 
-	it("records edge-only provider support for current image models", () => {
-		for (const model of IMAGE_MODELS) {
+	it("records provider routes for dedicated image models", () => {
+		for (const model of IMAGE_MODELS.filter((candidate) => !candidate.openRouterModelId)) {
 			expect(model.providers).toEqual([ImageModelProvider.EDGE]);
 		}
+		for (const modelId of [
+			ImageModelId.GEMINI_2_5_FLASH_IMAGE,
+			ImageModelId.GEMINI_3_PRO_IMAGE_PREVIEW,
+			ImageModelId.GEMINI_3_1_FLASH_IMAGE_PREVIEW
+		]) {
+			expect(IMAGE_MODELS.find((model) => model.id === modelId)?.providers).toEqual([
+				ImageModelProvider.EDGE,
+				ImageModelProvider.OPENROUTER,
+				ImageModelProvider.GOOGLE
+			]);
+		}
+		expect(IMAGE_MODELS.find((model) => model.id === ImageModelId.GROK_IMAGINE_IMAGE_QUALITY)?.providers).toEqual([
+			ImageModelProvider.EDGE,
+			ImageModelProvider.OPENROUTER
+		]);
 	});
 
 	it("stores prompt type per image model", () => {
@@ -92,46 +109,31 @@ describe("image model definitions", () => {
 		expect(IMAGE_MODELS.find((model) => model.id === ImageModelId.SEEDREAM_4_5)?.maxInputImages).toBe(5);
 		expect(IMAGE_MODELS.find((model) => model.id === ImageModelId.QWEN_2_0_PRO)?.maxInputImages).toBe(3);
 		expect(IMAGE_MODELS.find((model) => model.id === ImageModelId.QWEN_2_0)?.maxInputImages).toBe(3);
+		expect(IMAGE_MODELS.find((model) => model.id === ImageModelId.GEMINI_2_5_FLASH_IMAGE)?.maxInputImages).toBe(5);
+		expect(IMAGE_MODELS.find((model) => model.id === ImageModelId.GEMINI_3_PRO_IMAGE_PREVIEW)?.maxInputImages).toBe(
+			5
+		);
+		expect(
+			IMAGE_MODELS.find((model) => model.id === ImageModelId.GEMINI_3_1_FLASH_IMAGE_PREVIEW)?.maxInputImages
+		).toBe(5);
+		expect(IMAGE_MODELS.find((model) => model.id === ImageModelId.GROK_IMAGINE_IMAGE_QUALITY)?.maxInputImages).toBe(
+			3
+		);
 	});
 });
 
-describe("premium endpoint model mapping", () => {
-	it("keeps local Nano Banana as a local-only Gemini SDK model", () => {
-		const localNanoBanana = getChatModelDefinition("gemini-2.5-flash-image");
-
-		expect(localNanoBanana?.provider).toBe("gemini");
-		expect(localNanoBanana?.localOnly).toBe(true);
-		expect(localNanoBanana?.supportsImageOutput).toBe(true);
-	});
-
-	it("maps Nano Banana hybrid models to OpenRouter variants", () => {
-		const premiumAccess: ChatModelAccess = {
-			hasGeminiAccess: true,
-			hasOpenRouterAccess: true,
-			isPremiumEndpointPreferred: true
-		};
-
-		expect(getPremiumEndpointChatModel("gemini-2.5-flash-image")).toBe("google/gemini-2.5-flash-image");
-		expect(getValidChatModel("gemini-2.5-flash-image", premiumAccess)).toBe("google/gemini-2.5-flash-image");
-		expect(getValidChatModel("gemini-3-pro-image-preview", premiumAccess)).toBe(
-			"google/gemini-3-pro-image-preview"
-		);
-		expect(getValidChatModel("gemini-3.1-flash-image-preview", premiumAccess)).toBe(
-			"google/gemini-3.1-flash-image-preview"
-		);
-	});
-
-	it("keeps OpenRouter image-output variants as image-output chat models", () => {
-		const models = [
+describe("image models are not chat models", () => {
+	it("keeps dedicated image model IDs out of the chat catalog", () => {
+		for (const model of [
+			"gemini-2.5-flash-image",
+			"gemini-3-pro-image-preview",
+			"gemini-3.1-flash-image-preview",
 			"google/gemini-2.5-flash-image",
 			"google/gemini-3-pro-image-preview",
 			"google/gemini-3.1-flash-image-preview",
 			"x-ai/grok-imagine-image-quality"
-		];
-
-		for (const model of models) {
-			expect(getChatModelDefinition(model)?.provider).toBe("openrouter");
-			expect(getChatModelDefinition(model)?.supportsImageOutput).toBe(true);
+		]) {
+			expect(getChatModelDefinition(model)).toBeUndefined();
 		}
 	});
 });
@@ -140,11 +142,6 @@ describe("roleplay suggestion models", () => {
 	it("requires thinking for Gemini 3.5 Flash local and OpenRouter variants", () => {
 		expect(modelRequiresThinking("gemini-3.5-flash")).toBe(true);
 		expect(modelRequiresThinking("google/gemini-3.5-flash")).toBe(true);
-	});
-
-	it("requires thinking for Nano Banana Pro local and OpenRouter variants", () => {
-		expect(modelRequiresThinking("gemini-3-pro-image-preview")).toBe(true);
-		expect(modelRequiresThinking("google/gemini-3-pro-image-preview")).toBe(true);
 	});
 
 	it("includes only models flagged for roleplay suggestions", () => {


### PR DESCRIPTION
## Summary

- Move supported image-capable models from chat routing to the image model catalog and resolve requests through Gemini, OpenRouter, or the premium edge path.
- Replace Nano Banana daily allowance UI with image-credit messaging.
- Refine the subscription plans layout, including responsive cards, billing tabs, and FAQ presentation.

## Verification

- `npm run build`
- `npm run lint`
- `npm run test`
- `npx playwright test tests/e2e/subscription/mobile-layout.spec.ts`

Closes #211