### PR TITLE
Targeted in-app announcements

### DIFF
--- a/src/components/static/CloudSync.component.ts
+++ b/src/components/static/CloudSync.component.ts
@@ -17,8 +17,7 @@ import * as personalityService from "../../services/Personality.service";
 import * as settingsService from "../../services/Settings.service";
 import { themeService } from "../../services/Theme.service";
 import * as loraService from "../../services/Lora.service";
-import { dispatchEmptyAppEvent } from "../../events";
-import { onAppEvent } from "../../events";
+import { dispatchAppEvent, dispatchEmptyAppEvent, onAppEvent } from "../../events";
 import type { SyncStatus } from "../../events";
 import { info, danger } from "../../services/Toast.service";
 import { confirmDialog, confirmDialogDanger } from "../../utils/helpers";
@@ -68,6 +67,7 @@ const btnSyncForgotPassword = document.querySelector<HTMLButtonElement>("#btn-sy
 
 /** Track current modal mode to handle confirm button correctly. */
 let modalMode: "setup" | "unlock" | "enable" | "final-download" = "setup";
+let syncStartupUserId: string | null = null;
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -79,6 +79,12 @@ function showModal(el: HTMLElement | null) {
 function hideModal(el: HTMLElement | null) {
 	if (!el) return;
 	el.classList.add("hidden");
+}
+
+function settleSyncStartup(expectedUserId = syncStartupUserId): void {
+	if (!expectedUserId || syncStartupUserId !== expectedUserId) return;
+	dispatchAppEvent("sync-startup-settled", { userId: expectedUserId });
+	syncStartupUserId = null;
 }
 
 function showError(msg: string) {
@@ -222,6 +228,7 @@ btnSyncPromptLocal?.addEventListener("click", () => {
 	hideModal(syncPromptModal);
 	syncService.markSyncPromptSeen();
 	info({ title: "Data stays local", text: "You can enable cloud sync anytime from Settings → Data Management." });
+	settleSyncStartup();
 });
 
 // ── Encryption Password Modal ──────────────────────────────────────────────
@@ -316,6 +323,7 @@ btnSyncConfirm?.addEventListener(
 							text: "Migration complete. Local chat/persona data was deleted for maximum security; synced data now loads in-memory per session."
 						});
 						updateSettingsUI(true);
+						settleSyncStartup();
 					} else {
 						showError("Setup failed. Please try again.");
 					}
@@ -344,6 +352,7 @@ btnSyncConfirm?.addEventListener(
 							title: "Sync unlocked",
 							text: "Your synced data is available for this session (in-memory only)."
 						});
+						settleSyncStartup();
 					} else {
 						showError("Incorrect password. Please try again.");
 					}
@@ -403,6 +412,7 @@ btnSyncConfirm?.addEventListener(
 btnSyncSkip?.addEventListener("click", () => {
 	hideModal(syncModal);
 	resetModalFields();
+	settleSyncStartup();
 });
 
 // Forgot password escape hatch (visible in unlock and final-download modes)
@@ -429,6 +439,7 @@ btnSyncForgotPassword?.addEventListener(
 			} else {
 				danger({ title: "Error", text: "Failed to wipe cloud data. Please try again." });
 			}
+			settleSyncStartup();
 		})()
 );
 
@@ -592,51 +603,53 @@ onAppEvent(
 	"auth-state-changed",
 	(event) =>
 		void (async () => {
-			const { loggedIn, subscription } = event.detail;
+			const { loggedIn, subscription, session } = event.detail;
 
 			if (!loggedIn) {
 				// Hide sync section, reset state
+				syncStartupUserId = null;
 				cloudSyncSection?.classList.add("hidden");
 				cryptoService.clearCachedKey();
 				return;
 			}
 
+			const startupUserId = session?.user.id;
+			if (!startupUserId) return;
+			syncStartupUserId = startupUserId;
+
 			const tier = getSubscriptionTier(subscription ?? null);
 			const isPaid = tier === "pro" || tier === "pro_plus" || tier === "max";
 
-			if (isPaid && cloudSyncSection) {
-				cloudSyncSection.classList.remove("hidden");
-				syncUpgradeHint?.classList.add("hidden");
-				syncToggle?.removeAttribute("disabled");
+			try {
+				if (isPaid) {
+					cloudSyncSection?.classList.remove("hidden");
+					syncUpgradeHint?.classList.add("hidden");
+					syncToggle?.removeAttribute("disabled");
 
-				// Load current sync state
-				const prefs = await syncService.fetchSyncPreferences();
-				updateSettingsUI(prefs?.syncEnabled ?? false);
+					const prefs = await syncService.fetchSyncPreferences();
+					updateSettingsUI(prefs?.syncEnabled ?? false);
 
-				if (prefs?.syncEnabled) {
-					await syncService.fetchSyncQuota();
+					if (prefs?.syncEnabled) {
+						await syncService.fetchSyncQuota();
+					}
+				} else {
+					cloudSyncSection?.classList.remove("hidden");
+					syncUpgradeHint?.classList.remove("hidden");
+					syncToggle?.setAttribute("disabled", "true");
 				}
 
-				// During onboarding, cloud sync setup is handled inside onboarding flow.
-				// Avoid showing separate modals that occlude the onboarding UI.
+				// Onboarding owns its cloud-sync flow and remains the presentation blocker.
 				const onboardingCompleted = localStorage.getItem("onboardingCompleted") === "true";
 				if (!onboardingCompleted) {
+					settleSyncStartup(startupUserId);
 					return;
 				}
 
-				// Trigger unlock/setup prompt for paid users on login
-				await syncService.checkSyncOnLogin();
-			} else if (cloudSyncSection) {
-				cloudSyncSection.classList.remove("hidden");
-				syncUpgradeHint?.classList.remove("hidden");
-				syncToggle?.setAttribute("disabled", "true");
-
-				// Downgraded users may still have encrypted remote data.
-				// Offer one final restore-to-local flow and then revoke sync.
-				const onboardingCompleted = localStorage.getItem("onboardingCompleted") === "true";
-				if (onboardingCompleted) {
-					await syncService.checkSyncOnLogin();
-				}
+				const result = await syncService.checkSyncOnLogin();
+				if (result === "ready") settleSyncStartup(startupUserId);
+			} catch (error) {
+				console.error("Cloud sync startup check failed:", error);
+				settleSyncStartup(startupUserId);
 			}
 		})()
 );
@@ -670,6 +683,7 @@ onAppEvent(
 						title: "Cloud sync remains disabled",
 						text: "You can re-enable it anytime from Settings → Data Management."
 					});
+					settleSyncStartup();
 				}
 				return;
 			}
@@ -723,6 +737,8 @@ onAppEvent(
 					await chatsService.loadChat(currentChatId);
 				}
 			}
+
+			settleSyncStartup();
 		})()
 );
 

