### PR TITLE
Fix duplicate LoRAs and refine composer actions

### DIFF
--- a/src/components/static/ComposerActions.component.ts
+++ b/src/components/static/ComposerActions.component.ts
@@ -1,0 +1,222 @@
+import { openDropdownPortal, type DropdownPortal } from "../../utils/dropdownPortal";
+
+const messageBoxButtons = document.querySelector<HTMLDivElement>("#message-box-buttons");
+const messageBoxActions = document.querySelector<HTMLDivElement>("#message-box-actions");
+const messageBoxRight = document.querySelector<HTMLDivElement>(".message-box-right");
+const imageCreditsLabel = document.querySelector<HTMLDivElement>("#image-credits-label");
+const overflow = document.querySelector<HTMLDivElement>("#composer-actions-overflow");
+const overflowButton = document.querySelector<HTMLButtonElement>("#btn-composer-actions-overflow");
+const overflowMenu = document.querySelector<HTMLDivElement>("#composer-actions-menu");
+const actionButtons = Array.from(document.querySelectorAll<HTMLButtonElement>("[data-composer-action]"));
+
+if (
+	!messageBoxButtons ||
+	!messageBoxActions ||
+	!messageBoxRight ||
+	!imageCreditsLabel ||
+	!overflow ||
+	!overflowButton ||
+	!overflowMenu ||
+	actionButtons.length === 0
+) {
+	console.error("Composer actions component initialization failed");
+	throw new Error("Missing composer action elements");
+}
+
+const ensuredMessageBoxButtons = messageBoxButtons;
+const ensuredMessageBoxActions = messageBoxActions;
+const ensuredMessageBoxRight = messageBoxRight;
+const ensuredImageCreditsLabel = imageCreditsLabel;
+const ensuredOverflow = overflow;
+const ensuredOverflowButton = overflowButton;
+const ensuredOverflowMenu = overflowMenu;
+const managedActionClasses = new Set(["chat-actions-item", "composer-action-menu-item"]);
+
+let menuPortal: DropdownPortal | null = null;
+let layoutFrame: number | null = null;
+
+function resetMenuState(): void {
+	menuPortal = null;
+	ensuredOverflow.classList.remove("open");
+	ensuredOverflowButton.setAttribute("aria-expanded", "false");
+}
+
+function closeMenu(): void {
+	if (menuPortal) {
+		menuPortal.close();
+	} else {
+		resetMenuState();
+	}
+}
+
+function menuItems(): HTMLButtonElement[] {
+	return actionButtons.filter((button) => button.parentElement === ensuredOverflowMenu && !button.disabled);
+}
+
+function openMenu(): void {
+	if (menuPortal || ensuredOverflow.classList.contains("hidden")) return;
+
+	ensuredOverflow.classList.add("open");
+	ensuredOverflowButton.setAttribute("aria-expanded", "true");
+	menuPortal = openDropdownPortal(ensuredOverflowMenu, ensuredOverflowButton, {
+		align: "left",
+		offsetY: 4,
+		onClose: resetMenuState
+	});
+}
+
+function restoreActions(): void {
+	for (const action of actionButtons) {
+		ensuredMessageBoxActions.insertBefore(action, ensuredOverflow);
+		action.classList.remove(...managedActionClasses);
+		action.removeAttribute("role");
+	}
+}
+
+function moveActionToMenu(action: HTMLButtonElement): void {
+	action.classList.add(...managedActionClasses);
+	action.setAttribute("role", "menuitem");
+	ensuredOverflowMenu.prepend(action);
+}
+
+function actionGroupOverflows(): boolean {
+	return ensuredMessageBoxActions.scrollWidth > ensuredMessageBoxActions.clientWidth + 1;
+}
+
+function isActionAvailable(action: HTMLButtonElement): boolean {
+	return getComputedStyle(action).display !== "none";
+}
+
+function syncOverflowButtonState(): void {
+	const overflowedActions = actionButtons.filter((action) => action.parentElement === ensuredOverflowMenu);
+	const activeActions = overflowedActions.filter((action) => action.classList.contains("btn-toggled"));
+	const activeLabels = activeActions.map((action) => action.dataset.composerAction).filter(Boolean);
+	const label =
+		activeLabels.length > 0 ? `More message actions. Active: ${activeLabels.join(", ")}` : "More message actions";
+
+	ensuredOverflowButton.classList.toggle("btn-toggled", activeActions.length > 0);
+	ensuredOverflowButton.setAttribute("aria-label", label);
+	ensuredOverflowButton.title = label;
+}
+
+function updateLayout(): void {
+	closeMenu();
+	restoreActions();
+	ensuredOverflow.classList.add("hidden");
+	ensuredImageCreditsLabel.classList.remove("image-credits-label-compact");
+
+	if (ensuredMessageBoxButtons.clientWidth === 0 || !actionGroupOverflows()) {
+		syncOverflowButtonState();
+		return;
+	}
+
+	if (!ensuredImageCreditsLabel.classList.contains("hidden")) {
+		ensuredImageCreditsLabel.classList.add("image-credits-label-compact");
+		if (!actionGroupOverflows()) {
+			syncOverflowButtonState();
+			return;
+		}
+	}
+
+	ensuredOverflow.classList.remove("hidden");
+	const availableActions = actionButtons.filter(isActionAvailable);
+
+	for (let index = availableActions.length - 1; index >= 0 && actionGroupOverflows(); index -= 1) {
+		moveActionToMenu(availableActions[index]);
+	}
+
+	if (ensuredOverflowMenu.childElementCount === 0) {
+		ensuredOverflow.classList.add("hidden");
+	}
+
+	syncOverflowButtonState();
+}
+
+function scheduleLayout(): void {
+	if (layoutFrame !== null) return;
+	layoutFrame = requestAnimationFrame(() => {
+		layoutFrame = null;
+		updateLayout();
+	});
+}
+
+function unmanagedClassNames(value: string | null): string {
+	return (value ?? "")
+		.split(/\s+/)
+		.filter((className) => className && !managedActionClasses.has(className))
+		.sort()
+		.join(" ");
+}
+
+const resizeObserver = new ResizeObserver(scheduleLayout);
+resizeObserver.observe(ensuredMessageBoxButtons);
+resizeObserver.observe(ensuredMessageBoxActions);
+resizeObserver.observe(ensuredMessageBoxRight);
+
+const actionStateObserver = new MutationObserver((mutations) => {
+	const hasRelevantChange = mutations.some((mutation) => {
+		if (mutation.attributeName === "style") return true;
+		if (mutation.attributeName !== "class") return false;
+		return (
+			unmanagedClassNames(mutation.oldValue) !== unmanagedClassNames((mutation.target as HTMLElement).className)
+		);
+	});
+
+	if (hasRelevantChange) scheduleLayout();
+});
+
+for (const action of actionButtons) {
+	actionStateObserver.observe(action, {
+		attributes: true,
+		attributeFilter: ["class", "style"],
+		attributeOldValue: true
+	});
+}
+
+ensuredOverflowButton.addEventListener("click", (event) => {
+	event.stopPropagation();
+	if (menuPortal) {
+		closeMenu();
+	} else {
+		openMenu();
+	}
+});
+
+ensuredOverflowMenu.addEventListener("click", (event) => {
+	if (!(event.target as Element).closest<HTMLButtonElement>("[data-composer-action]")) return;
+	closeMenu();
+	scheduleLayout();
+});
+
+ensuredOverflowMenu.addEventListener("keydown", (event) => {
+	const items = menuItems();
+	if (items.length === 0) return;
+
+	const focusedIndex = items.indexOf(document.activeElement as HTMLButtonElement);
+	if (event.key === "Escape") {
+		event.preventDefault();
+		closeMenu();
+		ensuredOverflowButton.focus();
+		return;
+	}
+
+	if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+		event.preventDefault();
+		const direction = event.key === "ArrowDown" ? 1 : -1;
+		const nextIndex =
+			focusedIndex < 0
+				? direction > 0
+					? 0
+					: items.length - 1
+				: (focusedIndex + direction + items.length) % items.length;
+		items[nextIndex].focus();
+	}
+});
+
+document.addEventListener("click", (event) => {
+	const target = event.target as Node;
+	if (ensuredOverflow.contains(target) || ensuredOverflowMenu.contains(target)) return;
+	closeMenu();
+});
+
+scheduleLayout();

