### PR TITLE
Migrate Release Drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,25 +5,27 @@ change-template: "- $TITLE (#$NUMBER)"
 change-title-escapes: "<*_&"
 
 categories:
+    - type: "pre-include"
+      when:
+          labels:
+              - feature
+              - enhancement
+              - bug
+    - type: "pre-exclude"
+      when:
+          labels:
+              - code improvement
+              - documentation
+              - skip-changelog
     - title: "Features"
-      labels:
-          - feature
+      when:
+          label: feature
     - title: "Improvements"
-      labels:
-          - enhancement
+      when:
+          label: enhancement
     - title: "Fixes"
-      labels:
-          - bug
-
-include-labels:
-    - feature
-    - enhancement
-    - bug
-
-exclude-labels:
-    - code improvement
-    - documentation
-    - skip-changelog
+      when:
+          label: bug
 
 template: |
     ## What's New


### PR DESCRIPTION
## Summary

- replace deprecated top-level include/exclude fields with `pre-include` and `pre-exclude` categories
- move release category label matching into `when` conditions

## Why

Release Drafter warns that the previous fields will be removed in a future release. This migration keeps the existing feature, improvement, fix, and exclusion behavior while using the supported schema.

## Impact

Developer workflow only. User-facing release-note classification is unchanged.

## Validation

- `npx prettier --check .github/release-drafter.yml`
- `npm run lint`
- `npm run test`
- `git diff --check`