--- a/src/components/static/DebugAnnouncement.component.ts
+++ b/src/components/static/DebugAnnouncement.component.ts
@@ -1,0 +1,71 @@
+import * as overlayService from "../../services/Overlay.service";
+import * as toastService from "../../services/Toast.service";
+import { DEBUG_ANNOUNCEMENT_STORAGE_KEY, type Announcement, type AnnouncementAction } from "../../types/Announcement";
+
+const openButton = document.querySelector<HTMLButtonElement>("#btn-debug-announcement");
+const form = document.querySelector<HTMLFormElement>("#form-debug-announcement");
+const titleInput = document.querySelector<HTMLInputElement>("#debug-announcement-title");
+const bodyInput = document.querySelector<HTMLTextAreaElement>("#debug-announcement-body");
+const heroUrlInput = document.querySelector<HTMLInputElement>("#debug-announcement-hero-url");
+const heroAltInput = document.querySelector<HTMLInputElement>("#debug-announcement-hero-alt");
+const actionInput = document.querySelector<HTMLSelectElement>("#debug-announcement-action");
+const actionLabelInput = document.querySelector<HTMLInputElement>("#debug-announcement-action-label");
+const cancelButton = document.querySelector<HTMLButtonElement>("#btn-debug-announcement-cancel");
+
+if (
+	!openButton ||
+	!form ||
+	!titleInput ||
+	!bodyInput ||
+	!heroUrlInput ||
+	!heroAltInput ||
+	!actionInput ||
+	!actionLabelInput ||
+	!cancelButton
+) {
+	throw new Error("Missing debug announcement DOM elements");
+}
+
+const actionSelect = actionInput;
+const actionLabel = actionLabelInput;
+const isLocalhost = ["localhost", "127.0.0.1", "::1", "192.168.1.1"].includes(window.location.hostname);
+
+function updateActionLabelState(): void {
+	const hasAction = actionSelect.value === "dismiss" || actionSelect.value === "next";
+	actionLabel.disabled = !hasAction;
+	actionLabel.required = hasAction;
+}
+
+if (isLocalhost) {
+	openButton.addEventListener("click", () => {
+		overlayService.show("form-debug-announcement");
+		updateActionLabelState();
+		window.setTimeout(() => titleInput.focus(), 0);
+	});
+
+	actionSelect.addEventListener("change", updateActionLabelState);
+	cancelButton.addEventListener("click", () => overlayService.closeOverlay());
+
+	form.addEventListener("submit", (event) => {
+		event.preventDefault();
+		const action = (actionSelect.value || null) as AnnouncementAction | null;
+		const createdAt = Date.now();
+		const announcement: Announcement = {
+			id: `debug-announcement-${createdAt}`,
+			key: `debug-announcement-${createdAt}`,
+			title: titleInput.value.trim(),
+			body: bodyInput.value.trim(),
+			heroImageUrl: heroUrlInput.value.trim() || null,
+			heroImageAlt: heroAltInput.value.trim(),
+			actionLabel: action ? actionLabel.value.trim() : null,
+			action
+		};
+
+		localStorage.setItem(DEBUG_ANNOUNCEMENT_STORAGE_KEY, JSON.stringify(announcement));
+		overlayService.closeOverlay();
+		toastService.info({
+			title: "Announcement preview saved",
+			text: "Refresh the app to display it."
+		});
+	});
+}

--- a/src/components/static/TargetedAnnouncement.component.ts
+++ b/src/components/static/TargetedAnnouncement.component.ts
@@ -1,4 +1,4 @@
-import type { Announcement } from "../../types/Announcement";
+import { DEBUG_ANNOUNCEMENT_STORAGE_KEY, type Announcement } from "../../types/Announcement";
 import { onAppEvent } from "../../events";
 import { getEligibleAnnouncements, recordAnnouncementReceipt } from "../../services/Announcement.service";
 import * as overlayService from "../../services/Overlay.service";
@@ -42,8 +42,49 @@ let activeUserId: string | null = null;
 let loadingUserId: string | null = null;
 let loadedUserId: string | null = null;
 let currentAnnouncement: Announcement | null = null;
-let announcements: Announcement[] = [];
+let appReady = false;
 let presentationPaused = false;