--- a/src/components/static/ImageCreditsLabel.component.ts
+++ b/src/components/static/ImageCreditsLabel.component.ts
@@ -23,13 +23,33 @@ import { loraArchitectureFromCivitaiBaseModel } from "../../constants/Loras";
 
 const imageCreditsLabel = document.querySelector<HTMLDivElement>("#image-credits-label");
 const imageCreditsPopover = document.querySelector<HTMLDivElement>("#image-credits-popover");
+const imageCreditsCount = document.querySelector<HTMLSpanElement>("#image-credits-label .image-credits-count");
+const imageCreditsType = document.querySelector<HTMLSpanElement>("#image-credits-label .image-credits-type");
 const imageModelSelector = document.querySelector<HTMLSelectElement>("#selectedImageModel");
 const modelSelector = document.querySelector<HTMLSelectElement>("#selectedModel");
+const messageBoxButtons = document.querySelector<HTMLDivElement>("#message-box-buttons");
+const messageBoxActions = document.querySelector<HTMLDivElement>("#message-box-actions");
+const messageBoxRight = document.querySelector<HTMLDivElement>(".message-box-right");
 
-if (!imageCreditsLabel || !imageCreditsPopover) {
+if (
+	!imageCreditsLabel ||
+	!imageCreditsPopover ||
+	!imageCreditsCount ||
+	!imageCreditsType ||
+	!messageBoxButtons ||
+	!messageBoxActions ||
+	!messageBoxRight
+) {
 	console.error("Image credits label component initialization failed");
-	throw new Error("Missing DOM elements: #image-credits-label or #image-credits-popover");
+	throw new Error("Missing image credits label elements");
 }
+
+const ensuredImageCreditsLabel = imageCreditsLabel;
+const ensuredImageCreditsCount = imageCreditsCount;
+const ensuredImageCreditsType = imageCreditsType;
+const ensuredMessageBoxButtons = messageBoxButtons;
+const ensuredMessageBoxActions = messageBoxActions;
+const ensuredMessageBoxRight = messageBoxRight;
 
 let imageCredits: number | null | undefined = undefined;
 let megaCredits: number | null | undefined = undefined;
@@ -37,6 +57,42 @@ let subscriptionTier: "free" | "pro" | "pro_plus" | "max" | "canceled" = "free";
 let isPopoverVisible = false;
 
 type AllowanceMode = "image" | "mega" | null;
+
+function toolbarOverflows(): boolean {
+	const style = getComputedStyle(ensuredMessageBoxButtons);
+	const actionStyle = getComputedStyle(ensuredMessageBoxActions);
+	const visibleActions = Array.from(ensuredMessageBoxActions.children).filter(
+		(element): element is HTMLElement =>
+			element instanceof HTMLElement && getComputedStyle(element).display !== "none"
+	);
+	const availableWidth =
+		ensuredMessageBoxButtons.clientWidth -
+		(Number.parseFloat(style.paddingLeft) || 0) -
+		(Number.parseFloat(style.paddingRight) || 0);
+	const columnGap = Number.parseFloat(style.columnGap) || 0;
+	const actionGap = Number.parseFloat(actionStyle.columnGap) || 0;
+	const actionsWidth =
+		visibleActions.reduce((width, action) => width + action.offsetWidth, 0) +
+		actionGap * Math.max(visibleActions.length - 1, 0);
+	return actionsWidth + ensuredMessageBoxRight.offsetWidth + columnGap > availableWidth;
+}
+
+function updateCompactLabelState(): void {
+	ensuredMessageBoxButtons.classList.remove("message-box-buttons-wrap");
+	ensuredImageCreditsLabel.classList.remove("image-credits-label-compact");
+
+	if (!toolbarOverflows()) return;
+
+	if (!ensuredImageCreditsLabel.classList.contains("hidden")) {
+		ensuredImageCreditsLabel.classList.add("image-credits-label-compact");
+		if (!toolbarOverflows()) return;
+	}
+
+	ensuredMessageBoxButtons.classList.add("message-box-buttons-wrap");
+}
+
+new ResizeObserver(updateCompactLabelState).observe(ensuredMessageBoxButtons);
+ensuredMessageBoxActions.addEventListener("transitionend", updateCompactLabelState);
 
 // Click handler for the label
 imageCreditsLabel.addEventListener("click", (e) => {
@@ -309,20 +365,25 @@ function renderLabel(): void {
 
 	if (allowanceMode === "mega") {
 		if (hasInsufficientMegaCredits()) {
-			imageCreditsLabel.textContent = "No Mega Credits";
+			ensuredImageCreditsCount.textContent = "No";
+			ensuredImageCreditsType.textContent = "Mega Credits";
 		} else if (megaCredits === null || megaCredits === undefined) {
-			imageCreditsLabel.textContent = "— Mega Credits";
+			ensuredImageCreditsCount.textContent = "—";
+			ensuredImageCreditsType.textContent = "Mega Credits";
 		} else {
-			imageCreditsLabel.textContent = `${megaCredits} Mega Credits`;
+			ensuredImageCreditsCount.textContent = String(megaCredits);
+			ensuredImageCreditsType.textContent = "Mega Credits";
 		}
 
 		checkAndDispatchInsufficientCreditsState();
 		if (isPopoverVisible) renderPopoverContent();
+		updateCompactLabelState();
 		return;
 	}
 
-	const totalCredits = imageCredits === null || imageCredits === undefined ? "—" : String(imageCredits);
-	imageCreditsLabel.textContent = `${totalCredits} Image Credits`;
+	ensuredImageCreditsCount.textContent =
+		imageCredits === null || imageCredits === undefined ? "—" : String(imageCredits);
+	ensuredImageCreditsType.textContent = "Image Credits";
 
 	// Check and dispatch insufficient credits state
 	checkAndDispatchInsufficientCreditsState();
@@ -331,6 +392,8 @@ function renderLabel(): void {
 	if (isPopoverVisible) {
 		renderPopoverContent();
 	}
+
+	updateCompactLabelState();
 }
 
 function renderPopoverContent(): void {
@@ -576,4 +639,6 @@ export function updateImageCreditsLabelVisibility(): void {
 			hidePopover();
 		}
 	}
+
+	updateCompactLabelState();
 }

--- a/src/components/static/ImageCreditsLabel.component.ts
+++ b/src/components/static/ImageCreditsLabel.component.ts
@@ -27,29 +27,14 @@ const imageCreditsCount = document.querySelector<HTMLSpanElement>("#image-credit
 const imageCreditsType = document.querySelector<HTMLSpanElement>("#image-credits-label .image-credits-type");
 const imageModelSelector = document.querySelector<HTMLSelectElement>("#selectedImageModel");
 const modelSelector = document.querySelector<HTMLSelectElement>("#selectedModel");
-const messageBoxButtons = document.querySelector<HTMLDivElement>("#message-box-buttons");
-const messageBoxActions = document.querySelector<HTMLDivElement>("#message-box-actions");
-const messageBoxRight = document.querySelector<HTMLDivElement>(".message-box-right");
 
-if (
-	!imageCreditsLabel ||
-	!imageCreditsPopover ||
-	!imageCreditsCount ||
-	!imageCreditsType ||
-	!messageBoxButtons ||
-	!messageBoxActions ||
-	!messageBoxRight
-) {
+if (!imageCreditsLabel || !imageCreditsPopover || !imageCreditsCount || !imageCreditsType) {
 	console.error("Image credits label component initialization failed");
 	throw new Error("Missing image credits label elements");
 }
 
-const ensuredImageCreditsLabel = imageCreditsLabel;
 const ensuredImageCreditsCount = imageCreditsCount;
 const ensuredImageCreditsType = imageCreditsType;
-const ensuredMessageBoxButtons = messageBoxButtons;
-const ensuredMessageBoxActions = messageBoxActions;
-const ensuredMessageBoxRight = messageBoxRight;
 
 let imageCredits: number | null | undefined = undefined;
 let megaCredits: number | null | undefined = undefined;
@@ -57,42 +42,6 @@ let subscriptionTier: "free" | "pro" | "pro_plus" | "max" | "canceled" = "free";
 let isPopoverVisible = false;
 
 type AllowanceMode = "image" | "mega" | null;
-
-function toolbarOverflows(): boolean {
-	const style = getComputedStyle(ensuredMessageBoxButtons);
-	const actionStyle = getComputedStyle(ensuredMessageBoxActions);
-	const visibleActions = Array.from(ensuredMessageBoxActions.children).filter(
-		(element): element is HTMLElement =>
-			element instanceof HTMLElement && getComputedStyle(element).display !== "none"
-	);
-	const availableWidth =
-		ensuredMessageBoxButtons.clientWidth -
-		(Number.parseFloat(style.paddingLeft) || 0) -
-		(Number.parseFloat(style.paddingRight) || 0);
-	const columnGap = Number.parseFloat(style.columnGap) || 0;
-	const actionGap = Number.parseFloat(actionStyle.columnGap) || 0;
-	const actionsWidth =
-		visibleActions.reduce((width, action) => width + action.offsetWidth, 0) +
-		actionGap * Math.max(visibleActions.length - 1, 0);
-	return actionsWidth + ensuredMessageBoxRight.offsetWidth + columnGap > availableWidth;
-}
-
-function updateCompactLabelState(): void {
-	ensuredMessageBoxButtons.classList.remove("message-box-buttons-wrap");
-	ensuredImageCreditsLabel.classList.remove("image-credits-label-compact");
-
-	if (!toolbarOverflows()) return;
-
-	if (!ensuredImageCreditsLabel.classList.contains("hidden")) {
-		ensuredImageCreditsLabel.classList.add("image-credits-label-compact");
-		if (!toolbarOverflows()) return;
-	}
-
-	ensuredMessageBoxButtons.classList.add("message-box-buttons-wrap");
-}
-
-new ResizeObserver(updateCompactLabelState).observe(ensuredMessageBoxButtons);
-ensuredMessageBoxActions.addEventListener("transitionend", updateCompactLabelState);
 
 // Click handler for the label
 imageCreditsLabel.addEventListener("click", (e) => {
@@ -377,7 +326,6 @@ function renderLabel(): void {
 
 		checkAndDispatchInsufficientCreditsState();
 		if (isPopoverVisible) renderPopoverContent();
-		updateCompactLabelState();
 		return;
 	}
 
@@ -392,8 +340,6 @@ function renderLabel(): void {
 	if (isPopoverVisible) {
 		renderPopoverContent();
 	}
-
-	updateCompactLabelState();
 }
 
 function renderPopoverContent(): void {
@@ -639,6 +585,4 @@ export function updateImageCreditsLabelVisibility(): void {
 			hidePopover();
 		}
 	}
-
-	updateCompactLabelState();
 }

--- a/src/components/static/LoraManager.component.ts
+++ b/src/components/static/LoraManager.component.ts
@@ -1,13 +1,15 @@
 import type { LoRAInfo, LoRAState } from "../../types/Lora";
 import * as loraService from "../../services/Lora.service";
 import { supportedLoraBaseModelLabels } from "../../constants/Loras";
-import { danger, warn } from "../../services/Toast.service";
+import { info, danger, warn } from "../../services/Toast.service";
+import { onAppEvent } from "../../events";
 import { loraElement } from "../dynamic/lora";
 
 const input = document.querySelector<HTMLInputElement>("#lora-url-input");
 const addBtn = document.querySelector<HTMLButtonElement>("#btn-add-lora");
 const container = document.querySelector<HTMLDivElement>("#lora-settings");
 const loraContainerList = document.querySelector<HTMLDivElement>("#lora-list");
+let hasShownDuplicateCleanupToast = false;
 
 if (!input || !addBtn || !container || !loraContainerList) {
 	console.error("One or more LoRA manager elements are missing.");
@@ -25,14 +27,36 @@ input?.addEventListener("keydown", (e) => {
 	}
 });
 
-//populate LoRAs
+onAppEvent("lora-list-refreshed", (event) => {
+	renderLoras();
+	if (event.detail.removedDuplicateCount > 0 && !hasShownDuplicateCleanupToast) {
+		hasShownDuplicateCleanupToast = true;
+		const count = event.detail.removedDuplicateCount;
+		info({
+			title: "Duplicate LoRAs cleaned up",
+			text: `Cleaned up ${count} duplicate LoRA${count === 1 ? "" : "s"}.`
+		});
+	}
+});
+
 void initializeLoras();
 
 async function initializeLoras() {
 	await loraService.initialize();
-	loraService.getAll().forEach((lora) => {
-		appendLora(lora, loraService.initialLoraState);
-	});
+}
+
+function renderLoras() {
+	if (!loraContainerList) return;
+	const statesByModelVersionId = new Map(
+		loraService.getLoraState().map((state) => [state.lora.modelVersionId, state])
+	);
+	loraContainerList.replaceChildren(
+		...loraService
+			.getAll()
+			.map((lora) =>
+				loraElement(lora, statesByModelVersionId.get(lora.modelVersionId) ?? loraService.initialLoraState)
+			)
+	);
 }
 
 function isLikelyCivitUrl(url: string): boolean {
@@ -59,6 +83,10 @@ async function addLoraFromInput() {
 	switch (result.status) {
 		case "added":
 			appendLora(result.lora, loraService.initialLoraState);
+			info({
+				title: "LoRA added",
+				text: `Added \"${result.lora.name}\" to your LoRAs.`
+			});
 			break;
 		case "duplicate":
 			warn({

--- a/src/components/static/Onboarding.component.ts
+++ b/src/components/static/Onboarding.component.ts
@@ -9,6 +9,7 @@ import * as onboardingService from "../../services/Onboarding.service";
 import * as supabaseService from "../../services/Supabase.service";
 import * as syncService from "../../services/Sync.service";
 import * as settingsService from "../../services/Settings.service";
+import * as loraService from "../../services/Lora.service";
 import * as toastService from "../../services/Toast.service";
 import { themeService } from "../../services/Theme.service";
 import {
@@ -1667,6 +1668,7 @@ async function hydrateRemoteSettingsForOnboarding(): Promise<boolean> {
 	const didApplySyncedSettings = await syncService.applySyncedSettingsToLocalStorage();
 	if (didApplySyncedSettings) {
 		settingsService.loadSettings();
+		await loraService.initialize();
 		return false;
 	}
 

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -193,6 +193,10 @@ export interface LoraStateChangedDetail {
 	// No detail payload - listeners should query current state
 }
 
+export interface LoraListRefreshedDetail {
+	removedDuplicateCount: number;
+}
+
 // --- Cloud Sync Events ---
 
 export type SyncStatus = "idle" | "syncing" | "synced" | "error" | "offline";
@@ -283,6 +287,7 @@ export const EventNames = {
 
 	// Lora
 	LORA_STATE_CHANGED: "lora-state-changed",
+	LORA_LIST_REFRESHED: "lora-list-refreshed",
 
 	// Cloud Sync
 	SYNC_UNLOCK_REQUIRED: "sync-unlock-required",
@@ -359,6 +364,7 @@ export interface AppEventMap {
 
 	// Lora
 	[EventNames.LORA_STATE_CHANGED]: LoraStateChangedDetail;
+	[EventNames.LORA_LIST_REFRESHED]: LoraListRefreshedDetail;
 
 	// Cloud Sync
 	[EventNames.SYNC_UNLOCK_REQUIRED]: SyncUnlockRequiredDetail;

--- a/src/index.html
+++ b/src/index.html
@@ -1238,26 +1238,37 @@
 							</div>
 						</div>
 						<div id="message-box-buttons">
-							<button type="button" class="btn-textual material-symbols-outlined btn" id="btn-attach">
-								attach_file
-							</button>
-							<button type="button" class="btn-textual material-symbols-outlined btn" id="btn-internet">
-								language
-							</button>
-							<button type="button" class="btn-textual material-symbols-outlined btn" id="btn-roleplay">
-								pan_tool
-							</button>
-							<button type="button" class="btn-textual material-symbols-outlined btn" id="btn-image">
-								<div>brush</div>
-								<div id="image-generation-label">Image Generation</div>
-							</button>
-							<button type="button" class="btn-textual material-symbols-outlined btn" id="btn-edit">
-								<div>imagesearch_roller</div>
-								<div id="image-editing-label">Image Editing</div>
-							</button>
+							<div id="message-box-actions">
+								<button type="button" class="btn-textual material-symbols-outlined btn" id="btn-attach">
+									attach_file
+								</button>
+								<button
+									type="button"
+									class="btn-textual material-symbols-outlined btn"
+									id="btn-internet"
+								>
+									language
+								</button>
+								<button
+									type="button"
+									class="btn-textual material-symbols-outlined btn"
+									id="btn-roleplay"
+								>
+									pan_tool
+								</button>
+								<button type="button" class="btn-textual material-symbols-outlined btn" id="btn-image">
+									<div>brush</div>
+									<div id="image-generation-label">Image Generation</div>
+								</button>
+								<button type="button" class="btn-textual material-symbols-outlined btn" id="btn-edit">
+									<div>imagesearch_roller</div>
+									<div id="image-editing-label">Image Editing</div>
+								</button>
+							</div>
 							<div class="message-box-right">
 								<div id="image-credits-label" class="image-credits-label hidden">
-									— image credits left
+									<span class="image-credits-count">—</span>
+									<span class="image-credits-type">Image Credits</span>
 								</div>
 								<button type="submit" class="btn-textual material-symbols-outlined" id="btn-send">
 									send

--- a/src/index.html
+++ b/src/index.html
@@ -1239,31 +1239,78 @@
 						</div>
 						<div id="message-box-buttons">
 							<div id="message-box-actions">
-								<button type="button" class="btn-textual material-symbols-outlined btn" id="btn-attach">
-									attach_file
+								<button
+									type="button"
+									class="btn-textual btn composer-action"
+									id="btn-attach"
+									data-composer-action="Attach files"
+									aria-label="Attach files"
+								>
+									<span class="material-symbols-outlined composer-action-icon">attach_file</span>
+									<span class="composer-action-label">Attach files</span>
 								</button>
 								<button
 									type="button"
-									class="btn-textual material-symbols-outlined btn"
+									class="btn-textual btn composer-action"
 									id="btn-internet"
+									data-composer-action="Web search"
+									aria-label="Toggle web search"
 								>
-									language
+									<span class="material-symbols-outlined composer-action-icon">language</span>
+									<span class="composer-action-label">Web search</span>
 								</button>
 								<button
 									type="button"
-									class="btn-textual material-symbols-outlined btn"
+									class="btn-textual btn composer-action"
 									id="btn-roleplay"
+									data-composer-action="Roleplay"
+									aria-label="Toggle roleplay tools"
 								>
-									pan_tool
+									<span class="material-symbols-outlined composer-action-icon">pan_tool</span>
+									<span class="composer-action-label">Roleplay</span>
 								</button>
-								<button type="button" class="btn-textual material-symbols-outlined btn" id="btn-image">
-									<div>brush</div>
-									<div id="image-generation-label">Image Generation</div>
+								<button
+									type="button"
+									class="btn-textual btn composer-action"
+									id="btn-image"
+									data-composer-action="Image generation"
+									aria-label="Toggle image generation"
+								>
+									<span class="material-symbols-outlined composer-action-icon">brush</span>
+									<span class="composer-action-label" id="image-generation-label"
+										>Image Generation</span
+									>
 								</button>
-								<button type="button" class="btn-textual material-symbols-outlined btn" id="btn-edit">
-									<div>imagesearch_roller</div>
-									<div id="image-editing-label">Image Editing</div>
+								<button
+									type="button"
+									class="btn-textual btn composer-action"
+									id="btn-edit"
+									data-composer-action="Image editing"
+									aria-label="Toggle image editing"
+								>
+									<span class="material-symbols-outlined composer-action-icon"
+										>imagesearch_roller</span
+									>
+									<span class="composer-action-label" id="image-editing-label">Image Editing</span>
 								</button>
+								<div id="composer-actions-overflow" class="composer-actions-overflow hidden">
+									<button
+										type="button"
+										class="btn-textual btn"
+										id="btn-composer-actions-overflow"
+										aria-label="More message actions"
+										aria-haspopup="menu"
+										aria-expanded="false"
+										aria-controls="composer-actions-menu"
+									>
+										<span class="material-symbols-outlined">more_horiz</span>
+									</button>
+									<div
+										id="composer-actions-menu"
+										class="dropdown-menu composer-actions-menu"
+										role="menu"
+									></div>
+								</div>
 							</div>
 							<div class="message-box-right">
 								<div id="image-credits-label" class="image-credits-label hidden">

--- a/src/services/Lora.service.ts
+++ b/src/services/Lora.service.ts
@@ -2,7 +2,7 @@ import type { LoRAInfo, LoRAState } from "../types/Lora";
 import { LORA_STORAGE_KEY } from "../types/Lora";
 import { isLoraBaseModelSupported } from "../constants/Loras";
 import { supabase } from "./Supabase.service";
-import { dispatchEmptyAppEvent } from "../events";
+import { dispatchAppEvent, dispatchEmptyAppEvent } from "../events";
 import * as syncService from "./Sync.service";
 
 const LORA_GET_METDATA_ENDPOINT_SLUG = "get-lora-metadata-x";
@@ -87,6 +87,10 @@ export async function add(url: string): Promise<AddLoraResult> {
 		return { status: "failed" };
 	}
 	const lora = loraDetails[0];
+	if (loras.some((existingLora) => existingLora.modelVersionId === lora.modelVersionId)) {
+		console.log("[LoRA] LoRA model version already exists:", lora.modelVersionId);
+		return { status: "duplicate" };
+	}
 	if (!isLoraBaseModelSupported(lora.baseModel)) {
 		console.warn("[LoRA] Rejected LoRA with unsupported base model:", lora.baseModel);
 		return { status: "unsupported", baseModel: lora.baseModel };
@@ -103,11 +107,26 @@ export async function initialize(): Promise<void> {
 	loras = [];
 	loraState = [];
 	const all = readFromLocalstorage();
-	const info = await getLoraMetadata(all);
+	const uniqueUrls = [...new Set(all)];
+	let removedDuplicateCount = all.length - uniqueUrls.length;
+	const info = await getLoraMetadata(uniqueUrls);
 	if (info && info.length > 0) {
-		loras.push(...info);
+		const modelVersionIds = new Set<string>();
+		for (const lora of info) {
+			if (modelVersionIds.has(lora.modelVersionId)) {
+				removedDuplicateCount += 1;
+				continue;
+			}
+			modelVersionIds.add(lora.modelVersionId);
+			loras.push(lora);
+		}
+	}
+	if (removedDuplicateCount > 0) {
+		writeToLocalstorage(loras.length > 0 ? loras.map((lora) => lora.url) : uniqueUrls);
+		queueLoraSettingsSync();
 	}
 	loraState = loras.map((lora) => ({ lora, ...initialLoraState }));
+	dispatchAppEvent("lora-list-refreshed", { removedDuplicateCount });
 }
 
 export async function getLoraMetadata(urls: string[]): Promise<LoRAInfo[] | void> {

--- a/src/services/Lora.service.ts
+++ b/src/services/Lora.service.ts
@@ -108,21 +108,39 @@ export async function initialize(): Promise<void> {
 	loraState = [];
 	const all = readFromLocalstorage();
 	const uniqueUrls = [...new Set(all)];
-	let removedDuplicateCount = all.length - uniqueUrls.length;
 	const info = await getLoraMetadata(uniqueUrls);
+	const lorasByUrl = new Map<string, LoRAInfo>();
+	const lorasByModelVersionId = new Map<string, LoRAInfo>();
 	if (info && info.length > 0) {
-		const modelVersionIds = new Set<string>();
 		for (const lora of info) {
-			if (modelVersionIds.has(lora.modelVersionId)) {
-				removedDuplicateCount += 1;
-				continue;
+			lorasByUrl.set(lora.url, lora);
+			if (!lorasByModelVersionId.has(lora.modelVersionId)) {
+				lorasByModelVersionId.set(lora.modelVersionId, lora);
+				loras.push(lora);
 			}
-			modelVersionIds.add(lora.modelVersionId);
-			loras.push(lora);
 		}
 	}
+	const keptModelVersionIds = new Set<string>();
+	const normalizedUrls = uniqueUrls.filter((url) => {
+		let resolvedLora = lorasByUrl.get(url);
+		if (!resolvedLora) {
+			try {
+				const modelVersionId = new URL(url).searchParams.get("modelVersionId");
+				if (modelVersionId) {
+					resolvedLora = lorasByModelVersionId.get(modelVersionId);
+				}
+			} catch {
+				// Preserve invalid or unresolved URLs rather than treating them as deleted metadata.
+			}
+		}
+		if (!resolvedLora) return true;
+		if (keptModelVersionIds.has(resolvedLora.modelVersionId)) return false;
+		keptModelVersionIds.add(resolvedLora.modelVersionId);
+		return true;
+	});
+	const removedDuplicateCount = all.length - normalizedUrls.length;
 	if (removedDuplicateCount > 0) {
-		writeToLocalstorage(loras.length > 0 ? loras.map((lora) => lora.url) : uniqueUrls);
+		writeToLocalstorage(normalizedUrls);
 		queueLoraSettingsSync();
 	}
 	loraState = loras.map((lora) => ({ lora, ...initialLoraState }));

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4801,7 +4801,7 @@ body.full-width-chat #message-box {
 #message-box-buttons {
 	display: grid;
 	grid-template-columns: minmax(0, 1fr) auto;
-	align-items: start;
+	align-items: center;
 	gap: 0.35rem;
 	padding: 0.3rem 0.5rem 0.3rem 0.3rem;
 }
@@ -4814,8 +4814,76 @@ body.full-width-chat #message-box {
 	min-width: 0;
 }
 
-#message-box-buttons.message-box-buttons-wrap #message-box-actions {
-	flex-wrap: wrap;
+.composer-actions-overflow {
+	display: flex;
+	align-items: center;
+	position: relative;
+}
+
+.composer-actions-menu {
+	display: none;
+	min-width: 11rem;
+}
+
+.composer-action {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: fit-content;
+	gap: 0;
+}
+
+.composer-action-icon {
+	font-size: 1rem;
+	line-height: 1;
+}
+
+.composer-action-label {
+	display: none;
+	font-family: "Noto Sans", sans-serif;
+	font-size: 0.875rem;
+	line-height: 1.2;
+	text-transform: none;
+	white-space: nowrap;
+}
+
+#message-box-actions > #btn-image.btn-toggled,
+#message-box-actions > #btn-edit.btn-toggled {
+	gap: 0.3rem;
+}
+
+#message-box-actions > #btn-image.btn-toggled .composer-action-label,
+#message-box-actions > #btn-edit.btn-toggled .composer-action-label,
+.composer-action-menu-item .composer-action-label {
+	display: inline;
+}
+
+.composer-action-menu-item {
+	width: 100%;
+	justify-content: flex-start;
+	gap: 0.5rem;
+	padding: 0.4rem 0.6rem;
+	border-radius: 0.375rem;
+	font: inherit;
+	font-weight: inherit;
+	text-transform: none;
+}
+
+.composer-action-menu-item.btn-toggled {
+	background: var(--dropdown-menu-item-active-bg) !important;
+}
+
+.composer-action-menu-item:hover,
+.composer-action-menu-item:focus-visible {
+	background: var(--dropdown-menu-item-hover-bg) !important;
+}
+
+.composer-action-menu-item:active:not(:disabled) {
+	transform: none;
+}
+
+#btn-composer-actions-overflow.btn-toggled {
+	color: var(--primary);
 }
 
 #message-box-buttons button {
@@ -5458,32 +5526,12 @@ body.full-width-chat #message-box {
 	border-radius: 1rem;
 }
 
-#image-generation-label,
-#image-editing-label {
-	font-family: "Noto Sans", sans-serif;
-	width: 0;
-	font-size: 0.875rem;
-	transition: width 0.2s ease;
-	overflow: hidden;
-	text-transform: capitalize;
-}
-
-#btn-image.btn-toggled #image-generation-label,
-#btn-edit.btn-toggled #image-editing-label {
-	width: 100%;
-}
-
 #btn-image,
 #btn-edit {
 	display: flex;
 	width: fit-content;
-	align-items: start;
-	justify-content: start;
-}
-
-#btn-image:not(.btn-toggled),
-#btn-edit:not(.btn-toggled) {
-	gap: 0;
+	align-items: center;
+	justify-content: center;
 }
 
 #zodiac-branding {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4799,10 +4799,23 @@ body.full-width-chat #message-box {
 }
 
 #message-box-buttons {
-	display: flex;
-	align-items: center;
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: start;
 	gap: 0.35rem;
 	padding: 0.3rem 0.5rem 0.3rem 0.3rem;
+}
+
+#message-box-actions {
+	display: flex;
+	align-items: center;
+	flex-wrap: nowrap;
+	gap: 0.35rem;
+	min-width: 0;
+}
+
+#message-box-buttons.message-box-buttons-wrap #message-box-actions {
+	flex-wrap: wrap;
 }
 
 #message-box-buttons button {
@@ -4825,7 +4838,7 @@ body.full-width-chat #message-box {
 	display: inline-flex;
 	align-items: center;
 	gap: 0.35rem;
-	margin-left: auto;
+	flex-shrink: 0;
 }
 
 .image-credits-label,
@@ -4843,6 +4856,8 @@ body.full-width-chat #message-box {
 	display: inline-flex;
 	align-items: center;
 	gap: 0.35rem;
+	flex-shrink: 0;
+	white-space: nowrap;
 	min-height: 0;
 	cursor: pointer;
 	user-select: none;
@@ -4854,6 +4869,10 @@ body.full-width-chat #message-box {
 .image-credits-label:hover {
 	background: var(--badge-bg-hover);
 	border-color: var(--badge-border-hover);
+}
+
+.image-credits-label.image-credits-label-compact .image-credits-type {
+	display: none;
 }
 
 .message-limit-indicator {

--- a/tests/e2e/messages/composer-credit-badge.spec.ts
+++ b/tests/e2e/messages/composer-credit-badge.spec.ts
@@ -1,0 +1,244 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+import { seedLocalSettings, stubExternalTraffic } from "../helpers/app";
+
+const SUPABASE_HOST = "hglcltvwunzynnzduauy.supabase.co";
+const TEST_USER_ID = "00000000-0000-4000-8000-0000000005728";
+const PRO_MONTHLY_PRICE_ID = "price_1SOU2lKcI9PDo3JBhsT8URS9";
+
+function jsonResponse(body: unknown) {
+	return {
+		status: 200,
+		contentType: "application/json",
+		headers: {
+			"access-control-allow-origin": "*",
+			"access-control-allow-headers": "authorization, apikey, content-type, x-client-info, prefer",
+			"access-control-allow-methods": "GET, POST, PATCH, PUT, DELETE, OPTIONS"
+		},
+		body: JSON.stringify(body)
+	};
+}
+
+async function stubMegaAllowance(page: Page): Promise<void> {
+	await page.route(`https://${SUPABASE_HOST}/**/*`, async (route: Route) => {
+		const request = route.request();
+		const url = new URL(request.url());
+
+		if (request.method() === "OPTIONS") {
+			await route.fulfill(jsonResponse({}));
+			return;
+		}
+
+		if (url.pathname === "/auth/v1/user") {
+			await route.fulfill(
+				jsonResponse({
+					id: TEST_USER_ID,
+					email: "mega-layout-playwright@example.test",
+					aud: "authenticated",
+					role: "authenticated",
+					app_metadata: {},
+					user_metadata: {},
+					created_at: "2026-01-01T00:00:00.000Z"
+				})
+			);
+			return;
+		}
+
+		if (url.pathname === "/functions/v1/refresh-subscription-allowances") {
+			await route.fulfill(jsonResponse({ ok: true }));
+			return;
+		}
+
+		if (url.pathname.startsWith("/rest/v1/user_subscriptions")) {
+			await route.fulfill(
+				jsonResponse({
+					user_id: TEST_USER_ID,
+					status: "active",
+					price_id: PRO_MONTHLY_PRICE_ID,
+					current_period_end: "2026-12-31T00:00:00.000Z",
+					cancel_at_period_end: false,
+					stripe_customer_id: "cus_mega_layout_playwright"
+				})
+			);
+			return;
+		}
+
+		if (url.pathname.startsWith("/rest/v1/mega_credits")) {
+			await route.fulfill(jsonResponse({ user_id: TEST_USER_ID, remaining_mega_credits: 7 }));
+			return;
+		}
+
+		if (url.pathname.startsWith("/rest/v1/image_generations")) {
+			await route.fulfill(jsonResponse({ user_id: TEST_USER_ID, remaining_image_generations: 7 }));
+			return;
+		}
+
+		if (url.pathname.startsWith("/rest/v1/image_sub_allowance")) {
+			await route.fulfill(jsonResponse({ remaining_image_generations: 0 }));
+			return;
+		}
+
+		if (url.pathname.startsWith("/rest/v1/profiles")) {
+			await route.fulfill(jsonResponse({ avatar: "", preferredName: "", systemPromptAddition: "" }));
+			return;
+		}
+
+		await route.fulfill(jsonResponse({}));
+	});
+}
+
+async function seedSupabaseSession(page: Page): Promise<void> {
+	await page.addInitScript(
+		({ supabaseHost, userId }) => {
+			const testWindow = window as typeof window & { __zodiacAuthStateChanges?: number };
+			testWindow.__zodiacAuthStateChanges = 0;
+			window.addEventListener("auth-state-changed", () => {
+				testWindow.__zodiacAuthStateChanges = (testWindow.__zodiacAuthStateChanges ?? 0) + 1;
+			});
+			const projectRef = supabaseHost.split(".")[0];
+			localStorage.setItem("zodiac-sync-prompt-seen", "true");
+			localStorage.setItem(
+				`sb-${projectRef}-auth-token`,
+				JSON.stringify({
+					access_token: "playwright-access-token",
+					refresh_token: "playwright-refresh-token",
+					expires_at: Math.floor(Date.now() / 1000) + 3600,
+					expires_in: 3600,
+					token_type: "bearer",
+					user: {
+						id: userId,
+						email: "mega-layout-playwright@example.test",
+						aud: "authenticated",
+						role: "authenticated",
+						app_metadata: {},
+						user_metadata: {}
+					}
+				})
+			);
+		},
+		{ supabaseHost: SUPABASE_HOST, userId: TEST_USER_ID }
+	);
+}
+
+async function dispatchAuthenticatedState(page: Page): Promise<void> {
+	await page.evaluate(
+		async ({ userId, priceId }) => {
+			const importModule = new Function("path", "return import(path);") as (path: string) => Promise<any>;
+			const { dispatchAppEvent } = await importModule("/events/index.ts");
+			dispatchAppEvent("auth-state-changed", {
+				loggedIn: true,
+				subscription: {
+					user_id: userId,
+					status: "active",
+					price_id: priceId,
+					current_period_end: "2026-12-31T00:00:00.000Z",
+					cancel_at_period_end: false,
+					stripe_customer_id: "cus_mega_layout_playwright"
+				},
+				imageGenerationRecord: { user_id: userId, remaining_image_generations: 7 }
+			});
+		},
+		{ userId: TEST_USER_ID, priceId: PRO_MONTHLY_PRICE_ID }
+	);
+}
+
+async function openMegaComposer(page: Page, width: number): Promise<void> {
+	await page.setViewportSize({ width, height: 800 });
+	await stubExternalTraffic(page, []);
+	await stubMegaAllowance(page);
+	await seedLocalSettings(page);
+	await seedSupabaseSession(page);
+	await page.goto("/");
+
+	await expect
+		.poll(() =>
+			page.evaluate(
+				() => (window as typeof window & { __zodiacAuthStateChanges?: number }).__zodiacAuthStateChanges ?? 0
+			)
+		)
+		.toBeGreaterThan(0);
+	await dispatchAuthenticatedState(page);
+
+	await page.locator("#selectedModel").evaluate((element) => {
+		const select = element as HTMLSelectElement;
+		select.value = "openai/gpt-5.5";
+		select.dispatchEvent(new Event("change", { bubbles: true }));
+	});
+	await expect(page.locator("#selectedModel")).toHaveValue("openai/gpt-5.5");
+	const badge = page.locator("#image-credits-label");
+	await expect(badge).toHaveText("7 Mega Credits");
+	await dispatchAuthenticatedState(page);
+	await page.evaluate(async () => {
+		const importModule = new Function("path", "return import(path);") as (path: string) => Promise<any>;
+		const { dispatchAppEvent } = await importModule("/events/index.ts");
+		dispatchAppEvent("chat-model-changed", { model: "openai/gpt-5.5" });
+	});
+	await expect(badge).toBeVisible();
+}
+
+function getComposerLayout() {
+	const messageBox = document.querySelector<HTMLElement>("#message-box");
+	const sendButton = document.querySelector<HTMLElement>("#btn-send");
+	const toolbar = document.querySelector<HTMLElement>("#message-box-buttons");
+	const actionGroup = document.querySelector<HTMLElement>("#message-box-actions");
+	const rightGroup = document.querySelector<HTMLElement>(".message-box-right");
+	const actions = Array.from(
+		document.querySelectorAll<HTMLElement>("#btn-attach, #btn-internet, #btn-roleplay, #btn-image, #btn-edit")
+	).filter((action) => action.getClientRects().length > 0);
+
+	if (!messageBox || !sendButton || !toolbar || !actionGroup || !rightGroup || actions.length === 0) {
+		throw new Error("Missing composer layout elements");
+	}
+
+	const messageBoxBounds = messageBox.getBoundingClientRect();
+	const sendButtonBounds = sendButton.getBoundingClientRect();
+	const actionBounds = actions.map((action) => action.getBoundingClientRect());
+	const actionGap = Number.parseFloat(getComputedStyle(actionGroup).columnGap) || 0;
+	return {
+		actionRowCount: actionBounds.reduce(
+			(rows, bounds, index) => rows + (index > 0 && bounds.left <= actionBounds[index - 1].left ? 1 : 0),
+			1
+		),
+		actionRequiredWidth:
+			actions.reduce((width, action) => width + action.getBoundingClientRect().width, 0) +
+			actionGap * (actions.length - 1),
+		actionWidth: actionGroup.scrollWidth,
+		rightWidth: rightGroup.offsetWidth,
+		toolbarWidth: toolbar.clientWidth,
+		sendButtonFits:
+			sendButtonBounds.left >= messageBoxBounds.left && sendButtonBounds.right <= messageBoxBounds.right
+	};
+}
+
+test("collapses the Mega credit badge before wrapping optional controls", async ({ page }) => {
+	await openMegaComposer(page, 300);
+	const badge = page.locator("#image-credits-label");
+	await expect(badge).toHaveClass(/image-credits-label-compact/);
+	await expect(badge.locator(".image-credits-type")).toBeHidden();
+
+	const layout = await page.evaluate(getComposerLayout);
+
+	expect(layout.sendButtonFits, "The send button must remain inside the visible message box").toBe(true);
+	expect(
+		layout.actionRowCount,
+		`Collapsing the badge should happen before controls wrap: ${JSON.stringify(layout)}`
+	).toBe(1);
+
+	await page.setViewportSize({ width: 600, height: 800 });
+	await expect(badge).not.toHaveClass(/image-credits-label-compact/);
+	await expect(badge.locator(".image-credits-type")).toBeVisible();
+});
+
+test("wraps optional controls instead of clipping send when image mode is active at 255px", async ({ page }) => {
+	await openMegaComposer(page, 255);
+	await page.locator("#btn-image").click();
+	await expect(page.locator("#btn-image")).toHaveClass(/btn-toggled/);
+	const badge = page.locator("#image-credits-label");
+	await expect(badge).toHaveClass(/image-credits-label-compact/);
+	await expect(badge.locator(".image-credits-type")).toBeHidden();
+
+	await expect.poll(async () => (await page.evaluate(getComposerLayout)).actionRowCount).toBeGreaterThan(1);
+
+	const layout = await page.evaluate(getComposerLayout);
+	expect(layout.sendButtonFits, "The send button must remain inside the visible message box").toBe(true);
+});

--- a/tests/e2e/messages/composer-credit-badge.spec.ts
+++ b/tests/e2e/messages/composer-credit-badge.spec.ts
@@ -182,11 +182,13 @@ function getComposerLayout() {
 	const toolbar = document.querySelector<HTMLElement>("#message-box-buttons");
 	const actionGroup = document.querySelector<HTMLElement>("#message-box-actions");
 	const rightGroup = document.querySelector<HTMLElement>(".message-box-right");
-	const actions = Array.from(
-		document.querySelectorAll<HTMLElement>("#btn-attach, #btn-internet, #btn-roleplay, #btn-image, #btn-edit")
-	).filter((action) => action.getClientRects().length > 0);
+	const menu = document.querySelector<HTMLElement>("#composer-actions-menu");
+	const allActions = Array.from(document.querySelectorAll<HTMLElement>("[data-composer-action]"));
+	const actions = allActions.filter(
+		(action) => action.parentElement === actionGroup && action.getClientRects().length > 0
+	);
 
-	if (!messageBox || !sendButton || !toolbar || !actionGroup || !rightGroup || actions.length === 0) {
+	if (!messageBox || !sendButton || !toolbar || !actionGroup || !rightGroup || !menu || actions.length === 0) {
 		throw new Error("Missing composer layout elements");
 	}
 
@@ -205,12 +207,14 @@ function getComposerLayout() {
 		actionWidth: actionGroup.scrollWidth,
 		rightWidth: rightGroup.offsetWidth,
 		toolbarWidth: toolbar.clientWidth,
+		toolbarActionIds: actions.map((action) => action.id),
+		menuActionIds: allActions.filter((action) => action.parentElement === menu).map((action) => action.id),
 		sendButtonFits:
 			sendButtonBounds.left >= messageBoxBounds.left && sendButtonBounds.right <= messageBoxBounds.right
 	};
 }
 
-test("collapses the Mega credit badge before wrapping optional controls", async ({ page }) => {
+test("collapses the Mega credit badge before overflowing optional controls", async ({ page }) => {
 	await openMegaComposer(page, 300);
 	const badge = page.locator("#image-credits-label");
 	await expect(badge).toHaveClass(/image-credits-label-compact/);
@@ -221,24 +225,48 @@ test("collapses the Mega credit badge before wrapping optional controls", async 
 	expect(layout.sendButtonFits, "The send button must remain inside the visible message box").toBe(true);
 	expect(
 		layout.actionRowCount,
-		`Collapsing the badge should happen before controls wrap: ${JSON.stringify(layout)}`
+		`Collapsing the badge should happen before actions overflow: ${JSON.stringify(layout)}`
 	).toBe(1);
+	expect(layout.menuActionIds).toEqual([]);
+	await expect(page.locator("#composer-actions-overflow")).toBeHidden();
 
 	await page.setViewportSize({ width: 600, height: 800 });
 	await expect(badge).not.toHaveClass(/image-credits-label-compact/);
 	await expect(badge.locator(".image-credits-type")).toBeVisible();
 });
 
-test("wraps optional controls instead of clipping send when image mode is active at 255px", async ({ page }) => {
+test("moves optional controls into a menu when image mode runs out of room at 255px", async ({ page }) => {
 	await openMegaComposer(page, 255);
-	await page.locator("#btn-image").click();
-	await expect(page.locator("#btn-image")).toHaveClass(/btn-toggled/);
 	const badge = page.locator("#image-credits-label");
 	await expect(badge).toHaveClass(/image-credits-label-compact/);
 	await expect(badge.locator(".image-credits-type")).toBeHidden();
+	await page.locator("#btn-image").click();
+	await expect(page.locator("#btn-image")).toHaveClass(/btn-toggled/);
 
-	await expect.poll(async () => (await page.evaluate(getComposerLayout)).actionRowCount).toBeGreaterThan(1);
+	const overflowButton = page.locator("#btn-composer-actions-overflow");
+	await expect(overflowButton).toBeVisible();
+	await expect(overflowButton).toHaveClass(/btn-toggled/);
+
+	const initialLayout = await page.evaluate(getComposerLayout);
+	expect(initialLayout.menuActionIds.length).toBeGreaterThan(0);
+	expect(initialLayout.menuActionIds).toContain("btn-image");
+	expect(initialLayout.actionRowCount, JSON.stringify(initialLayout)).toBe(1);
+	expect(initialLayout.sendButtonFits, "The send button must remain inside the visible message box").toBe(true);
+
+	await overflowButton.click();
+	const menu = page.locator("#composer-actions-menu.dropdown-menu--portal");
+	await expect(menu).toBeVisible();
+	const imageAction = menu.locator("#btn-image");
+	await expect(imageAction).toBeVisible();
+	await expect(imageAction).toHaveClass(/btn-toggled/);
+	await expect(imageAction.locator(".composer-action-label")).toHaveText("Image Generation");
+	await imageAction.click();
+	await expect(page.locator("#btn-image")).not.toHaveClass(/btn-toggled/);
+	await expect(menu).toBeHidden();
+	await expect(overflowButton).toBeHidden();
 
 	const layout = await page.evaluate(getComposerLayout);
+	expect(layout.actionRowCount, JSON.stringify(layout)).toBe(1);
+	expect(layout.menuActionIds).toEqual([]);
 	expect(layout.sendButtonFits, "The send button must remain inside the visible message box").toBe(true);
 });

--- a/tests/e2e/settings/lora-duplicates.spec.ts
+++ b/tests/e2e/settings/lora-duplicates.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+import { seedLocalSettings, stubExternalTraffic } from "../helpers/app";
+
+const SUPABASE_HOST = "hglcltvwunzynnzduauy.supabase.co";
+const LORA_URL = "https://civitai.com/models/example?modelVersionId=123";
+const EQUIVALENT_LORA_URL = "https://civitai.com/models/other-link?modelVersionId=123";
+
+const loraMetadata = {
+	baseModel: "Illustrious",
+	name: "Playwright LoRA",
+	trainedWords: ["playwright"],
+	modelVersionId: "123",
+	url: LORA_URL,
+	downloadUrl: "https://example.com/lora.safetensors",
+	fileName: "lora.safetensors"
+};
+
+function jsonResponse(body: unknown) {
+	return {
+		status: 200,
+		contentType: "application/json",
+		headers: {
+			"access-control-allow-origin": "*",
+			"access-control-allow-headers": "authorization, apikey, content-type, x-client-info",
+			"access-control-allow-methods": "POST, OPTIONS"
+		},
+		body: JSON.stringify(body)
+	};
+}
+
+async function stubLoraMetadata(page: Page): Promise<void> {
+	await page.route(`https://${SUPABASE_HOST}/functions/v1/get-lora-metadata-x`, async (route: Route) => {
+		if (route.request().method() === "OPTIONS") {
+			await route.fulfill(jsonResponse({}));
+			return;
+		}
+
+		const urls = (route.request().postDataJSON() as { urls?: string[] } | null)?.urls ?? [];
+		await route.fulfill(jsonResponse(urls.map(() => loraMetadata)));
+	});
+}
+
+async function openImageSettings(page: Page): Promise<void> {
+	await page.locator(".navbar-tab").filter({ hasText: "Settings" }).first().click();
+	await page.locator('[data-settings-target="image"]').click();
+	await expect(page.locator("#lora-url-input")).toBeVisible();
+}
+
+async function storedLoras(page: Page): Promise<string[]> {
+	return await page.evaluate(() => JSON.parse(localStorage.getItem("loras") ?? "[]") as string[]);
+}
+
+test("adds a LoRA once and warns when another URL resolves to the same version", async ({ page }) => {
+	await stubExternalTraffic(page, []);
+	await stubLoraMetadata(page);
+	await seedLocalSettings(page);
+	await page.goto("/");
+	await openImageSettings(page);
+
+	await page.locator("#lora-url-input").fill(LORA_URL);
+	await page.locator("#btn-add-lora").click();
+
+	await expect(page.locator(".card-lora")).toHaveCount(1);
+	await expect(page.locator(".toast", { hasText: "LoRA added" })).toBeVisible();
+
+	await page.locator("#lora-url-input").fill(EQUIVALENT_LORA_URL);
+	await page.locator("#btn-add-lora").click();
+
+	await expect(page.locator(".card-lora")).toHaveCount(1);
+	await expect(page.locator(".toast", { hasText: "LoRA already added" })).toBeVisible();
+	expect(await storedLoras(page)).toEqual([LORA_URL]);
+});
+
+test("repairs locally stored duplicate LoRAs on startup and reports one cleanup", async ({ page }) => {
+	await stubExternalTraffic(page, []);
+	await stubLoraMetadata(page);
+	await seedLocalSettings(page);
+	await page.addInitScript(
+		(urls) => {
+			localStorage.setItem("loras", JSON.stringify(urls));
+		},
+		[LORA_URL, LORA_URL]
+	);
+	await page.goto("/");
+	await openImageSettings(page);
+
+	await expect(page.locator(".card-lora")).toHaveCount(1);
+	await expect(page.locator(".toast", { hasText: "Cleaned up 1 duplicate LoRA." })).toHaveCount(1);
+	expect(await storedLoras(page)).toEqual([LORA_URL]);
+});
+
+test("does not repeat the cleanup toast when cloud settings contain the same duplicates", async ({ page }) => {
+	await stubExternalTraffic(page, []);
+	await stubLoraMetadata(page);
+	await seedLocalSettings(page);
+	await page.addInitScript(
+		(urls) => {
+			localStorage.setItem("loras", JSON.stringify(urls));
+		},
+		[LORA_URL, LORA_URL]
+	);
+	await page.goto("/");
+	await openImageSettings(page);
+	await expect(page.locator(".toast", { hasText: "Cleaned up 1 duplicate LoRA." })).toHaveCount(1);
+
+	await page.evaluate(
+		(urls) => {
+			localStorage.setItem("loras", JSON.stringify(urls));
+			window.dispatchEvent(new CustomEvent("sync-data-pulled", { detail: {} }));
+		},
+		[LORA_URL, EQUIVALENT_LORA_URL]
+	);
+
+	await expect(page.locator(".card-lora")).toHaveCount(1);
+	await expect(page.locator(".toast", { hasText: "Cleaned up 1 duplicate LoRA." })).toHaveCount(1);
+	expect(await storedLoras(page)).toEqual([LORA_URL]);
+});

--- a/tests/integration/settings/lora-sync.test.ts
+++ b/tests/integration/settings/lora-sync.test.ts
@@ -31,6 +31,7 @@ const loraFixture: LoRAInfo = {
 };
 
 const equivalentLoraUrl = "https://civitai.com/models/other-link?modelVersionId=123";
+const unresolvedLoraUrl = "https://civitai.com/models/temporarily-unavailable";
 
 describe("LoRA synced settings", () => {
 	beforeEach(() => {
@@ -97,6 +98,36 @@ describe("LoRA synced settings", () => {
 		expect(refreshed).toHaveBeenCalledTimes(1);
 		expect(refreshed.mock.calls[0][0].detail).toEqual({ removedDuplicateCount: 1 });
 		window.removeEventListener("lora-list-refreshed", refreshed);
+	});
+
+	it("preserves an unresolved unique LoRA URL while removing an exact duplicate", async () => {
+		localStorage.setItem(
+			SETTINGS_STORAGE_KEYS.LORAS,
+			JSON.stringify([loraFixture.url, loraFixture.url, unresolvedLoraUrl])
+		);
+		supabaseMock.functions.invoke.mockResolvedValue({ data: [loraFixture], error: null });
+		const loraService = await import("../../../src/services/Lora.service");
+
+		await loraService.initialize();
+
+		expect(JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEYS.LORAS) ?? "[]")).toEqual([
+			loraFixture.url,
+			unresolvedLoraUrl
+		]);
+		expect(loraService.getAll()).toEqual([loraFixture]);
+		expect(syncServiceMock.queueSettingsPush).toHaveBeenCalledTimes(1);
+	});
+
+	it("removes equivalent stored URLs when metadata coalesces them into one model version", async () => {
+		localStorage.setItem(SETTINGS_STORAGE_KEYS.LORAS, JSON.stringify([loraFixture.url, equivalentLoraUrl]));
+		supabaseMock.functions.invoke.mockResolvedValue({ data: [loraFixture], error: null });
+		const loraService = await import("../../../src/services/Lora.service");
+
+		await loraService.initialize();
+
+		expect(JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEYS.LORAS) ?? "[]")).toEqual([loraFixture.url]);
+		expect(loraService.getAll()).toEqual([loraFixture]);
+		expect(syncServiceMock.queueSettingsPush).toHaveBeenCalledTimes(1);
 	});
 
 	it("pushes current settings when a LoRA URL is deleted", async () => {

--- a/tests/integration/settings/lora-sync.test.ts
+++ b/tests/integration/settings/lora-sync.test.ts
@@ -30,6 +30,8 @@ const loraFixture: LoRAInfo = {
 	fileName: "lora.safetensors"
 };
 
+const equivalentLoraUrl = "https://civitai.com/models/other-link?modelVersionId=123";
+
 describe("LoRA synced settings", () => {
 	beforeEach(() => {
 		vi.resetModules();
@@ -62,6 +64,39 @@ describe("LoRA synced settings", () => {
 		expect(result.status).toBe("unsupported");
 		expect(JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEYS.LORAS) ?? "[]")).toEqual([]);
 		expect(syncServiceMock.queueSettingsPush).not.toHaveBeenCalled();
+	});
+
+	it("rejects a second URL that resolves to an already-added LoRA model version", async () => {
+		const loraService = await import("../../../src/services/Lora.service");
+
+		await expect(loraService.add(loraFixture.url)).resolves.toMatchObject({ status: "added" });
+		await expect(loraService.add(equivalentLoraUrl)).resolves.toEqual({ status: "duplicate" });
+
+		expect(JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEYS.LORAS) ?? "[]")).toEqual([loraFixture.url]);
+		expect(syncServiceMock.queueSettingsPush).toHaveBeenCalledTimes(1);
+	});
+
+	it("normalizes existing duplicate LoRAs and queues one cloud settings update", async () => {
+		localStorage.setItem(SETTINGS_STORAGE_KEYS.LORAS, JSON.stringify([loraFixture.url, equivalentLoraUrl]));
+		supabaseMock.functions.invoke.mockImplementation(
+			async (_slug: string, { body }: { body: { urls: string[] } }) => ({
+				data: body.urls.map(() => loraFixture),
+				error: null
+			})
+		);
+		const loraService = await import("../../../src/services/Lora.service");
+		const refreshed = vi.fn();
+		window.addEventListener("lora-list-refreshed", refreshed);
+
+		await loraService.initialize();
+
+		expect(loraService.getAll()).toEqual([loraFixture]);
+		expect(JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEYS.LORAS) ?? "[]")).toEqual([loraFixture.url]);
+		expect(syncServiceMock.queueSettingsPush).toHaveBeenCalledTimes(1);
+		expect(syncServiceMock.queueSettingsPush).toHaveBeenLastCalledWith({ label: "LoRA settings" });
+		expect(refreshed).toHaveBeenCalledTimes(1);
+		expect(refreshed.mock.calls[0][0].detail).toEqual({ removedDuplicateCount: 1 });
+		window.removeEventListener("lora-list-refreshed", refreshed);
 	});
 
 	it("pushes current settings when a LoRA URL is deleted", async () => {


### PR DESCRIPTION
Closes #212

## What changed

- Prevent duplicate LoRA records from being added locally or restored through sync.
- Consolidate narrow composer actions into an adaptive menu while keeping mobile actions accessible.
- Improve the image credit badge behavior and onboarding wiring.

## Why

Repeated imports or sync restores could leave duplicate LoRAs in a user's library. The composer updates also keep secondary controls usable without crowding the narrow layout.

## Impact

Users keep a clean LoRA library and have more reliable composer controls on smaller screens.

## Validation

- Added integration coverage for synced LoRA deduplication.
- Added Playwright coverage for duplicate LoRA handling and the composer credit badge.