+
+function readDebugAnnouncement(): Announcement | null {
+	const isLocalhost = ["localhost", "127.0.0.1", "::1", "192.168.1.1"].includes(window.location.hostname);
+	if (!isLocalhost) return null;
+
+	const stored = localStorage.getItem(DEBUG_ANNOUNCEMENT_STORAGE_KEY);
+	if (!stored) return null;
+
+	try {
+		const value = JSON.parse(stored) as Partial<Announcement>;
+		const action = value.action === "dismiss" || value.action === "next" ? value.action : null;
+		if (
+			typeof value.id !== "string" ||
+			typeof value.key !== "string" ||
+			typeof value.title !== "string" ||
+			!value.title.trim() ||
+			typeof value.body !== "string" ||
+			!value.body.trim()
+		) {
+			throw new Error("Invalid debug announcement");
+		}
+
+		return {
+			id: value.id,
+			key: value.key,
+			title: value.title,
+			body: value.body,
+			heroImageUrl: typeof value.heroImageUrl === "string" && value.heroImageUrl ? value.heroImageUrl : null,
+			heroImageAlt: typeof value.heroImageAlt === "string" ? value.heroImageAlt : "",
+			actionLabel:
+				action && typeof value.actionLabel === "string" && value.actionLabel ? value.actionLabel : null,
+			action
+		};
+	} catch {
+		localStorage.removeItem(DEBUG_ANNOUNCEMENT_STORAGE_KEY);
+		return null;
+	}
+}
+
+let debugAnnouncement = readDebugAnnouncement();
+let announcements: Announcement[] = debugAnnouncement ? [debugAnnouncement] : [];
 
 function canPresent(): boolean {
 	return overlay.classList.contains("hidden") && onboardingOverlay.classList.contains("hidden");
@@ -51,17 +92,19 @@ function canPresent(): boolean {
 
 function showNextAnnouncement(): void {
 	const modalAlreadyOpen = !modal.classList.contains("hidden");
+	const announcement = announcements[0];
+	const isDebugAnnouncement = announcement?.id === debugAnnouncement?.id;
 	if (
+		!appReady ||
 		presentationPaused ||
 		currentAnnouncement ||
-		!announcements.length ||
-		!activeUserId ||
+		!announcement ||
+		(!activeUserId && !isDebugAnnouncement) ||
 		(!modalAlreadyOpen && !canPresent())
 	) {
 		return;
 	}
 
-	const announcement = announcements[0];
 	currentAnnouncement = announcement;
 	title.textContent = announcement.title;
 	body.textContent = announcement.body;
@@ -86,7 +129,9 @@ function showNextAnnouncement(): void {
 		overlayService.show("targeted-announcement");
 		requestAnimationFrame(() => closeButton.focus());
 	}
-	void recordAnnouncementReceipt(activeUserId, announcement.id, "seen");
+	if (!isDebugAnnouncement && activeUserId) {
+		void recordAnnouncementReceipt(activeUserId, announcement.id, "seen");
+	}
 }
 
 function removeCurrentAnnouncement(): Announcement | null {
@@ -94,16 +139,22 @@ function removeCurrentAnnouncement(): Announcement | null {
 	if (!announcement) return null;
 
 	announcements = announcements.filter((candidate) => candidate.id !== announcement.id);
+	if (announcement.id === debugAnnouncement?.id) debugAnnouncement = null;
 	currentAnnouncement = null;
 	return announcement;
 }
 
 function dismissCurrentAnnouncement(actioned: boolean): void {
+	const isDebugAnnouncement = currentAnnouncement?.id === debugAnnouncement?.id;
 	const announcement = removeCurrentAnnouncement();
-	if (!announcement || !activeUserId) return;
+	if (!announcement) return;
 
 	presentationPaused = true;
-	void recordAnnouncementReceipt(activeUserId, announcement.id, actioned ? "actioned" : "dismissed");
+	if (isDebugAnnouncement) {
+		localStorage.removeItem(DEBUG_ANNOUNCEMENT_STORAGE_KEY);
+	} else if (activeUserId) {
+		void recordAnnouncementReceipt(activeUserId, announcement.id, actioned ? "actioned" : "dismissed");
+	}
 	overlayService.closeOverlay();
 }
 
@@ -116,7 +167,12 @@ async function loadAnnouncements(userId: string): Promise<void> {
 	const eligibleAnnouncements = await getEligibleAnnouncements();
 	if (activeUserId !== userId) return;
 
-	announcements = eligibleAnnouncements;
+	announcements = debugAnnouncement
+		? [
+				debugAnnouncement,
+				...eligibleAnnouncements.filter((announcement) => announcement.id !== debugAnnouncement?.id)
+			]
+		: eligibleAnnouncements;
 	loadedUserId = userId;
 	loadingUserId = null;
 	showNextAnnouncement();
@@ -126,13 +182,18 @@ closeButton.addEventListener("click", () => dismissCurrentAnnouncement(false));
 
 actionButton.addEventListener("click", () => {
 	const announcement = currentAnnouncement;
-	if (!announcement || !activeUserId) return;
+	if (!announcement) return;
 
 	const action = announcement.action;
+	const isDebugAnnouncement = announcement.id === debugAnnouncement?.id;
 	const dismissedAnnouncement = removeCurrentAnnouncement();
 	if (!dismissedAnnouncement) return;
 
-	void recordAnnouncementReceipt(activeUserId, dismissedAnnouncement.id, "actioned");
+	if (isDebugAnnouncement) {
+		localStorage.removeItem(DEBUG_ANNOUNCEMENT_STORAGE_KEY);
+	} else if (activeUserId) {
+		void recordAnnouncementReceipt(activeUserId, dismissedAnnouncement.id, "actioned");
+	}
 	if (action === "next" && announcements.length) {
 		showNextAnnouncement();
 		return;
@@ -163,17 +224,20 @@ onAppEvent("auth-state-changed", (event) => {
 	loadingUserId = null;
 	loadedUserId = null;
 	currentAnnouncement = null;
-	announcements = [];
-	presentationPaused = true;
+	announcements = debugAnnouncement ? [debugAnnouncement] : [];
+	presentationPaused = !debugAnnouncement;
+	showNextAnnouncement();
 });
 
-async function loadAnnouncementsForCurrentUser(): Promise<void> {
+async function initializeAnnouncements(): Promise<void> {
+	appReady = true;
+	showNextAnnouncement();
 	const user = await getCurrentUser();
 	if (user) void loadAnnouncements(user.id);
 }
 
 if (document.readyState === "complete") {
-	void loadAnnouncementsForCurrentUser();
+	void initializeAnnouncements();
 } else {
-	window.addEventListener("load", () => void loadAnnouncementsForCurrentUser(), { once: true });
+	window.addEventListener("load", () => void initializeAnnouncements(), { once: true });
 }

--- a/src/components/static/TargetedAnnouncement.component.ts
+++ b/src/components/static/TargetedAnnouncement.component.ts
@@ -1,0 +1,179 @@
+import type { Announcement } from "../../types/Announcement";
+import { onAppEvent } from "../../events";
+import { getEligibleAnnouncements, recordAnnouncementReceipt } from "../../services/Announcement.service";
+import * as overlayService from "../../services/Overlay.service";
+import { getCurrentUser } from "../../services/Supabase.service";
+
+const overlayElement = document.querySelector<HTMLElement>("#overlay");
+const onboardingOverlayElement = document.querySelector<HTMLElement>("#onboarding-overlay");
+const modalElement = document.querySelector<HTMLElement>("#targeted-announcement");
+const closeButtonElement = document.querySelector<HTMLButtonElement>("#targeted-announcement-close");
+const heroElement = document.querySelector<HTMLElement>("#targeted-announcement-hero");
+const heroImageElement = document.querySelector<HTMLImageElement>("#targeted-announcement-image");
+const titleElement = document.querySelector<HTMLElement>("#targeted-announcement-title");
+const bodyElement = document.querySelector<HTMLElement>("#targeted-announcement-body");
+const actionButtonElement = document.querySelector<HTMLButtonElement>("#targeted-announcement-action");
+
+if (
+	!overlayElement ||
+	!onboardingOverlayElement ||
+	!modalElement ||
+	!closeButtonElement ||
+	!heroElement ||
+	!heroImageElement ||
+	!titleElement ||
+	!bodyElement ||
+	!actionButtonElement
+) {
+	throw new Error("Missing targeted announcement DOM elements");
+}
+
+const overlay = overlayElement;
+const onboardingOverlay = onboardingOverlayElement;
+const modal = modalElement;
+const closeButton = closeButtonElement;
+const hero = heroElement;
+const heroImage = heroImageElement;
+const title = titleElement;
+const body = bodyElement;
+const actionButton = actionButtonElement;
+
+let activeUserId: string | null = null;
+let loadingUserId: string | null = null;
+let loadedUserId: string | null = null;
+let currentAnnouncement: Announcement | null = null;
+let announcements: Announcement[] = [];
+let presentationPaused = false;
+
+function canPresent(): boolean {
+	return overlay.classList.contains("hidden") && onboardingOverlay.classList.contains("hidden");
+}
+
+function showNextAnnouncement(): void {
+	const modalAlreadyOpen = !modal.classList.contains("hidden");
+	if (
+		presentationPaused ||
+		currentAnnouncement ||
+		!announcements.length ||
+		!activeUserId ||
+		(!modalAlreadyOpen && !canPresent())
+	) {
+		return;
+	}
+
+	const announcement = announcements[0];
+	currentAnnouncement = announcement;
+	title.textContent = announcement.title;
+	body.textContent = announcement.body;
+
+	hero.classList.add("hidden");
+	heroImage.removeAttribute("src");
+	heroImage.alt = announcement.heroImageAlt;
+	if (announcement.heroImageUrl) {
+		heroImage.onload = () => hero.classList.remove("hidden");
+		heroImage.onerror = () => hero.classList.add("hidden");
+		heroImage.src = announcement.heroImageUrl;
+	}
+
+	if (announcement.action && announcement.actionLabel) {
+		actionButton.textContent = announcement.actionLabel;
+		actionButton.classList.remove("hidden");
+	} else {
+		actionButton.classList.add("hidden");
+	}
+
+	if (!modalAlreadyOpen) {
+		overlayService.show("targeted-announcement");
+		requestAnimationFrame(() => closeButton.focus());
+	}
+	void recordAnnouncementReceipt(activeUserId, announcement.id, "seen");
+}
+
+function removeCurrentAnnouncement(): Announcement | null {
+	const announcement = currentAnnouncement;
+	if (!announcement) return null;
+
+	announcements = announcements.filter((candidate) => candidate.id !== announcement.id);
+	currentAnnouncement = null;
+	return announcement;
+}
+
+function dismissCurrentAnnouncement(actioned: boolean): void {
+	const announcement = removeCurrentAnnouncement();
+	if (!announcement || !activeUserId) return;
+
+	presentationPaused = true;
+	void recordAnnouncementReceipt(activeUserId, announcement.id, actioned ? "actioned" : "dismissed");
+	overlayService.closeOverlay();
+}
+
+async function loadAnnouncements(userId: string): Promise<void> {
+	if (loadingUserId === userId || loadedUserId === userId) return;
+
+	activeUserId = userId;
+	loadingUserId = userId;
+	presentationPaused = false;
+	const eligibleAnnouncements = await getEligibleAnnouncements();
+	if (activeUserId !== userId) return;
+
+	announcements = eligibleAnnouncements;
+	loadedUserId = userId;
+	loadingUserId = null;
+	showNextAnnouncement();
+}
+
+closeButton.addEventListener("click", () => dismissCurrentAnnouncement(false));
+
+actionButton.addEventListener("click", () => {
+	const announcement = currentAnnouncement;
+	if (!announcement || !activeUserId) return;
+
+	const action = announcement.action;
+	const dismissedAnnouncement = removeCurrentAnnouncement();
+	if (!dismissedAnnouncement) return;
+
+	void recordAnnouncementReceipt(activeUserId, dismissedAnnouncement.id, "actioned");
+	if (action === "next" && announcements.length) {
+		showNextAnnouncement();
+		return;
+	}
+
+	presentationPaused = true;
+	overlayService.closeOverlay();
+});
+
+document.addEventListener("keydown", (event) => {
+	if (event.key === "Escape" && !modal.classList.contains("hidden")) {
+		event.preventDefault();
+		dismissCurrentAnnouncement(false);
+	}
+});
+
+const overlayObserver = new MutationObserver(() => showNextAnnouncement());
+overlayObserver.observe(overlay, { attributes: true, attributeFilter: ["class"] });
+overlayObserver.observe(onboardingOverlay, { attributes: true, attributeFilter: ["class"] });
+
+onAppEvent("auth-state-changed", (event) => {
+	if (event.detail.loggedIn && event.detail.session) {
+		void loadAnnouncements(event.detail.session.user.id);
+		return;
+	}
+
+	activeUserId = null;
+	loadingUserId = null;
+	loadedUserId = null;
+	currentAnnouncement = null;
+	announcements = [];
+	presentationPaused = true;
+});
+
+async function loadAnnouncementsForCurrentUser(): Promise<void> {
+	const user = await getCurrentUser();
+	if (user) void loadAnnouncements(user.id);
+}
+
+if (document.readyState === "complete") {
+	void loadAnnouncementsForCurrentUser();
+} else {
+	window.addEventListener("load", () => void loadAnnouncementsForCurrentUser(), { once: true });
+}

--- a/src/components/static/TargetedAnnouncement.component.ts
+++ b/src/components/static/TargetedAnnouncement.component.ts
@@ -6,6 +6,7 @@ import { getCurrentUser } from "../../services/Supabase.service";
 
 const overlayElement = document.querySelector<HTMLElement>("#overlay");
 const onboardingOverlayElement = document.querySelector<HTMLElement>("#onboarding-overlay");
+const appDialogs = document.querySelectorAll<HTMLElement>("#main-container > .dialog");
 const modalElement = document.querySelector<HTMLElement>("#targeted-announcement");
 const closeButtonElement = document.querySelector<HTMLButtonElement>("#targeted-announcement-close");
 const heroElement = document.querySelector<HTMLElement>("#targeted-announcement-hero");
@@ -41,6 +42,7 @@ const actionButton = actionButtonElement;
 let activeUserId: string | null = null;
 let loadingUserId: string | null = null;
 let loadedUserId: string | null = null;
+let syncStartupSettledUserId: string | null = null;
 let currentAnnouncement: Announcement | null = null;
 let appReady = false;
 let presentationPaused = false;
@@ -87,7 +89,11 @@ let debugAnnouncement = readDebugAnnouncement();
 let announcements: Announcement[] = debugAnnouncement ? [debugAnnouncement] : [];
 
 function canPresent(): boolean {
-	return overlay.classList.contains("hidden") && onboardingOverlay.classList.contains("hidden");
+	return (
+		overlay.classList.contains("hidden") &&
+		onboardingOverlay.classList.contains("hidden") &&
+		Array.from(appDialogs).every((dialog) => dialog.classList.contains("hidden"))
+	);
 }
 
 function showNextAnnouncement(): void {
@@ -100,6 +106,7 @@ function showNextAnnouncement(): void {
 		currentAnnouncement ||
 		!announcement ||
 		(!activeUserId && !isDebugAnnouncement) ||
+		(activeUserId !== null && syncStartupSettledUserId !== activeUserId) ||
 		(!modalAlreadyOpen && !canPresent())
 	) {
 		return;
@@ -213,16 +220,26 @@ document.addEventListener("keydown", (event) => {
 const overlayObserver = new MutationObserver(() => showNextAnnouncement());
 overlayObserver.observe(overlay, { attributes: true, attributeFilter: ["class"] });
 overlayObserver.observe(onboardingOverlay, { attributes: true, attributeFilter: ["class"] });
+appDialogs.forEach((dialog) => overlayObserver.observe(dialog, { attributes: true, attributeFilter: ["class"] }));
+
+onAppEvent("sync-startup-settled", (event) => {
+	syncStartupSettledUserId = event.detail.userId;
+	showNextAnnouncement();
+});
 
 onAppEvent("auth-state-changed", (event) => {
 	if (event.detail.loggedIn && event.detail.session) {
-		void loadAnnouncements(event.detail.session.user.id);
+		const userId = event.detail.session.user.id;
+		if (syncStartupSettledUserId !== userId) syncStartupSettledUserId = null;
+		activeUserId = userId;
+		void loadAnnouncements(userId);
 		return;
 	}
 
 	activeUserId = null;
 	loadingUserId = null;
 	loadedUserId = null;
+	syncStartupSettledUserId = null;
 	currentAnnouncement = null;
 	announcements = debugAnnouncement ? [debugAnnouncement] : [];
 	presentationPaused = !debugAnnouncement;
@@ -230,10 +247,13 @@ onAppEvent("auth-state-changed", (event) => {
 });
 
 async function initializeAnnouncements(): Promise<void> {
-	appReady = true;
-	showNextAnnouncement();
 	const user = await getCurrentUser();
-	if (user) void loadAnnouncements(user.id);
+	appReady = true;
+	if (user) {
+		activeUserId = user.id;
+		void loadAnnouncements(user.id);
+	}
+	showNextAnnouncement();
 }
 
 if (document.readyState === "complete") {

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -226,6 +226,10 @@ export interface SyncDataPulledDetail {
 	// No detail payload
 }
 
+export interface SyncStartupSettledDetail {
+	userId: string;
+}
+
 // ================================================================================
 // EVENT NAME CONSTANTS
 // ================================================================================
@@ -294,7 +298,8 @@ export const EventNames = {
 	SYNC_STATE_CHANGED: "sync-state-changed",
 	SYNC_QUOTA_UPDATED: "sync-quota-updated",
 	SYNC_SETUP_COMPLETE: "sync-setup-complete",
-	SYNC_DATA_PULLED: "sync-data-pulled"
+	SYNC_DATA_PULLED: "sync-data-pulled",
+	SYNC_STARTUP_SETTLED: "sync-startup-settled"
 } as const;
 
 export type EventName = (typeof EventNames)[keyof typeof EventNames];
@@ -372,6 +377,7 @@ export interface AppEventMap {
 	[EventNames.SYNC_QUOTA_UPDATED]: SyncQuotaUpdatedDetail;
 	[EventNames.SYNC_SETUP_COMPLETE]: SyncSetupCompleteDetail;
 	[EventNames.SYNC_DATA_PULLED]: SyncDataPulledDetail;
+	[EventNames.SYNC_STARTUP_SETTLED]: SyncStartupSettledDetail;
 }
 
 // ================================================================================

--- a/src/index.html
+++ b/src/index.html
@@ -1673,6 +1673,38 @@
 					</ul>
 				</div>
 
+				<section
+					id="targeted-announcement"
+					class="targeted-announcement hidden"
+					role="dialog"
+					aria-modal="true"
+					aria-labelledby="targeted-announcement-title"
+					tabindex="-1"
+				>
+					<button
+						id="targeted-announcement-close"
+						class="targeted-announcement-close material-symbols-outlined"
+						type="button"
+						aria-label="Dismiss announcement"
+					>
+						close
+					</button>
+					<div id="targeted-announcement-hero" class="targeted-announcement-hero hidden">
+						<img id="targeted-announcement-image" alt="" decoding="async" />
+					</div>
+					<div class="targeted-announcement-content">
+						<h1 id="targeted-announcement-title"></h1>
+						<p id="targeted-announcement-body"></p>
+						<div class="targeted-announcement-actions">
+							<button
+								id="targeted-announcement-action"
+								class="btn btn-primary hidden"
+								type="button"
+							></button>
+						</div>
+					</div>
+				</section>
+
 				<!-- Add Persona Modal -->
 				<div id="modal-add-persona" class="hidden">
 					<span class="material-symbols-outlined sync-modal-icon">person_add</span>

--- a/src/index.html
+++ b/src/index.html
@@ -1124,6 +1124,9 @@
 									Open Subscription Options
 								</button>
 								<button class="btn btn-primary" id="btn-debug-onboarding">Test Onboarding</button>
+								<button class="btn btn-primary" id="btn-debug-announcement">
+									Compose Announcement Preview
+								</button>
 							</div>
 						</div>
 					</div>
@@ -1773,6 +1776,51 @@
 						</button>
 					</div>
 				</div>
+
+				<form id="form-debug-announcement" class="debug-announcement-form hidden">
+					<h1>Announcement Preview</h1>
+					<p class="overlay-description">Save a one-time announcement to display after the next refresh.</p>
+
+					<label for="debug-announcement-title">Title</label>
+					<input id="debug-announcement-title" type="text" value="Max is now unlimited" required />
+
+					<label for="debug-announcement-body">Body</label>
+					<textarea id="debug-announcement-body" rows="4" required>
+Your Max plan no longer has a monthly usage limit.</textarea
+					>
+
+					<label for="debug-announcement-hero-url">Hero image URL</label>
+					<input
+						id="debug-announcement-hero-url"
+						type="url"
+						placeholder="https://example.com/announcement.webp"
+					/>
+
+					<label for="debug-announcement-hero-alt">Hero image alt text</label>
+					<input id="debug-announcement-hero-alt" type="text" placeholder="Describe the image" />
+
+					<div class="debug-announcement-action-fields">
+						<div>
+							<label for="debug-announcement-action">Action</label>
+							<select id="debug-announcement-action">
+								<option value="">No action</option>
+								<option value="dismiss" selected>Dismiss</option>
+								<option value="next">Next</option>
+							</select>
+						</div>
+						<div>
+							<label for="debug-announcement-action-label">Action label</label>
+							<input id="debug-announcement-action-label" type="text" value="Got it" required />
+						</div>
+					</div>
+
+					<div class="overlay-actions">
+						<button id="btn-debug-announcement-cancel" class="btn btn-secondary" type="button">
+							Cancel
+						</button>
+						<button class="btn btn-primary" type="submit">Save for next refresh</button>
+					</div>
+				</form>
 
 				<div id="login-register-tabs" class="hidden">
 					<div class="navbar" data-target-id="login-register-container">

--- a/src/services/Announcement.service.ts
+++ b/src/services/Announcement.service.ts
@@ -1,0 +1,104 @@
+import type { Announcement, AnnouncementAction, AnnouncementReceiptEvent } from "../types/Announcement";
+import type { Tables } from "../types/database.types";
+import { supabase } from "./Supabase.service";
+
+type AnnouncementRow = Pick<
+	Tables<"announcements">,
+	"id" | "key" | "title" | "body" | "hero_image_url" | "hero_image_alt" | "action_label" | "action"
+>;
+
+type AnnouncementReceiptRow = Pick<Tables<"announcement_receipts">, "announcement_id" | "dismissed_at">;
+
+function isAction(value: unknown): value is AnnouncementAction {
+	return value === "dismiss" || value === "next";
+}
+
+function normalizeAnnouncement(row: AnnouncementRow): Announcement | null {
+	if (
+		typeof row.id !== "string" ||
+		typeof row.key !== "string" ||
+		typeof row.title !== "string" ||
+		typeof row.body !== "string"
+	) {
+		return null;
+	}
+
+	const action = isAction(row.action) ? row.action : null;
+	const actionLabel =
+		action && typeof row.action_label === "string" && row.action_label.trim() ? row.action_label : null;
+
+	return {
+		id: row.id,
+		key: row.key,
+		title: row.title,
+		body: row.body,
+		heroImageUrl: typeof row.hero_image_url === "string" && row.hero_image_url.trim() ? row.hero_image_url : null,
+		heroImageAlt: typeof row.hero_image_alt === "string" ? row.hero_image_alt : "",
+		actionLabel,
+		action: actionLabel ? action : null
+	};
+}
+
+export async function getEligibleAnnouncements(): Promise<Announcement[]> {
+	const { data, error } = await supabase
+		.from("announcements")
+		.select("id,key,title,body,hero_image_url,hero_image_alt,action_label,action")
+		.order("priority", { ascending: false });
+
+	if (error) {
+		console.warn("Unable to load in-app announcements:", error.message);
+		return [];
+	}
+
+	const announcements = ((data ?? []) as AnnouncementRow[])
+		.map(normalizeAnnouncement)
+		.filter((announcement): announcement is Announcement => announcement !== null);
+	if (!announcements.length) return [];
+
+	const { data: receiptData, error: receiptError } = await supabase
+		.from("announcement_receipts")
+		.select("announcement_id,dismissed_at")
+		.in(
+			"announcement_id",
+			announcements.map((announcement) => announcement.id)
+		);
+
+	if (receiptError) {
+		console.warn("Unable to load announcement receipts:", receiptError.message);
+		return [];
+	}
+
+	const dismissedIds = new Set(
+		((receiptData ?? []) as AnnouncementReceiptRow[])
+			.filter((receipt) => typeof receipt.announcement_id === "string" && receipt.dismissed_at !== null)
+			.map((receipt) => receipt.announcement_id as string)
+	);
+
+	return announcements.filter((announcement) => !dismissedIds.has(announcement.id));
+}
+
+export async function recordAnnouncementReceipt(
+	userId: string,
+	announcementId: string,
+	event: AnnouncementReceiptEvent
+): Promise<void> {
+	const occurredAt = new Date().toISOString();
+	const receipt: Record<string, string> = {
+		user_id: userId,
+		announcement_id: announcementId
+	};
+
+	if (event === "seen") receipt.seen_at = occurredAt;
+	if (event === "dismissed") receipt.dismissed_at = occurredAt;
+	if (event === "actioned") {
+		receipt.actioned_at = occurredAt;
+		receipt.dismissed_at = occurredAt;
+	}
+
+	const { error } = await supabase
+		.from("announcement_receipts")
+		.upsert(receipt, { onConflict: "announcement_id,user_id" });
+	if (error) {
+		console.warn(`Unable to record announcement ${event} receipt:`, error.message);
+	}
+}

--- a/src/services/Sync.service.ts
+++ b/src/services/Sync.service.ts
@@ -2854,9 +2854,11 @@ function attachDexieHooks(): void {
  * Called after auth state change when user is logged in.
  * Checks sync preferences and emits unlock-required event if needed.
  */
-export async function checkSyncOnLogin(): Promise<void> {
+export type SyncLoginCheckResult = "ready" | "interaction-required";
+
+export async function checkSyncOnLogin(): Promise<SyncLoginCheckResult> {
 	const user = await getCurrentUser();
-	if (!user) return;
+	if (!user) return "ready";
 
 	// Check subscription tier
 	const sub = await getUserSubscription();
@@ -2867,8 +2869,9 @@ export async function checkSyncOnLogin(): Promise<void> {
 		const prefs = await fetchSyncPreferences();
 		if (prefs?.syncEnabled) {
 			dispatchAppEvent("sync-unlock-required", { isFirstSetup: false, mode: "final-download" });
+			return "interaction-required";
 		}
-		return;
+		return "ready";
 	}
 
 	const prefs = await fetchSyncPreferences();
@@ -2878,8 +2881,9 @@ export async function checkSyncOnLogin(): Promise<void> {
 		// If they haven't seen the prompt yet, show it.
 		if (!hasSeenSyncPrompt()) {
 			dispatchAppEvent("sync-unlock-required", { isFirstSetup: true, mode: "setup" });
+			return "interaction-required";
 		}
-		return;
+		return "ready";
 	}
 
 	if (!prefs.syncEnabled) {
@@ -2894,14 +2898,18 @@ export async function checkSyncOnLogin(): Promise<void> {
 			} else {
 				dispatchAppEvent("sync-unlock-required", { isFirstSetup: true, mode: "setup" });
 			}
+			return "interaction-required";
 		}
-		return;
+		return "ready";
 	}
 
 	// Sync is enabled — they need to enter their encryption password
 	if (!crypto.isUnlocked()) {
 		dispatchAppEvent("sync-unlock-required", { isFirstSetup: false, mode: "unlock" });
+		return "interaction-required";
 	}
+
+	return "ready";
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2926,6 +2926,38 @@ form {
 	flex-direction: column;
 }
 
+.debug-announcement-form {
+	display: flex;
+	flex-direction: column;
+	gap: 0.65rem;
+	width: min(34rem, 100%);
+	max-height: calc(100dvh - 2rem);
+	padding: 1.5rem;
+	overflow-y: auto;
+	box-sizing: border-box;
+	border: 1px solid var(--card-border);
+	border-radius: 0.75rem;
+	background: var(--modal-bg);
+	box-shadow: var(--modal-shadow);
+}
+
+.debug-announcement-form label {
+	font-size: 0.85rem;
+	font-weight: 700;
+}
+
+.debug-announcement-action-fields {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 0.75rem;
+}
+
+.debug-announcement-action-fields > div {
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
+}
+
 .message-debug-summary {
 	display: flex;
 	flex-direction: column;
@@ -2973,6 +3005,10 @@ form {
 }
 
 @media (max-width: 640px) {
+	.debug-announcement-action-fields {
+		grid-template-columns: 1fr;
+	}
+
 	.message-debug-row {
 		flex-direction: column;
 		align-items: flex-start;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3465,6 +3465,110 @@ form {
 	overflow-y: auto;
 }
 
+#overlay:has(> .overlay-content > #targeted-announcement:not(.hidden)) > .header {
+	display: none;
+}
+
+.targeted-announcement {
+	position: relative;
+	width: min(34rem, calc(100vw - 2rem));
+	max-height: min(42rem, calc(100dvh - 2rem));
+	overflow-y: auto;
+	border: 1px solid var(--card-border);
+	border-radius: 0.75rem;
+	background: var(--modal-bg);
+	color: var(--modal-fg);
+	box-shadow: var(--modal-shadow);
+}
+
+.targeted-announcement-close {
+	position: absolute;
+	top: 0.75rem;
+	right: 0.75rem;
+	z-index: 1;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.25rem;
+	height: 2.25rem;
+	padding: 0;
+	border: 1px solid var(--input-text-border);
+	border-radius: 0.5rem;
+	background: color-mix(in srgb, var(--modal-bg) 88%, transparent);
+	color: inherit;
+	cursor: pointer;
+}
+
+.targeted-announcement-close:hover {
+	background: color-mix(in srgb, var(--modal-bg) 82%, var(--primary) 18%);
+}
+
+.targeted-announcement-close:focus-visible {
+	outline: 2px solid var(--primary);
+	outline-offset: 2px;
+}
+
+.targeted-announcement-hero {
+	width: 100%;
+	max-height: 16rem;
+	overflow: hidden;
+	border-bottom: 1px solid var(--card-border);
+}
+
+.targeted-announcement-hero img {
+	display: block;
+	width: 100%;
+	height: min(16rem, 38dvh);
+	object-fit: cover;
+}
+
+.targeted-announcement-content {
+	padding: 1.5rem;
+}
+
+.targeted-announcement-content h1 {
+	margin: 0 2.5rem 0.625rem 0;
+	font-size: clamp(1.35rem, 4vw, 1.75rem);
+	line-height: 1.2;
+}
+
+.targeted-announcement-content p {
+	margin: 0;
+	color: var(--text-secondary);
+	line-height: 1.6;
+	white-space: pre-line;
+}
+
+.targeted-announcement-actions {
+	display: flex;
+	justify-content: flex-end;
+	margin-top: 1.5rem;
+}
+
+.targeted-announcement-actions:has(.hidden) {
+	display: none;
+}
+
+.targeted-announcement-actions .btn {
+	min-width: 7rem;
+	padding: 0.65rem 1rem;
+}
+
+@media (max-width: 600px) {
+	.targeted-announcement {
+		width: calc(100vw - 1.5rem);
+		max-height: calc(100dvh - 1.5rem);
+	}
+
+	.targeted-announcement-content {
+		padding: 1.25rem;
+	}
+
+	.targeted-announcement-actions .btn {
+		width: 100%;
+	}
+}
+
 .backButton {
 	position: absolute;
 	top: 1rem;

--- a/src/types/Announcement.ts
+++ b/src/types/Announcement.ts
@@ -1,5 +1,7 @@
 import type { Enums } from "./database.types";
 
+export const DEBUG_ANNOUNCEMENT_STORAGE_KEY = "debug-announcement-preview";
+
 export type AnnouncementAction = Enums<"announcement_action">;
 
 export interface Announcement {

--- a/src/types/Announcement.ts
+++ b/src/types/Announcement.ts
@@ -1,0 +1,16 @@
+import type { Enums } from "./database.types";
+
+export type AnnouncementAction = Enums<"announcement_action">;
+
+export interface Announcement {
+	id: string;
+	key: string;
+	title: string;
+	body: string;
+	heroImageUrl: string | null;
+	heroImageAlt: string;
+	actionLabel: string | null;
+	action: AnnouncementAction | null;
+}
+
+export type AnnouncementReceiptEvent = "seen" | "dismissed" | "actioned";

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1401,6 +1401,13 @@ export type Database = {
 			};
 		};
 		Functions: {
+			admin_search_users: {
+				Args: { result_limit?: number; search_query: string };
+				Returns: {
+					email: string;
+					user_id: string;
+				}[];
+			};
 			admin_user_emails: {
 				Args: { ids: string[] };
 				Returns: {

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -7,7 +7,7 @@
  * Contributors: Treat this as READ-ONLY.
  * If you need schema changes, open an issue describing the required modifications.
  *
- * Generated: 2026-04-30
+ * Generated: 2026-07-19
  */
 
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
@@ -169,6 +169,172 @@ export type Database = {
 					}
 				];
 			};
+			announcement_receipts: {
+				Row: {
+					actioned_at: string | null;
+					announcement_id: string;
+					dismissed_at: string | null;
+					seen_at: string | null;
+					user_id: string;
+				};
+				Insert: {
+					actioned_at?: string | null;
+					announcement_id: string;
+					dismissed_at?: string | null;
+					seen_at?: string | null;
+					user_id?: string;
+				};
+				Update: {
+					actioned_at?: string | null;
+					announcement_id?: string;
+					dismissed_at?: string | null;
+					seen_at?: string | null;
+					user_id?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "announcement_receipts_announcement_id_fkey";
+						columns: ["announcement_id"];
+						isOneToOne: false;
+						referencedRelation: "announcements";
+						referencedColumns: ["id"];
+					},
+					{
+						foreignKeyName: "announcement_receipts_user_id_fkey";
+						columns: ["user_id"];
+						isOneToOne: false;
+						referencedRelation: "admin_dashboard";
+						referencedColumns: ["user_id"];
+					}
+				];
+			};
+			announcement_tier_targets: {
+				Row: {
+					announcement_id: string;
+					tier: string;
+				};
+				Insert: {
+					announcement_id: string;
+					tier: string;
+				};
+				Update: {
+					announcement_id?: string;
+					tier?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "announcement_tier_targets_announcement_id_fkey";
+						columns: ["announcement_id"];
+						isOneToOne: false;
+						referencedRelation: "announcements";
+						referencedColumns: ["id"];
+					}
+				];
+			};
+			announcement_user_targets: {
+				Row: {
+					announcement_id: string;
+					user_id: string;
+				};
+				Insert: {
+					announcement_id: string;
+					user_id: string;
+				};
+				Update: {
+					announcement_id?: string;
+					user_id?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "announcement_user_targets_announcement_id_fkey";
+						columns: ["announcement_id"];
+						isOneToOne: false;
+						referencedRelation: "announcements";
+						referencedColumns: ["id"];
+					},
+					{
+						foreignKeyName: "announcement_user_targets_user_id_fkey";
+						columns: ["user_id"];
+						isOneToOne: false;
+						referencedRelation: "admin_dashboard";
+						referencedColumns: ["user_id"];
+					}
+				];
+			};
+			announcements: {
+				Row: {
+					action: Database["public"]["Enums"]["announcement_action"] | null;
+					action_label: string | null;
+					audience_type: Database["public"]["Enums"]["announcement_audience_type"];
+					body: string;
+					ends_at: string | null;
+					hero_image_alt: string | null;
+					hero_image_url: string | null;
+					id: string;
+					key: string;
+					priority: number;
+					starts_at: string | null;
+					status: Database["public"]["Enums"]["announcement_status"];
+					title: string;
+				};
+				Insert: {
+					action?: Database["public"]["Enums"]["announcement_action"] | null;
+					action_label?: string | null;
+					audience_type: Database["public"]["Enums"]["announcement_audience_type"];
+					body: string;
+					ends_at?: string | null;
+					hero_image_alt?: string | null;
+					hero_image_url?: string | null;
+					id?: string;
+					key: string;
+					priority?: number;
+					starts_at?: string | null;
+					status?: Database["public"]["Enums"]["announcement_status"];
+					title: string;
+				};
+				Update: {
+					action?: Database["public"]["Enums"]["announcement_action"] | null;
+					action_label?: string | null;
+					audience_type?: Database["public"]["Enums"]["announcement_audience_type"];
+					body?: string;
+					ends_at?: string | null;
+					hero_image_alt?: string | null;
+					hero_image_url?: string | null;
+					id?: string;
+					key?: string;
+					priority?: number;
+					starts_at?: string | null;
+					status?: Database["public"]["Enums"]["announcement_status"];
+					title?: string;
+				};
+				Relationships: [];
+			};
+			dashboard_settings: {
+				Row: {
+					settings: Json;
+					updated_at: string;
+					user_id: string;
+				};
+				Insert: {
+					settings?: Json;
+					updated_at?: string;
+					user_id: string;
+				};
+				Update: {
+					settings?: Json;
+					updated_at?: string;
+					user_id?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "dashboard_settings_user_id_fkey";
+						columns: ["user_id"];
+						isOneToOne: true;
+						referencedRelation: "admin_dashboard";
+						referencedColumns: ["user_id"];
+					}
+				];
+			};
 			deleted_comments: {
 				Row: {
 					comment_content: string;
@@ -322,6 +488,68 @@ export type Database = {
 						foreignKeyName: "image_sub_allowance_user_id_fkey";
 						columns: ["user_id"];
 						isOneToOne: true;
+						referencedRelation: "admin_dashboard";
+						referencedColumns: ["user_id"];
+					}
+				];
+			};
+			llm_usage: {
+				Row: {
+					cached_tokens: number;
+					cost: number;
+					created_at: string;
+					end_model: string;
+					fallback: boolean;
+					generation_id: string | null;
+					id: number;
+					input_tokens: number;
+					message_count: number | null;
+					output_tokens: number;
+					reason: string;
+					request_slug: string | null;
+					requested_model: string;
+					tier_snapshot: string | null;
+					user_id: string;
+				};
+				Insert: {
+					cached_tokens?: number;
+					cost: number;
+					created_at?: string;
+					end_model: string;
+					fallback?: boolean;
+					generation_id?: string | null;
+					id?: never;
+					input_tokens: number;
+					message_count?: number | null;
+					output_tokens: number;
+					reason: string;
+					request_slug?: string | null;
+					requested_model: string;
+					tier_snapshot?: string | null;
+					user_id: string;
+				};
+				Update: {
+					cached_tokens?: number;
+					cost?: number;
+					created_at?: string;
+					end_model?: string;
+					fallback?: boolean;
+					generation_id?: string | null;
+					id?: never;
+					input_tokens?: number;
+					message_count?: number | null;
+					output_tokens?: number;
+					reason?: string;
+					request_slug?: string | null;
+					requested_model?: string;
+					tier_snapshot?: string | null;
+					user_id?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "llm_usage_user_id_fkey";
+						columns: ["user_id"];
+						isOneToOne: false;
 						referencedRelation: "admin_dashboard";
 						referencedColumns: ["user_id"];
 					}
@@ -1031,14 +1259,31 @@ export type Database = {
 			admin_dashboard: {
 				Row: {
 					email: string | null;
+					granted_mega_credits: number | null;
+					granted_subscription_image_gens: number | null;
+					image_allowance_period_end: string | null;
+					image_allowance_period_start: string | null;
 					last_activity_timestamp: string | null;
 					last_chat_timestamp: string | null;
+					mega_allowance_period_end: string | null;
+					mega_allowance_period_start: string | null;
 					name: string | null;
+					nano_banana_daily_limit: number | null;
+					nano_banana_remaining_today: number | null;
+					nano_usage_date: string | null;
 					nano_usage_today: number | null;
 					remaining_image_gens: number | null;
 					remaining_mega_credits: number | null;
+					remaining_purchased_image_gens: number | null;
+					remaining_subscription_image_gens: number | null;
+					stripe_customer_id: string | null;
+					stripe_subscription_id: string | null;
+					subscription_cancel_at_period_end: boolean | null;
+					subscription_created_at: string | null;
+					subscription_current_period_end: string | null;
 					subscription_status: string | null;
 					subscription_tier: Database["public"]["Enums"]["subscription_tier"] | null;
+					subscription_updated_at: string | null;
 					sync_storage_quota_bytes: number | null;
 					sync_storage_used_bytes: number | null;
 					total_bucket_storage_bytes: number | null;
@@ -1156,6 +1401,20 @@ export type Database = {
 			};
 		};
 		Functions: {
+			admin_user_emails: {
+				Args: { ids: string[] };
+				Returns: {
+					email: string;
+					user_id: string;
+				}[];
+			};
+			announcement_is_eligible_for_current_user: {
+				Args: {
+					target_announcement_id: string;
+					target_audience_type: Database["public"]["Enums"]["announcement_audience_type"];
+				};
+				Returns: boolean;
+			};
 			can_read_cloud_sync: {
 				Args: { target_user_id: string };
 				Returns: boolean;
@@ -1213,6 +1472,9 @@ export type Database = {
 			wipe_my_synced_data: { Args: never; Returns: undefined };
 		};
 		Enums: {
+			announcement_action: "dismiss" | "next";
+			announcement_audience_type: "all" | "tiers" | "users";
+			announcement_status: "draft" | "published" | "archived";
 			persona_category: "character" | "assistant";
 			spotlight_action: "add" | "remove" | "move";
 			subscription_tier:
@@ -1348,6 +1610,9 @@ export type CompositeTypes<
 export const Constants = {
 	public: {
 		Enums: {
+			announcement_action: ["dismiss", "next"],
+			announcement_audience_type: ["all", "tiers", "users"],
+			announcement_status: ["draft", "published", "archived"],
 			persona_category: ["character", "assistant"],
 			spotlight_action: ["add", "remove", "move"],
 			subscription_tier: [

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1408,13 +1408,6 @@ export type Database = {
 					user_id: string;
 				}[];
 			};
-			announcement_is_eligible_for_current_user: {
-				Args: {
-					target_announcement_id: string;
-					target_audience_type: Database["public"]["Enums"]["announcement_audience_type"];
-				};
-				Returns: boolean;
-			};
 			can_read_cloud_sync: {
 				Args: { target_user_id: string };
 				Returns: boolean;

--- a/tests/e2e/announcements/targeted-announcement.spec.ts
+++ b/tests/e2e/announcements/targeted-announcement.spec.ts
@@ -185,3 +185,166 @@ test("eligible announcements render optional hero media and advance through app 
 			])
 		);
 });
+
+test("announcement waits for the cloud sync unlock flow to settle", async ({ page }) => {
+	const userId = "00000000-0000-4000-8000-000000000199";
+	const priceId = "price_1SOU2lKcI9PDo3JBhsT8URS9";
+	const response = (body: unknown, status = 200) => ({
+		status,
+		contentType: "application/json",
+		headers: {
+			"access-control-allow-origin": "*",
+			"access-control-allow-headers": "authorization, apikey, content-type, x-client-info, prefer",
+			"access-control-allow-methods": "GET, POST, PATCH, PUT, DELETE, OPTIONS"
+		},
+		body: JSON.stringify(body)
+	});
+
+	await stubExternalTraffic(page, []);
+	await page.route("https://hglcltvwunzynnzduauy.supabase.co/**/*", async (route) => {
+		const request = route.request();
+		const path = new URL(request.url()).pathname;
+
+		if (request.method() === "OPTIONS") {
+			await route.fulfill(response({}));
+			return;
+		}
+		if (path === "/auth/v1/user") {
+			await route.fulfill(
+				response({
+					id: userId,
+					email: "announcements@example.test",
+					aud: "authenticated",
+					role: "authenticated",
+					app_metadata: {},
+					user_metadata: {},
+					created_at: "2026-01-01T00:00:00.000Z"
+				})
+			);
+			return;
+		}
+		if (path === "/functions/v1/refresh-subscription-allowances") {
+			await route.fulfill(response({ ok: true }));
+			return;
+		}
+		if (path.startsWith("/rest/v1/profiles")) {
+			await route.fulfill(
+				response({ avatar: "", preferredName: "Announcement Tester", systemPromptAddition: "" })
+			);
+			return;
+		}
+		if (path.startsWith("/rest/v1/user_subscriptions")) {
+			await route.fulfill(
+				response({
+					user_id: userId,
+					status: "active",
+					price_id: priceId,
+					current_period_end: "2026-12-31T00:00:00.000Z",
+					cancel_at_period_end: false,
+					stripe_customer_id: "cus_announcement_test"
+				})
+			);
+			return;
+		}
+		if (path.startsWith("/rest/v1/image_generations")) {
+			await route.fulfill(response({ user_id: userId, remaining_image_generations: 10 }));
+			return;
+		}
+		if (path.startsWith("/rest/v1/image_sub_allowance")) {
+			await route.fulfill(response({ remaining_image_generations: 0 }));
+			return;
+		}
+		if (path.startsWith("/rest/v1/user_sync_preferences")) {
+			await route.fulfill(
+				response({
+					sync_enabled: true,
+					encryption_salt: "00",
+					key_verification: "00",
+					key_verification_iv: "00"
+				})
+			);
+			return;
+		}
+		if (path.startsWith("/rest/v1/user_sync_quotas")) {
+			await route.fulfill(response({ storage_used_bytes: 0, storage_quota_bytes: 10 * 1024 * 1024 }));
+			return;
+		}
+		if (path.startsWith("/rest/v1/announcements")) {
+			await route.fulfill(
+				response([
+					{
+						id: "sync-gated-announcement",
+						key: "sync-gated-announcement",
+						title: "Shown after unlock",
+						body: "This should wait for the sync decision.",
+						hero_image_url: null,
+						hero_image_alt: null,
+						action_label: "Got it",
+						action: "dismiss"
+					}
+				])
+			);
+			return;
+		}
+		if (path.startsWith("/rest/v1/announcement_receipts")) {
+			await route.fulfill(response([], request.method() === "POST" ? 201 : 200));
+			return;
+		}
+
+		await route.fulfill(response({}));
+	});
+	await seedLocalSettings(page);
+	await page.addInitScript(
+		({ id, subscriptionPriceId }) => {
+			localStorage.setItem("zodiac-sync-prompt-seen", "true");
+			localStorage.setItem(
+				"sb-hglcltvwunzynnzduauy-auth-token",
+				JSON.stringify({
+					access_token: "playwright-access-token",
+					refresh_token: "playwright-refresh-token",
+					expires_at: Math.floor(Date.now() / 1000) + 3600,
+					expires_in: 3600,
+					token_type: "bearer",
+					user: {
+						id,
+						email: "announcements@example.test",
+						aud: "authenticated",
+						role: "authenticated",
+						app_metadata: {},
+						user_metadata: {},
+						subscriptionPriceId
+					}
+				})
+			);
+		},
+		{ id: userId, subscriptionPriceId: priceId }
+	);
+	await page.goto("/");
+
+	await page.evaluate(
+		({ id, subscriptionPriceId }) => {
+			window.dispatchEvent(
+				new CustomEvent("auth-state-changed", {
+					detail: {
+						loggedIn: true,
+						session: { user: { id } },
+						subscription: {
+							user_id: id,
+							status: "active",
+							price_id: subscriptionPriceId
+						}
+					}
+				})
+			);
+		},
+		{ id: userId, subscriptionPriceId: priceId }
+	);
+
+	await expect(page.locator("#sync-modal")).toBeVisible();
+	await expect(page.getByRole("dialog", { name: "Shown after unlock" })).toBeHidden();
+
+	await page.locator("#btn-sync-skip").click();
+
+	await expect(page.locator("#sync-modal")).toBeHidden();
+	await expect(page.getByRole("dialog", { name: "Shown after unlock" })).toBeVisible();
+});

--- a/tests/e2e/announcements/targeted-announcement.spec.ts
+++ b/tests/e2e/announcements/targeted-announcement.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "@playwright/test";
+
+import { seedLocalSettings, stubExternalTraffic } from "../helpers/app";
+
+test("eligible announcements render optional hero media and advance through app actions", async ({ page }) => {
+	const receiptWrites: Array<Record<string, string>> = [];
+
+	await stubExternalTraffic(page, []);
+	await page.route("https://hglcltvwunzynnzduauy.supabase.co/rest/v1/**", async (route) => {
+		const url = new URL(route.request().url());
+		const table = url.pathname.split("/").at(-1);
+
+		if (table === "announcements" && route.request().method() === "GET") {
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				headers: { "access-control-allow-origin": "*" },
+				body: JSON.stringify([
+					{
+						id: "announcement-1",
+						key: "max-unlimited-2026",
+						title: "Max is now unlimited",
+						body: "Your Max plan no longer has a monthly usage limit.",
+						hero_image_url:
+							"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='360'%3E%3Crect width='800' height='360' fill='%23614a3a'/%3E%3C/svg%3E",
+						hero_image_alt: "A warm abstract illustration",
+						action_label: "Next",
+						action: "next"
+					},
+					{
+						id: "announcement-2",
+						key: "second-announcement",
+						title: "Ready when you are",
+						body: "There is nothing else you need to configure.",
+						hero_image_url: null,
+						hero_image_alt: null,
+						action_label: "Got it",
+						action: "dismiss"
+					}
+				])
+			});
+			return;
+		}
+
+		if (table === "announcement_receipts" && route.request().method() === "GET") {
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				headers: { "access-control-allow-origin": "*" },
+				body: "[]"
+			});
+			return;
+		}
+
+		if (table === "announcement_receipts" && route.request().method() === "POST") {
+			receiptWrites.push(JSON.parse(route.request().postData() ?? "{}") as Record<string, string>);
+			await route.fulfill({
+				status: 201,
+				contentType: "application/json",
+				headers: { "access-control-allow-origin": "*" },
+				body: "[]"
+			});
+			return;
+		}
+
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			headers: { "access-control-allow-origin": "*" },
+			body: "[]"
+		});
+	});
+	await seedLocalSettings(page);
+	await page.goto("/");
+
+	await page.evaluate(() => {
+		window.dispatchEvent(
+			new CustomEvent("auth-state-changed", {
+				detail: {
+					loggedIn: true,
+					session: { user: { id: "user-1" } }
+				}
+			})
+		);
+	});
+
+	const modal = page.getByRole("dialog", { name: "Max is now unlimited" });
+	await expect(modal).toBeVisible();
+	await expect(modal.locator("#targeted-announcement-image")).toBeVisible();
+	await expect(modal.getByRole("button", { name: "Next" })).toBeVisible();
+
+	await modal.getByRole("button", { name: "Next" }).click();
+	await expect(page.getByRole("dialog", { name: "Ready when you are" })).toBeVisible();
+	await expect(page.locator("#targeted-announcement-hero")).toHaveClass(/hidden/);
+
+	await page.getByRole("button", { name: "Got it" }).click();
+	await expect(page.locator("#targeted-announcement")).toBeHidden();
+	await expect
+		.poll(() => receiptWrites)
+		.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					announcement_id: "announcement-1",
+					user_id: "user-1",
+					seen_at: expect.any(String)
+				}),
+				expect.objectContaining({
+					announcement_id: "announcement-1",
+					user_id: "user-1",
+					actioned_at: expect.any(String),
+					dismissed_at: expect.any(String)
+				}),
+				expect.objectContaining({
+					announcement_id: "announcement-2",
+					user_id: "user-1",
+					seen_at: expect.any(String)
+				}),
+				expect.objectContaining({
+					announcement_id: "announcement-2",
+					user_id: "user-1",
+					actioned_at: expect.any(String),
+					dismissed_at: expect.any(String)
+				})
+			])
+		);
+});

--- a/tests/e2e/announcements/targeted-announcement.spec.ts
+++ b/tests/e2e/announcements/targeted-announcement.spec.ts
@@ -2,6 +2,67 @@ import { expect, test } from "@playwright/test";
 
 import { seedLocalSettings, stubExternalTraffic } from "../helpers/app";
 
+test("debug composer saves a one-time announcement for the next refresh", async ({ page }) => {
+	await stubExternalTraffic(page, []);
+	await page.route("https://example.test/announcement.svg", async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: "image/svg+xml",
+			body: '<svg xmlns="http://www.w3.org/2000/svg" width="800" height="360"><rect width="800" height="360" fill="#614a3a"/></svg>'
+		});
+	});
+	await seedLocalSettings(page);
+	await page.goto("/");
+
+	await page.locator(".navbar-tab").nth(2).click();
+	await page.locator("#btn-debug-announcement").click();
+
+	const form = page.locator("#form-debug-announcement");
+	await expect(form).toBeVisible();
+	await form.locator("#debug-announcement-title").fill("A preview announcement");
+	await form.locator("#debug-announcement-body").fill("This message should appear after refresh.");
+	await form.locator("#debug-announcement-hero-url").fill("https://example.test/announcement.svg");
+	await form.locator("#debug-announcement-hero-alt").fill("A brown preview image");
+	await form.locator("#debug-announcement-action").selectOption("next");
+	await form.locator("#debug-announcement-action-label").fill("Continue");
+	await form.getByRole("button", { name: "Save for next refresh" }).click();
+
+	await expect(form).toBeHidden();
+	await expect
+		.poll(() =>
+			page.evaluate(() => {
+				const stored = localStorage.getItem("debug-announcement-preview");
+				return stored ? JSON.parse(stored) : null;
+			})
+		)
+		.toEqual(
+			expect.objectContaining({
+				title: "A preview announcement",
+				body: "This message should appear after refresh.",
+				heroImageUrl: "https://example.test/announcement.svg",
+				heroImageAlt: "A brown preview image",
+				action: "next",
+				actionLabel: "Continue"
+			})
+		);
+
+	await page.reload();
+
+	const announcement = page.getByRole("dialog", { name: "A preview announcement" });
+	await expect(announcement).toBeVisible();
+	await expect(announcement).toContainText("This message should appear after refresh.");
+	await expect(announcement.locator("#targeted-announcement-image")).toHaveAttribute("alt", "A brown preview image");
+	await expect(announcement.getByRole("button", { name: "Continue" })).toBeVisible();
+	await expect.poll(() => page.evaluate(() => localStorage.getItem("debug-announcement-preview"))).not.toBeNull();
+
+	await page.reload();
+	await expect(page.getByRole("dialog", { name: "A preview announcement" })).toBeVisible();
+
+	await page.getByRole("button", { name: "Continue" }).click();
+	await expect(page.locator("#targeted-announcement")).toBeHidden();
+	await expect.poll(() => page.evaluate(() => localStorage.getItem("debug-announcement-preview"))).toBeNull();
+});
+
 test("eligible announcements render optional hero media and advance through app actions", async ({ page }) => {
 	const receiptWrites: Array<Record<string, string>> = [];
 


### PR DESCRIPTION
## Summary

- Add targeted in-app announcements with optional hero images and app-native dismiss/next actions
- Track seen, dismissed, and actioned receipts through Supabase while RLS controls audience eligibility
- Add a localhost debug composer for previewing announcement content after refresh
- Defer announcements until cloud-sync startup and other blocking dialogs have settled

## Testing

- `npm run build`
- `npm run test` (125 tests)
- `npm run test:e2e` (24 tests)